### PR TITLE
Added a default for radio button name

### DIFF
--- a/src/blocks/custom/radio/manifest.json
+++ b/src/blocks/custom/radio/manifest.json
@@ -49,7 +49,8 @@
       "type": "string"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "default": "your-radio-button"
     },
     "prefillData": {
       "type": "bool",


### PR DESCRIPTION
Without this, the radio buttons in group don't know about each other and don't behave like radio buttons but more like checkboxes.