### PR TITLE
Fixed mailchimp client setting logic

### DIFF
--- a/src/integrations/mailchimp/class-mailchimp-marketing-client.php
+++ b/src/integrations/mailchimp/class-mailchimp-marketing-client.php
@@ -23,6 +23,15 @@ class Mailchimp_Marketing_Client implements Mailchimp_Marketing_Client_Interface
    */
   public function __construct() {
     $this->client = new MarketingApiClient();
+
+  }
+
+  /**
+   * Sets the config because we can't set config during construction (filters aren't yet registered)
+   *
+   * @return void
+   */
+  public function set_config() {
     $this->client->setConfig( [
       'apiKey' => \has_filter( Filters::MAILCHIMP ) ? \apply_filters( Filters::MAILCHIMP, 'api_key' ) : '',
       'server' => \has_filter( Filters::MAILCHIMP ) ? \apply_filters( Filters::MAILCHIMP, 'server' ) : '',

--- a/src/routes/class-base-route.php
+++ b/src/routes/class-base-route.php
@@ -362,6 +362,14 @@ abstract class Base_Route extends Libs_Base_Route implements Callable_Route {
         'code' => 400,
         'message' => esc_html__( 'Not all Mailchimp API info is set', 'eightshift-forms' ),
       ],
+      'mailchimp-missing-list-id' => [
+        'code' => 400,
+        'message' => esc_html__( 'Please set a valid List ID in Form options in editor.', 'eightshift-forms' ),
+      ],
+      'mailchimp-missing-email' => [
+        'code' => 400,
+        'message' => esc_html__( 'Please enter your email.', 'eightshift-forms' ),
+      ],
     ];
   }
 

--- a/src/routes/class-mailchimp-route.php
+++ b/src/routes/class-mailchimp-route.php
@@ -88,6 +88,16 @@ class Mailchimp_Route extends Base_Route implements Filters {
     $merge_field_params = $this->unset_irrelevant_params( $params );
     $response           = [];
 
+    // Make sure we have the list ID
+    if ( empty( $list_id ) ) {
+      return $this->rest_response_handler( 'mailchimp-missing-list-id' );
+    }
+
+    // Make sure we have an email
+    if ( empty( $email ) ) {
+      return $this->rest_response_handler( 'mailchimp-missing-email' );
+    }
+
     // Retrieve all entities from the "leads" Entity Set.
     try {
       $response['add'] = $this->mailchimp->add_or_update_member( $list_id, $email, $merge_field_params );

--- a/tests/Mocks/MockMailchimpMarketingClient.php
+++ b/tests/Mocks/MockMailchimpMarketingClient.php
@@ -45,8 +45,21 @@ class MockMailchimpMarketingClient implements Mailchimp_Marketing_Client_Interfa
         'updateListMemberTags' => function( $list_id, $subscriber_hash, $tags ) {
           return '';
         },
+
+        'setConfig' => function($data) {
+          return;
+        }
       ]),
     ]);
+  }
+
+  /**
+   * Mock setting config.
+   *
+   * @return object
+   */
+  public function set_config() {
+    $this->client->setConfig([]);
   }
 
   /**


### PR DESCRIPTION
Changelog
---
* Fixed a bug with mailchimp client (unable to set config data from filter during construction / injection because it's too soon in WP's hook lifecycle)
* Fixed tests
* Added better error messages for Mailchimp route