### PR TITLE
Better Mailchimp logic

### DIFF
--- a/src/integrations/mailchimp/class-mailchimp.php
+++ b/src/integrations/mailchimp/class-mailchimp.php
@@ -69,6 +69,34 @@ class Mailchimp {
   }
 
   /**
+   * Adds a member in Mailchimp.
+   *
+   * @param  string $list_id      Audience list ID.
+   * @param  string $email        Contact's email.
+   * @param  array  $merge_fields List of merge fields to add to request.
+   * @param  array  $params       (Optional) list of params from request.
+   * @param  string $status       (Optional) Member's status (if new).
+   * @return mixed
+   *
+   * @throws \Exception When response is invalid.
+   */
+  public function add_member( string $list_id, string $email, array $merge_fields, array $params = [], string $status = 'pending' ) {
+    $this->setup_client_config_and_verify();
+
+    $params['email_address'] = $email;
+    $params['status']        = $status;
+    $params['merge_fields']  = $merge_fields;
+
+    $response = $this->client->lists->addListMember( $list_id, $params );
+
+    if ( ! is_object( $response ) || ! isset( $response->id, $response->email_address ) ) {
+      throw new \Exception( 'setListMember response invalid' );
+    }
+
+    return $response;
+  }
+
+  /**
    * Add a tag to a member.
    *
    * @param  string $list_id   Audience list ID.

--- a/src/routes/class-mailchimp-route.php
+++ b/src/routes/class-mailchimp-route.php
@@ -134,12 +134,6 @@ class Mailchimp_Route extends Base_Route implements Filters {
         $response['tags'] = $this->mailchimp->add_member_tags( $list_id, $email, $tags );
       }
     } catch ( ClientException $e ) {
-
-      // If Response is null for whatever reason, just treat it like a unknown error.
-      if ( empty( $e->getResponse() ) ) {
-        return $this->rest_response_handler_unknown_error( [ 'error' => $e->getMessage() ] );
-      }
-
       $decoded_exception = ! empty( $e->getResponse() ) ? json_decode( $e->getResponse()->getBody()->getContents(), true ) : [];
 
       if ( isset( $decoded_exception['title'] ) && $decoded_exception['title'] === self::ERROR_USER_EXISTS ) {
@@ -152,6 +146,8 @@ class Mailchimp_Route extends Base_Route implements Filters {
         if ( ! empty( $tags ) ) {
           $response['tags'] = $this->mailchimp->add_member_tags( $list_id, $email, $tags );
         }
+      } else {
+        return $this->rest_response_handler_unknown_error( [ 'error' => $e->getMessage() ] );
       }
     } catch ( Missing_Filter_Info_Exception $e ) {
       return $this->rest_response_handler( 'mailchimp-missing-keys', [ 'message' => $e->getMessage() ] );

--- a/src/routes/class-mailchimp-route.php
+++ b/src/routes/class-mailchimp-route.php
@@ -134,7 +134,13 @@ class Mailchimp_Route extends Base_Route implements Filters {
         $response['tags'] = $this->mailchimp->add_member_tags( $list_id, $email, $tags );
       }
     } catch ( ClientException $e ) {
-      $decoded_exception = json_decode( $e->getResponse()->getBody()->getContents(), true );
+
+      // If Response is null for whatever reason, just treat it like a unknown error.
+      if ( empty( $e->getResponse() ) ) {
+        return $this->rest_response_handler_unknown_error( [ 'error' => $e->getMessage() ] );
+      }
+
+      $decoded_exception = ! empty( $e->getResponse() ) ? json_decode( $e->getResponse()->getBody()->getContents(), true ) : [];
 
       if ( isset( $decoded_exception['title'] ) && $decoded_exception['title'] === self::ERROR_USER_EXISTS ) {
         $msg_user_exists = \esc_html__( 'User already exists', 'eightshift-forms' );

--- a/src/routes/class-mailchimp-route.php
+++ b/src/routes/class-mailchimp-route.php
@@ -18,6 +18,7 @@ use Eightshift_Forms\Captcha\Basic_Captcha;
 use Eightshift_Forms\Exception\Missing_Filter_Info_Exception;
 use Eightshift_Forms\Exception\Unverified_Request_Exception;
 use Eightshift_Forms\Integrations\Mailchimp\Mailchimp;
+use GuzzleHttp\Exception\ClientException;
 
 /**
  * Class Mailchimp_Route
@@ -53,12 +54,18 @@ class Mailchimp_Route extends Base_Route implements Filters {
   const TAGS_PARAM = 'tags';
 
   /**
+   * Error if user exists
+   *
+   * @var string
+   */
+  const ERROR_USER_EXISTS = 'Member Exists';
+
+  /**
    * Config data obj.
    *
    * @var Config_Data
    */
   protected $config;
