### PR TITLE
Minor bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /public
 /vendor
 /node_modules
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /public
 /vendor
 /node_modules
-.vscode/*
+/.vscode

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "source": "https://github.com/infinum/eightshift-forms-plugin"
   },
   "require-dev": {
-    "infinum/coding-standards-wp": "0.4.3",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+    "giacocorsiglia/wordpress-stubs": "^5.1",
+    "infinum/coding-standards-wp": "0.4.3"
   },
   "require": {
     "php": ">=7.1",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "source": "https://github.com/infinum/eightshift-forms-plugin"
   },
   "require-dev": {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "giacocorsiglia/wordpress-stubs": "^5.1",
     "infinum/coding-standards-wp": "0.4.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af15c2a82a70997fac43d02262ee45c9",
+    "content-hash": "3b6a9ee704d973a043ff553d4326d578",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1577,70 +1577,43 @@
     ],
     "packages-dev": [
         {
-            "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "name": "giacocorsiglia/wordpress-stubs",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "url": "https://github.com/GiacoCorsiglia/wordpress-stubs.git",
+                "reference": "1c6f011f5c241bab7293315d7fb7fca27fe79473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/GiacoCorsiglia/wordpress-stubs/zipball/1c6f011f5c241bab7293315d7fb7fca27fe79473",
+                "reference": "1c6f011f5c241bab7293315d7fb7fca27fe79473",
                 "shasum": ""
             },
-            "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
-            },
             "require-dev": {
-                "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "ext-gettext": "*",
+                "giacocorsiglia/stubs-generator": "^0.5.0",
+                "johnpbloch/wordpress": "5.1.1",
+                "php": "^7.1"
             },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
-                }
-            },
+            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
-                    "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "name": "Giaco Corsiglia",
+                    "email": "GiacoCorsiglia@gmail.com"
                 }
             ],
-            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
+            "description": "WordPress function, class, and global variable declaration stubs for easier static analysis.",
+            "homepage": "https://github.com/GiacoCorsiglia/wordpress-stubs",
             "keywords": [
-                "PHPCodeSniffer",
-                "PHP_CodeSniffer",
-                "code quality",
-                "codesniffer",
-                "composer",
-                "installer",
-                "phpcs",
-                "plugin",
-                "qa",
-                "quality",
-                "standard",
-                "standards",
-                "style guide",
-                "stylecheck",
-                "tests"
+                "static analysis",
+                "wordpress"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "time": "2019-03-13T21:16:05+00:00"
         },
         {
             "name": "infinum/coding-standards-wp",
@@ -1862,16 +1835,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -1909,7 +1882,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b6a9ee704d973a043ff553d4326d578",
+    "content-hash": "17db53323faa1ee7701b0608decfd232",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1576,6 +1576,72 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2020-06-25T14:57:39+00:00"
+        },
         {
             "name": "giacocorsiglia/wordpress-stubs",
             "version": "v5.1.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,4 +34,20 @@
   <rule ref="WordPress.WP.GlobalVariablesOverride.OverrideProhibited">
     <severity>0</severity>
   </rule>
+
+  <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+    <severity>0</severity>
+  </rule>
+
+  <rule ref="PEAR.Functions.FunctionCallSignature.MultipleArguments">
+    <severity>0</severity>
+  </rule>
+
+  <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+    <severity>0</severity>
+  </rule>
+
+  <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+    <severity>0</severity>
+  </rule>
 </ruleset>

--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -9,7 +9,7 @@ namespace Eightshift_Forms\Blocks;
 
 use Eightshift_Libs\Blocks\Blocks as Lib_Blocks;
 use Eightshift_Forms\Admin\Forms;
-use Eightshift_Forms\Core\Config;
+use Eightshift_Forms\Core\Filters;
 
 /**
  * Blocks class.
@@ -37,7 +37,11 @@ class Blocks extends Lib_Blocks {
    */
   public function get_all_allowed_forms_blocks( $allowed_block_types, $post ) {
     if ( $post->post_type === Forms::POST_TYPE_SLUG ) {
-      return $this->get_all_blocks_list();
+      if ( has_filter( Filters::ALLOWED_BLOCKS ) ) {
+        return apply_filters( Filters::ALLOWED_BLOCKS, $this->get_all_blocks_list() );
+      } else {
+        return $this->get_all_blocks_list();
+      }
     }
 
     $allowed_block_types[] = "{$this->config->get_project_name()}/forms";

--- a/src/blocks/custom/checkbox/components/checkbox-editor.js
+++ b/src/blocks/custom/checkbox/components/checkbox-editor.js
@@ -24,14 +24,6 @@ export const CheckboxEditor = (props) => {
   return (
     <div className={`${blockClass} ${blockClass}__theme--${theme}`}>
       <label className={`${blockClass}__label`}>
-        <span className={`${blockClass}__label-content`}>
-          <RichText
-            className={`${blockClass}__label`}
-            placeholder={__('Add your label', 'eightshift-forms')}
-            onChange={onChangeLabel}
-            value={label}
-          />
-        </span>
         <input
           name={name}
           id={id}
@@ -43,6 +35,15 @@ export const CheckboxEditor = (props) => {
           readOnly={isReadOnly}
         />
         <span className={`${blockClass}__checkmark`}></span>
+        <span className={`${blockClass}__label-content`}>
+          <RichText
+            className={`${blockClass}__label`}
+            placeholder={__('Add your label', 'eightshift-forms')}
+            onChange={onChangeLabel}
+            value={label}
+          />
+        </span>
+
       </label>
     </div>
   );

--- a/src/blocks/custom/form/assets/form.js
+++ b/src/blocks/custom/form/assets/form.js
@@ -19,6 +19,7 @@ export class Form {
     this.formType = this.form.getAttribute(this.DATA_ATTR_FORM_TYPE);
 
     this.siteUrl = window.eightshiftForms.siteUrl;
+    this.internalServerErrorMessage = window.eightshiftForms.internalServerError;
 
     this.restRouteUrls = {
       dynamicsCrmRestUri: `${this.siteUrl}${window.eightshiftForms.dynamicsCrm.restUri}`,
@@ -53,6 +54,12 @@ export class Form {
     this.startLoading();
     const response = await sendForm(url, data);
     const isSuccess = response && response.code && response.code === 200;
+    const is500Error = response && response.code && response.code === 'internal_server_error';
+
+    if (is500Error) {
+      response.message = this.internalServerErrorMessage;
+    }
+
     this.endLoading(isSuccess, response);
   }
 
@@ -63,7 +70,7 @@ export class Form {
     this.overlay.classList.remove(this.CLASS_HIDE_OVERLAY);
     this.spinner.innerHTML = `<p>${this.formAccessibilityStatus.loading}</p>`;
     [this.formMessageSuccess, this.formMessageError].forEach((msgElem) => msgElem.classList.add(this.CLASS_HIDE_MESSAGE));
-    
+
     this.submits.forEach((submit) => {
       submit.disabled = true;
     });

--- a/src/blocks/custom/form/components/form-options.js
+++ b/src/blocks/custom/form/components/form-options.js
@@ -65,9 +65,14 @@ export const FormOptions = (props) => {
   const themeAsOptions = hasThemes ? themes.map((tempTheme) => ({ label: tempTheme, value: tempTheme })) : [];
 
   // All Dynamics CRM config stuff
-  let crmEntitiesAsOptions = [];
+  let crmEntitiesAsOptions = [
+
+  ];
   if (isDynamicsCrmUsed) {
-    crmEntitiesAsOptions = dynamicsCrm.availableEntities.map((entity) => ({ label: entity, value: entity }));
+    crmEntitiesAsOptions = [
+      { label: __('Select CRM entity', 'eightshift-forms'), value: 'select-please' },
+      ...dynamicsCrm.availableEntities.map((entity) => ({ label: entity, value: entity })),
+    ];
     formTypes.push({ label: __('Microsoft Dynamics CRM 365', 'eightshift-forms'), value: 'dynamics-crm' });
   }
 

--- a/src/blocks/custom/input/components/input-editor.js
+++ b/src/blocks/custom/input/components/input-editor.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-
+import classNames from 'classnames'; // eslint-disable-line no-unused-vars
 import { LabelEditor } from './../../../components/label/components/label-editor';
 
 export const InputEditor = (props) => {
@@ -19,21 +19,36 @@ export const InputEditor = (props) => {
     },
   } = props;
 
+  const blockClasses = classNames(
+    blockClass,
+    type === 'hidden' ? `${blockClass}--hidden` : '',
+  );
+
+  const wrapClasses = classNames(
+    `${blockClass}__content-wrap`,
+    `${blockClass}__theme--${theme}`,
+  );
+
+  const inputClasses = classNames(
+    `${blockClass}__input`,
+    classes,
+  );
+
   return (
-    <div className={`${blockClass}`}>
+    <div className={blockClasses}>
       <LabelEditor
         blockClass={blockClass}
         label={label}
         id={id}
       />
-      <div className={`${blockClass}__content-wrap ${blockClass}__theme--${theme}`}>
+      <div className={wrapClasses}>
         <input
           name={name}
           placeholder={placeholder}
           id={id}
-          className={`${blockClass}__input ${classes}`}
+          className={inputClasses}
           value={value}
-          type={type}
+          type={type !== 'hidden' ? type : 'input'}
           disabled={isDisabled}
           readOnly={isReadOnly}
         />

--- a/src/blocks/custom/input/components/input-options.js
+++ b/src/blocks/custom/input/components/input-options.js
@@ -59,6 +59,7 @@ export const InputOptions = (props) => {
           value={type}
           options={[
             { label: __('Text', 'eightshift-forms'), value: 'text' },
+            { label: __('Hidden', 'eightshift-forms'), value: 'hidden' },
             { label: __('Url', 'eightshift-forms'), value: 'url' },
             { label: __('Email', 'eightshift-forms'), value: 'email' },
             { label: __('Number', 'eightshift-forms'), value: 'nmber' },

--- a/src/blocks/custom/input/input-editor.scss
+++ b/src/blocks/custom/input/input-editor.scss
@@ -1,0 +1,5 @@
+.block-input {
+  &--hidden {
+    opacity: 0.5;
+  }
+}

--- a/src/class-filters.php
+++ b/src/class-filters.php
@@ -14,6 +14,7 @@ namespace Eightshift_Forms\Core;
  */
 class Filters {
 
-  const DYNAMICS_CRM = 'eightshift_forms/dynamics_info';
-  const GENERAL = 'eightshift_forms/general_info';
+  const DYNAMICS_CRM   = 'eightshift_forms/dynamics_info';
+  const ALLOWED_BLOCKS = 'eightshift_forms/allowed_blocks';
+  const GENERAL        = 'eightshift_forms/general_info';
 }

--- a/src/enqueue/class-localization-constants.php
+++ b/src/enqueue/class-localization-constants.php
@@ -45,8 +45,9 @@ class Localization_Constants {
         'content' => [
           'formLoading' => esc_html__( 'Form is submitting, please wait.', 'eightshift-forms' ),
           'formSuccess' => esc_html__( 'Form successfully submitted.', 'eightshift-forms' )
-        ]
-      ]
+        ],
+        'internalServerError' => esc_html__( 'Internal server error', 'eightshift-forms' ),
+      ],
     ];
 
     if ( has_filter( Filters::GENERAL ) ) {

--- a/src/routes/class-base-route.php
+++ b/src/routes/class-base-route.php
@@ -87,13 +87,12 @@ abstract class Base_Route extends Libs_Base_Route implements Callable_Route {
     );
   }
 
-    /**
-     * Response handler for unknown errors
-     *
-     * @param  string $message Message to output.
-     * @param  array  $data    (Optional) data to output.
-     * @return mixed
-     */
+  /**
+   * Response handler for unknown errors
+   *
+   * @param  array $data (Optional) data to output.
+   * @return mixed
+   */
   protected function rest_response_handler_unknown_error( array $data = array() ) {
     return \rest_ensure_response(
       array(

--- a/src/routes/class-dynamics-crm-route.php
+++ b/src/routes/class-dynamics-crm-route.php
@@ -112,6 +112,7 @@ class Dynamics_Crm_Route extends Base_Route {
       Basic_Captcha::SECOND_NUMBER_KEY,
       Basic_Captcha::RESULT_KEY,
       'privacy',
+      'privacy-policy',
     ];
   }
 

--- a/src/routes/class-dynamics-crm-route.php
+++ b/src/routes/class-dynamics-crm-route.php
@@ -21,7 +21,7 @@ use Eightshift_Forms\Captcha\Basic_Captcha;
  * Class Dynamics_Crm_Route
  */
 class Dynamics_Crm_Route extends Base_Route {
-  
+
   const ACCESS_TOKEN_KEY = 'dynamics-crm-access-token';
 
   const ENTITY_PARAM = 'dynamics-crm-entity';
@@ -36,12 +36,13 @@ class Dynamics_Crm_Route extends Base_Route {
   /**
    * Construct object
    *
-   * @param Config_Data  $config       Config data obj.
-   * @param Dynamics_CRM $dynamics_crm Dynamics CRM object.
+   * @param Config_Data   $config       Config data obj.
+   * @param Dynamics_CRM  $dynamics_crm Dynamics CRM object.
+   * @param Basic_Captcha $basic_captcha Basic_Captcha object.
    */
-  public function __construct(Config_Data $config, Dynamics_CRM $dynamics_crm, Basic_Captcha $basic_captcha) {
-    $this->config = $config;
-    $this->dynamics_crm = $dynamics_crm;
+  public function __construct( Config_Data $config, Dynamics_CRM $dynamics_crm, Basic_Captcha $basic_captcha ) {
+    $this->config        = $config;
+    $this->dynamics_crm  = $dynamics_crm;
     $this->basic_captcha = $basic_captcha;
   }
 
@@ -66,41 +67,84 @@ class Dynamics_Crm_Route extends Base_Route {
       return $this->rest_response_handler( 'wrong-captcha' );
     }
 
-    if ( ! isset( $params[self::ENTITY_PARAM ] ) ) {
+    if ( ! isset( $params[ self::ENTITY_PARAM ] ) ) {
       return $this->rest_response_handler( 'missing-entity-key' );
     }
-  
-    // We don't want to send thee entity to CRM or it will reject our request.
-    $entity = $params[self::ENTITY_PARAM];
-    unset($params[self::ENTITY_PARAM]);
 
-    $this->dynamics_crm->set_oauth_credentials([
-      'url'           => apply_filters( Filters::DYNAMICS_CRM, 'auth_token_url' ),
-      'client_id'     => apply_filters( Filters::DYNAMICS_CRM, 'client_id' ),
-      'client_secret' => apply_filters( Filters::DYNAMICS_CRM, 'client_secret' ),
-      'scope'         => apply_filters( Filters::DYNAMICS_CRM, 'scope' ),
-      'api_url'       => apply_filters( Filters::DYNAMICS_CRM, 'api_url' ),
-    ]);
+    // We don't want to send thee entity to CRM or it will reject our request.
+    $entity = $params[ self::ENTITY_PARAM ];
+    $params = $this->unset_irrelevant_params( $params );
+
+    $this->dynamics_crm->set_oauth_credentials(
+      [
+        'url'           => apply_filters( Filters::DYNAMICS_CRM, 'auth_token_url' ),
+        'client_id'     => apply_filters( Filters::DYNAMICS_CRM, 'client_id' ),
+        'client_secret' => apply_filters( Filters::DYNAMICS_CRM, 'client_secret' ),
+        'scope'         => apply_filters( Filters::DYNAMICS_CRM, 'scope' ),
+        'api_url'       => apply_filters( Filters::DYNAMICS_CRM, 'api_url' ),
+      ]
+    );
+
+    error_log(print_r($params, true));
 
     // Retrieve all entities from the "leads" Entity Set.
     try {
-      $response = $this->dynamics_crm->add_record( $entity, $params);
+      $response = $this->dynamics_crm->add_record( $entity, $params );
     } catch ( \Exception $e ) {
       return $this->rest_response_handler_unknown_error( [ 'error' => $e->getMessage() ] );
     }
 
-    return \rest_ensure_response([
-      'code' => 200,
-      'data' => $response,
-    ]);
+    return \rest_ensure_response(
+      [
+        'code' => 200,
+        'data' => $response,
+      ]
+    );
+  }
+
+  /**
+   * Returns keys of irrelevant params which we don't want to send to CRM (even tho they're in form).
+   *
+   * @return array
+   */
+  protected function get_irrelevant_params(): array {
+    return [
+      self::ENTITY_PARAM,
+      Basic_Captcha::FIRST_NUMBER_KEY,
+      Basic_Captcha::SECOND_NUMBER_KEY,
+      Basic_Captcha::RESULT_KEY,
+      'privacy',
+    ];
+  }
+
+
+  /**
+   * Removes some params we don't want to send to CRM from request.
+   *
+   * @param  array $params Params received in request.
+   * @return array
+   */
+  protected function unset_irrelevant_params( array $params ): array {
+    $filtered_params   = [];
+    $irrelevant_params = array_flip( $this->get_irrelevant_params() );
+
+    foreach ( $params as $key => $param ) {
+      if ( ! isset( $irrelevant_params [ $key ] ) ) {
+        $filtered_params[ $key ] = $param;
+      }
+    }
+
+    return $filtered_params;
   }
 
   /**
    * Define a list of responses for this route.
    *
+   * @param  string $response_key Which key to return.
+   * @param  array  $data         Optional data to also return in response.
    * @return array
    */
-  protected function defined_responses(string $response_key, array $data = []): array {
+  protected function defined_responses( string $response_key, array $data = [] ): array {
     $responses = [
       'wrong-captcha' => [
         'code' => 429,
@@ -119,6 +163,6 @@ class Dynamics_Crm_Route extends Base_Route {
       ],
     ];
 
-    return $responses[$response_key];
+    return $responses[ $response_key ];
   }
 }

--- a/src/routes/class-dynamics-crm-route.php
+++ b/src/routes/class-dynamics-crm-route.php
@@ -85,8 +85,6 @@ class Dynamics_Crm_Route extends Base_Route {
       ]
     );
 
-    error_log(print_r($params, true));
-
     // Retrieve all entities from the "leads" Entity Set.
     try {
       $response = $this->dynamics_crm->add_record( $entity, $params );


### PR DESCRIPTION
Changelog
---
* Added ability to filter allowed blocks inside `Form` using `add_filter( 'eightshift_forms/allowed_blocks' )`
* Nicer handling of internal 500 server errors on form
* Added default option when selecting CRM entity so you need to select one you need (otherwise the first option isn't saved as onChange isn't triggered)
* Ignoring some received form fields while sending data to CRM (if an unrecognized field is sent, the entire request is rejected)