### PR TITLE
Modify capabilities

### DIFF
--- a/src/admin/class-forms.php
+++ b/src/admin/class-forms.php
@@ -15,11 +15,18 @@ use Eightshift_Libs\Core\Service;
 class Forms implements Service {
 
   /**
-   * Post type slug costant.
+   * Post type slug constant.
    *
    * @var string
    */
   const POST_TYPE_SLUG = 'eightshift-forms';
+
+  /**
+   * Post type slug constant.
+   *
+   * @var string
+   */
+  const POST_CAPABILITY_TYPE = 'eightshift-form';
 
   /**
    * Browser url slug constant.
@@ -77,7 +84,7 @@ class Forms implements Service {
       'show_in_rest'       => true,
       'publicly_queryable' => false,
       'can_export'         => true,
-      'capability_type'    => 'page',
+      'capability_type'    => self::POST_CAPABILITY_TYPE,
       'rest_base'          => static::REST_API_ENDPOINT_SLUG,
       'template_lock'      => 'all',
       'template'           => $template,

--- a/src/admin/class-users.php
+++ b/src/admin/class-users.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Modifying capabilities / roles.
+ *
+ * @package D66\Eightshift_Forms
+ */
+
+declare( strict_types=1 );
+
+namespace Eightshift_Forms\Admin;
+
+use Eightshift_Forms\Hooks\Filters;
+use Eightshift_Libs\Core\Service;
+/**
+ * Class that modifies user capabilities
+ */
+final class Users implements Service {
+
+  /**
+   * Register all the hooks
+   *
+   * @return void
+   */
+  public function register() {
+    add_action( 'admin_init', [ $this, 'allow_forms_access' ], 10 );
+  }
+
+  /**
+   * Easy 1 function for managing additional capabilities.
+   *
+   * @return void
+   */
+  public function allow_forms_access() {
+    if ( has_filter( Filters::ROLES_WITH_FORMS_ACCESS ) ) {
+      $roles = apply_filters( Filters::ROLES_WITH_FORMS_ACCESS, $this->get_roles_with_forms_access() );
+    } else {
+      $roles =  $this->get_roles_with_forms_access();
+    }
+
+    $this->manage_additional_roles( $roles );
+  }
+
+  /**
+   * Easy 1 function for managing additional capabilities.
+   *
+   * @return void
+   */
+  public function manage_additional_roles(array $roles) {
+    foreach ( $roles as $role_name => $has_access ) {
+      $role_object = get_role( $role_name );
+
+      if ( empty( $role_object ) ) {
+        continue;
+      }
+
+      if ( $has_access ) {
+        foreach( $this->get_all_post_type_caps( Forms::POST_CAPABILITY_TYPE ) as $cap => $value ) {
+          if ( ! $role_object->has_cap( $cap ) ) {
+            $role_object->add_cap( $cap );
+          }
+        }
+      } else {
+        foreach( $this->get_all_post_type_caps( Forms::POST_CAPABILITY_TYPE ) as $cap => $value ) {
+          if ( $role_object->has_cap( $cap ) ) {
+            $role_object->remove_cap( $cap );
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the default array of roles which can access Forms CPT:
+   *
+   * @return array
+   */
+  public function get_roles_with_forms_access(): array {
+    return [
+      'administrator' => true,
+    ];
+  }
+
+  /**
+   * Get all post type caps.
+   *
+   * @param string $type      Name of post type.
+   *
+   * @return array
+   */
+  private function get_all_post_type_caps( string $type ): array {
+    $output = [
+      "publish_{$type}s"       => true,
+      "edit_{$type}s"          => true,
+      "edit_others_{$type}s"   => true,
+      "delete_{$type}s"        => true,
+      "delete_others_{$type}s" => true,
+      "read_private_{$type}s"  => true,
+      "edit_{$type}"           => true,
+      "delete_{$type}"         => true,
+      "read_{$type}"           => true,
+    ];
+
+    return $output;
+  }
+}

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -72,6 +72,9 @@ class Main extends Lib_Core {
       // Authorization.
       Integrations\Authorization\HMAC::class,
 
+      // Admin
+      Admin\Users::class,
+
       // Dynamics CRM.
       Integrations\Core\Guzzle_Client::class => array(
         Client::class,

--- a/src/hooks/class-filters.php
+++ b/src/hooks/class-filters.php
@@ -108,10 +108,13 @@ interface Filters {
    * You should return an array with the key name == role_name and value as true / false (if you wish to add or remove access)
    * [
    *   'administrator' => true,
+   *   'editor' => true,
+   * ]
+   *
+   * If you wish to remove access from a role you previously authorized, you can just return it in the array with false:
+   * [
+   *   'administrator' => true,
    *   'editor' => false,
-   *   'author' => false,
-   *   'contributor' => false,
-   *   'subscriber' => false,
    * ]
    *
    * Example:
@@ -121,7 +124,7 @@ interface Filters {
    *   }
    *
    *   public function modify_roles_with_access( array $existing_roles ) {
-   *     $existing_roles['editor] = true;
+   *     $existing_roles['editor'] = true;
    *     return $existing_roles;
    *   }
    *

--- a/src/hooks/class-filters.php
+++ b/src/hooks/class-filters.php
@@ -101,4 +101,31 @@ interface Filters {
    * @var string
    */
   const REQUIRED_PARAMS_BUCKAROO_IDEAL = 'eightshift_forms/required_params/buckaroo_ideal';
+
+  /**
+   * Filter used to modify which roles have access to Forms CPT (by default it's just admins).
+   *
+   * You should return an array with the key name == role_name and value as true / false (if you wish to add or remove access)
+   * [
+   *   'administrator' => true,
+   *   'editor' => false,
+   *   'author' => false,
+   *   'contributor' => false,
+   *   'subscriber' => false,
+   * ]
+   *
+   * Example:
+   *
+   *   public function register(): void {
+   *     add_filter( 'eightshift_forms/roles_with_access_to_forms', [ $this, 'modify_roles_with_access' ], 11, 1 );
+   *   }
+   *
+   *   public function modify_roles_with_access( array $existing_roles ) {
+   *     $existing_roles['editor] = true;
+   *     return $existing_roles;
+   *   }
+   *
+   * @var string
+   */
+  const ROLES_WITH_FORMS_ACCESS = 'eightshift_forms/roles_with_access_to_forms';
 }


### PR DESCRIPTION
Modified Eightshift forms CPT capabilities so they're `eightshift-forms` rather than `post` so we can selectively add / grant access to forms them.

By default only administrators can access it but it can be modified with a filter. I'm open to changing it so that everyone has access by default.