### PR TITLE
Added placeholder if form is empty

### DIFF
--- a/src/blocks/custom/form/components/form-editor.js
+++ b/src/blocks/custom/form/components/form-editor.js
@@ -1,12 +1,18 @@
+import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { Placeholder } from '@wordpress/components';
 
 /**
  * Form editor.
  *
  * @param {object} props Props.
  */
+
 export const FormEditor = (props) => {
   const {
+    clientId,
     attributes: {
       blockClass,
       classes,
@@ -14,8 +20,27 @@ export const FormEditor = (props) => {
     },
   } = props;
 
+  const [hasInnerBlocks, setHasInnerBlocks] = useState(false);
+
+  useSelect((select) => {
+    const hasInner = select('core/block-editor').getBlock(clientId).innerBlocks.length > 0;
+
+    if (
+      (!hasInnerBlocks && hasInner) ||
+      (hasInnerBlocks && !hasInner)
+    ) {
+      setHasInnerBlocks(hasInner);
+    }
+  });
+
   return (
     <form className={`${blockClass} ${classes}`} id={id}>
+      {!hasInnerBlocks &&
+        <Placeholder
+          icon="welcome-write-blog"
+          label={__('This is an empty form. Click on me to start building your form.', 'eightshift-forms')}
+        />
+      }
       <InnerBlocks
         templateLock={false}
       />

--- a/src/blocks/custom/form/form-block.js
+++ b/src/blocks/custom/form/form-block.js
@@ -9,6 +9,7 @@ import { FormOptions } from './components/form-options';
 
 export const Form = (props) => {
   const {
+    clientId,
     attributes,
   } = props;
 
@@ -23,6 +24,7 @@ export const Form = (props) => {
         />
       </InspectorControls>
       <FormEditor
+        clientId={clientId}
         attributes={attributes}
         actions={actions}
       />


### PR DESCRIPTION
Removes the confusion on WP >=5.6 when it's not clear how to add new blocks to a new empty form.