-
   /**
    * Mailchimp object.
    *
@@ -121,10 +128,24 @@ class Mailchimp_Route extends Base_Route implements Filters {
 
     // Retrieve all entities from the "leads" Entity Set.
     try {
-      $response['add'] = $this->mailchimp->add_or_update_member( $list_id, $email, $merge_field_params );
+      $response['add'] = $this->mailchimp->add_member( $list_id, $email, $merge_field_params );
 
       if ( ! empty( $tags ) ) {
         $response['tags'] = $this->mailchimp->add_member_tags( $list_id, $email, $tags );
+      }
+    } catch ( ClientException $e ) {
+      $decoded_exception = json_decode( $e->getResponse()->getBody()->getContents(), true );
+
+      if ( isset( $decoded_exception['title'] ) && $decoded_exception['title'] === self::ERROR_USER_EXISTS ) {
+        $msg_user_exists = \esc_html__( 'User already exists', 'eightshift-forms' );
+        $response['add'] = $msg_user_exists;
+        $message         = $msg_user_exists;
+
+        // We need to do the "adding tags" call as well (if needed) as the exception in the "add_member" method
+        // has stopped execution.
+        if ( ! empty( $tags ) ) {
+          $response['tags'] = $this->mailchimp->add_member_tags( $list_id, $email, $tags );
+        }
       }
     } catch ( Missing_Filter_Info_Exception $e ) {
       return $this->rest_response_handler( 'mailchimp-missing-keys', [ 'message' => $e->getMessage() ] );
@@ -136,7 +157,7 @@ class Mailchimp_Route extends Base_Route implements Filters {
       [
         'code' => 200,
         'data' => $response,
-        'message' => esc_html__( 'Successfully added ', 'eightshift-forms' ),
+        'message' => ! empty( $message ) ? $message : \esc_html__( 'Successfully added ', 'eightshift-forms' ),
       ]
     );
   }

--- a/tests/Mocks/MockMailchimpMarketingClient.php
+++ b/tests/Mocks/MockMailchimpMarketingClient.php
@@ -41,6 +41,17 @@ class MockMailchimpMarketingClient implements Mailchimp_Marketing_Client_Interfa
             'mergeFields' => $params['merge_fields'],
           ]);
         },
+        'addListMember' => function( $list_id, $params ) {
+          if ( $list_id === DataProvider::INVALID_LIST_ID ) {
+            throw new ClientException( 'invalid list id', new Request('GET', 'test'), new Response() );
+          }
+
+          return DataProvider::getMockAddOrUpdateMemberResponse([
+            'listId' => $list_id,
+            'email' => DataProvider::MOCK_EMAIL,
+            'mergeFields' => $params['merge_fields'],
+          ]);
+        },
 
         'updateListMemberTags' => function( $list_id, $subscriber_hash, $tags ) {
           return '';

--- a/tests/Routes/MailchimpRouteTest.php
+++ b/tests/Routes/MailchimpRouteTest.php
@@ -32,8 +32,6 @@ class MailchimpRouteTest extends BaseRouteTest
     ];
     $response = $this->route_endpoint->route_callback( $request );
 
-    error_log(print_r($response, true));
-
     $this->verifyProperlyFormattedResponse($response);
     $this->assertEquals(200, $response->data['code'] );
   }

--- a/tests/Routes/MailchimpRouteTest.php
+++ b/tests/Routes/MailchimpRouteTest.php
@@ -32,12 +32,14 @@ class MailchimpRouteTest extends BaseRouteTest
     ];
     $response = $this->route_endpoint->route_callback( $request );
 
+    error_log(print_r($response, true));
+
     $this->verifyProperlyFormattedResponse($response);
     $this->assertEquals(200, $response->data['code'] );
   }
 
   /**
-   * Correct request should result in 200 response
+   * Invalid list ID should trigger an error response.
    *
    * @return void
    */


### PR DESCRIPTION
Mailchimp route only adds users by default (doesn't update them).

We should never really have a form which updates on frontend (unless it's specifically a form for updating user data - which is currently out of scope).

If user already exists it still returns 200 with an appropriate message "User already exists" (as that's not really an error).