### PR TITLE
All routes used on frontend (in forms) are now POST by default

### DIFF
--- a/src/blocks/helpers/forms.js
+++ b/src/blocks/helpers/forms.js
@@ -1,5 +1,5 @@
-const sendGet = async (url, data, options = {
-  method: 'GET', // *GET, POST, PUT, DELETE, etc.
+const sendRequest = async (url, data, method = 'POST', options = {
+  method, // *GET, POST, PUT, DELETE, etc.
   mode: 'cors', // no-cors, *cors, same-origin
   cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
   credentials: 'same-origin', // include, *same-origin, omit
@@ -23,5 +23,6 @@ const sendGet = async (url, data, options = {
 };
 
 export const sendForm = async (where, formData) => {
-  return sendGet(where, formData);
+  return sendRequest(where, formData);
 };
+

--- a/src/routes/class-base-buckaroo-route.php
+++ b/src/routes/class-base-buckaroo-route.php
@@ -193,6 +193,24 @@ abstract class Base_Buckaroo_Route extends Base_Route implements Filters {
   }
 
   /**
+   * Toggle if this route requires nonce verification
+   *
+   * @return bool
+   */
+  protected function requires_nonce_verification(): bool {
+    return true;
+  }
+
+  /**
+   * Returns allowed methods for this route.
+   *
+   * @return string|array
+   */
+  protected function get_methods() {
+    return static::CREATABLE;
+  }
+
+  /**
    * Method that returns rest response
    *
    * @param  \WP_REST_Request $request Data got from endpoint url.

--- a/src/routes/class-base-route.php
+++ b/src/routes/class-base-route.php
@@ -123,10 +123,19 @@ abstract class Base_Route extends Libs_Base_Route implements Callable_Route, Act
    */
   protected function get_callback_arguments() : array {
     return [
-      'methods'  => static::READABLE,
+      'methods'  => $this->get_methods(),
       'callback' => [ $this, 'route_callback' ],
       'permission_callback' => [ $this, 'permission_callback' ],
     ];
+  }
+
+  /**
+   * Returns allowed methods for this route.
+   *
+   * @return string|array
+   */
+  protected function get_methods() {
+    return static::READABLE;
   }
 
   /**

--- a/src/routes/class-buckaroo-response-handler-route.php
+++ b/src/routes/class-buckaroo-response-handler-route.php
@@ -257,14 +257,11 @@ class Buckaroo_Response_Handler_Route extends Base_Route implements Actions, Fil
   }
 
   /**
-   * Override default get_callback_arguments method in order to allow POST requests as well as GET.
+   * Returns allowed methods for this route.
    *
-   * @return array
+   * @return string|array
    */
-  protected function get_callback_arguments() : array {
-    return [
-      'methods'  => [ static::READABLE, static::CREATABLE ],
-      'callback' => [ $this, 'route_callback' ],
-    ];
+  protected function get_methods() {
+    return [ static::READABLE, static::CREATABLE ];
   }
 }

--- a/src/routes/class-dynamics-crm-route.php
+++ b/src/routes/class-dynamics-crm-route.php
@@ -142,4 +142,22 @@ class Dynamics_Crm_Route extends Base_Route implements Filters {
       self::ENTITY_PARAM,
     ];
   }
+
+  /**
+   * Toggle if this route requires nonce verification
+   *
+   * @return bool
+   */
+  protected function requires_nonce_verification(): bool {
+    return true;
+  }
+
+  /**
+   * Returns allowed methods for this route.
+   *
+   * @return string|array
+   */
+  protected function get_methods() {
+    return static::CREATABLE;
+  }
 }

--- a/src/routes/class-mailchimp-route.php
+++ b/src/routes/class-mailchimp-route.php
@@ -200,4 +200,13 @@ class Mailchimp_Route extends Base_Route implements Filters {
   protected function requires_nonce_verification(): bool {
     return true;
   }
+
+  /**
+   * Returns allowed methods for this route.
+   *
+   * @return mixed
+   */
+  protected function get_methods() {
+    return static::CREATABLE;
+  }
 }

--- a/src/routes/class-mailchimp-route.php
+++ b/src/routes/class-mailchimp-route.php
@@ -204,7 +204,7 @@ class Mailchimp_Route extends Base_Route implements Filters {
   /**
    * Returns allowed methods for this route.
    *
-   * @return mixed
+   * @return string|array
    */
   protected function get_methods() {
     return static::CREATABLE;

--- a/src/routes/class-send-email-route.php
+++ b/src/routes/class-send-email-route.php
@@ -172,4 +172,22 @@ class Send_Email_Route extends Base_Route {
       self::MESSAGE_PARAM,
     ];
   }
+
+  /**
+   * Toggle if this route requires nonce verification
+   *
+   * @return bool
+   */
+  protected function requires_nonce_verification(): bool {
+    return true;
+  }
+
+  /**
+   * Returns allowed methods for this route.
+   *
+   * @return string|array
+   */
+  protected function get_methods() {
+    return static::CREATABLE;
+  }
 }

--- a/tests/Routes/BuckarooResponseHandlerRouteTest.php
+++ b/tests/Routes/BuckarooResponseHandlerRouteTest.php
@@ -9,6 +9,7 @@ use Brain\Monkey\Filters as BrainFilters;
 
 class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters, Actions
 {
+  const METHOD = 'GET';
 
   protected function getRouteName(): string {
     return Buckaroo_Response_Handler_Route::class;
@@ -41,8 +42,8 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
   {
     $this->addHooks();
 
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::REDIRECT_URL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_CANCEL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_ERROR_PARAM => 'http://someurl.com',
@@ -54,7 +55,7 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
     // We need to URL encode params before calculating the hash (because that is done in the route before
     // verifying the hash. However we can't send the URLs encoded because that won't work. In the app these are sent
     // (encoded) to Buckaroo which will decode them when redirecting back to the response handler.
-    $request->params['GET'][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
+    $request->params[self::METHOD][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
       $this->urlencode_params($request->get_query_params()),
       \apply_filters( self::BUCKAROO, 'secret_key' )
     );
@@ -73,15 +74,15 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
   {
     $this->addHooks();
 
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::REDIRECT_URL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_CANCEL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_ERROR_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_REJECT_PARAM => 'http://someurl.com',
       $this->route_endpoint::STATUS_PARAM => 'success',
     ];
-    $request->params['GET'][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash($request->get_query_params(), \apply_filters( self::BUCKAROO, 'secret_key' ) );
+    $request->params[self::METHOD][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash($request->get_query_params(), \apply_filters( self::BUCKAROO, 'secret_key' ) );
     $response = $this->route_endpoint->route_callback( $request );
 
     $this->verifyProperlyFormattedError($response);
@@ -97,8 +98,8 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
   {
     $this->addHooks();
 
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::REDIRECT_URL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_CANCEL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_ERROR_PARAM => 'http://someurl.com',
@@ -108,7 +109,7 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
     $request->params['POST'] = [
       $this->route_endpoint::BUCKAROO_RESPONSE_CODE_PARAM => 190,
     ];
-    $request->params['GET'][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
+    $request->params[self::METHOD][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
       $this->urlencode_params($request->get_query_params()),
       \apply_filters( self::BUCKAROO, 'secret_key' )
     );
@@ -126,8 +127,8 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
   {
     $this->addHooks();
 
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::REDIRECT_URL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_CANCEL_PARAM => 'http://someurl.com',
       $this->route_endpoint::REDIRECT_URL_ERROR_PARAM => 'http://someurl.com',
@@ -135,7 +136,7 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
       $this->route_endpoint::STATUS_PARAM => rawurlencode('success'),
     ];
     $request->params['POST'] = DataProvider::idealSuccessResponseMock();
-    $request->params['GET'][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
+    $request->params[self::METHOD][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
       $this->urlencode_params($request->get_query_params()),
       \apply_filters( self::BUCKAROO, 'secret_key' )
     );
@@ -152,8 +153,8 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
   {
     $this->addHooks();
 
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::REDIRECT_URL_PARAM => '',
       $this->route_endpoint::REDIRECT_URL_CANCEL_PARAM => '',
       $this->route_endpoint::REDIRECT_URL_ERROR_PARAM => '',
@@ -163,7 +164,7 @@ class BuckarooResponseHandlerRouteTest extends BaseRouteTest implements Filters,
     $request->params['POST'] = [
       $this->route_endpoint::BUCKAROO_RESPONSE_CODE_PARAM => 190,
     ];
-    $request->params['GET'][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
+    $request->params[self::METHOD][ HMAC::AUTHORIZATION_KEY ] = $this->hmac->generate_hash(
       $this->urlencode_params($request->get_query_params()),
       \apply_filters( self::BUCKAROO, 'secret_key' )
     );

--- a/tests/Routes/MailchimpRouteTest.php
+++ b/tests/Routes/MailchimpRouteTest.php
@@ -6,6 +6,8 @@ use EightshiftFormsTests\Integrations\Mailchimp\DataProvider;
 
 class MailchimpRouteTest extends BaseRouteTest
 {
+  const METHOD = 'POST';
+
   protected function getRouteName(): string {
     return Mailchimp_Route::class;
   }
@@ -25,8 +27,8 @@ class MailchimpRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessfulWhenAddingNewMembers()
   {
-    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
-    $request->params['POST'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::EMAIL_PARAM => 'someemail@infinum.com',
       $this->route_endpoint::LIST_ID_PARAM => 'list-id',
       'nonce' => 'asdb',
@@ -45,8 +47,8 @@ class MailchimpRouteTest extends BaseRouteTest
    */
   public function testRestCallFailsIfInvalidListId()
   {
-    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
-    $request->params['POST'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::EMAIL_PARAM => 'someemail@infinum.com',
       $this->route_endpoint::LIST_ID_PARAM => DataProvider::INVALID_LIST_ID,
     ];
@@ -63,8 +65,8 @@ class MailchimpRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessfulWhenAddingTags()
   {
-    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
-    $request->params['POST'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::EMAIL_PARAM => 'someemail@infinum.com',
       $this->route_endpoint::LIST_ID_PARAM => 'list-id',
       $this->route_endpoint::TAGS_PARAM => [

--- a/tests/Routes/MailchimpRouteTest.php
+++ b/tests/Routes/MailchimpRouteTest.php
@@ -25,8 +25,8 @@ class MailchimpRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessfulWhenAddingNewMembers()
   {
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
+    $request->params['POST'] = [
       $this->route_endpoint::EMAIL_PARAM => 'someemail@infinum.com',
       $this->route_endpoint::LIST_ID_PARAM => 'list-id',
       'nonce' => 'asdb',
@@ -45,8 +45,8 @@ class MailchimpRouteTest extends BaseRouteTest
    */
   public function testRestCallFailsIfInvalidListId()
   {
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
+    $request->params['POST'] = [
       $this->route_endpoint::EMAIL_PARAM => 'someemail@infinum.com',
       $this->route_endpoint::LIST_ID_PARAM => DataProvider::INVALID_LIST_ID,
     ];
@@ -63,8 +63,8 @@ class MailchimpRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessfulWhenAddingTags()
   {
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
+    $request->params['POST'] = [
       $this->route_endpoint::EMAIL_PARAM => 'someemail@infinum.com',
       $this->route_endpoint::LIST_ID_PARAM => 'list-id',
       $this->route_endpoint::TAGS_PARAM => [

--- a/tests/Routes/SendEmailRouteTest.php
+++ b/tests/Routes/SendEmailRouteTest.php
@@ -14,11 +14,13 @@ class SendEmailRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessful()
   {
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
+    $request->params['POST'] = [
       $this->route_endpoint::TO_PARAM => 'some value',
       $this->route_endpoint::SUBJECT_PARAM => 'some value',
       $this->route_endpoint::MESSAGE_PARAM => 'some value',
+      'nonce' => 'some value',
+      'form-unique-id' => 'some-d',
     ];
     $response = $this->route_endpoint->route_callback( $request );
 
@@ -34,11 +36,13 @@ class SendEmailRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessfulWithPlaceholders()
   {
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
+    $request->params['POST'] = [
       $this->route_endpoint::TO_PARAM => 'to param',
       $this->route_endpoint::SUBJECT_PARAM => 'subject',
       $this->route_endpoint::MESSAGE_PARAM => 'Message [[message]]',
+      'nonce' => 'some value',
+      'form-unique-id' => 'some-d',
     ];
 
     $response = $this->route_endpoint->route_callback( $request );

--- a/tests/Routes/SendEmailRouteTest.php
+++ b/tests/Routes/SendEmailRouteTest.php
@@ -3,6 +3,8 @@
 use Eightshift_Forms\Rest\Send_Email_Route;
 class SendEmailRouteTest extends BaseRouteTest
 {
+  const METHOD = 'POST';
+
   protected function getRouteName(): string {
     return Send_Email_Route::class;
   }
@@ -14,8 +16,8 @@ class SendEmailRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessful()
   {
-    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
-    $request->params['POST'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::TO_PARAM => 'some value',
       $this->route_endpoint::SUBJECT_PARAM => 'some value',
       $this->route_endpoint::MESSAGE_PARAM => 'some value',
@@ -36,8 +38,8 @@ class SendEmailRouteTest extends BaseRouteTest
    */
   public function testRestCallSuccessfulWithPlaceholders()
   {
-    $request = new \WP_REST_Request('POST', $this->route_endpoint->get_route_uri());
-    $request->params['POST'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::TO_PARAM => 'to param',
       $this->route_endpoint::SUBJECT_PARAM => 'subject',
       $this->route_endpoint::MESSAGE_PARAM => 'Message [[message]]',
@@ -59,8 +61,8 @@ class SendEmailRouteTest extends BaseRouteTest
    */
   public function testRestCallFailsIfRequiredParamsEmpty()
   {
-    $request = new \WP_REST_Request('GET', $this->route_endpoint->get_route_uri());
-    $request->params['GET'] = [
+    $request = new \WP_REST_Request(self::METHOD, $this->route_endpoint->get_route_uri());
+    $request->params[self::METHOD] = [
       $this->route_endpoint::TO_PARAM => 'to param',
       $this->route_endpoint::SUBJECT_PARAM => 'subject',
       $this->route_endpoint::MESSAGE_PARAM => '',
@@ -72,7 +74,7 @@ class SendEmailRouteTest extends BaseRouteTest
     $this->assertEquals(400, $response->data['code'] );
     $this->assertSame( 0, did_action( self::WP_MAIL_ACTION ) );
 
-    $request->params['GET'] = [
+    $request->params[self::METHOD] = [
       $this->route_endpoint::TO_PARAM => 'to param',
       $this->route_endpoint::SUBJECT_PARAM => '',
       $this->route_endpoint::MESSAGE_PARAM => 'message',
@@ -84,7 +86,7 @@ class SendEmailRouteTest extends BaseRouteTest
     $this->assertEquals(400, $response->data['code'] );
     $this->assertSame( 0, did_action( self::WP_MAIL_ACTION ) );
 
-    $request->params['GET'] = [
+    $request->params[self::METHOD] = [
       $this->route_endpoint::TO_PARAM => '',
       $this->route_endpoint::SUBJECT_PARAM => 'subject',
       $this->route_endpoint::MESSAGE_PARAM => 'message',

--- a/tests/WordPressMocks/WP_REST_Request.php
+++ b/tests/WordPressMocks/WP_REST_Request.php
@@ -37,13 +37,13 @@ class WP_REST_Request
 	 * @return array Parameter map of key to value
 	 */
 	public function get_query_params() {
-		return $this->params['GET'];
+		return $this->method === 'POST' ? $this->params['POST'] : $this->params['GET'];
 	}
 
 	/**
 	 * Retrieves parameters from body.
 	 *
-	 * These are the parameters you'd typically find in `$_POST`.
+	 * These are the parameters you'd typically find in `$_POST` (if you have both $_GET and $_POST params at the same time)
 	 *
 	 * @return array Parameter map of key to value
 	 */


### PR DESCRIPTION
Changelog
---
* Ajax form submission uses POST
* Email route now only accepts POST requests + added nonce verification
* Mailchimp route now only accepts POST requests + added nonce verification
* CRM (add entity) route now only accepts POST requests + added nonce verification
* Buckaroo route now only accepts POST requests + added nonce verification