### PR TITLE
Add caching to Mailchimp getLists call

### DIFF
--- a/src/blocks/custom/form/components/form-options.js
+++ b/src/blocks/custom/form/components/form-options.js
@@ -105,10 +105,11 @@ export const FormOptions = (props) => {
     isBuckarooUsed,
     isMailchimpUsed,
     dynamicsCrm = [],
-    mailchimp = {},
   } = window.eightshiftForms;
 
-  const audiences = (mailchimp && mailchimp.audiences) ? mailchimp.audiences : [];
+  const mailchimpAdmin = window.eightshiftFormsAdmin.mailchimp || {};
+
+  const audiences = (mailchimpAdmin && mailchimpAdmin.audiences) ? mailchimpAdmin.audiences : [];
 
   const themeAsOptions = hasThemes ? themes.map((tempTheme) => ({ label: tempTheme, value: tempTheme })) : [];
 

--- a/src/cache/class-transient-cache.php
+++ b/src/cache/class-transient-cache.php
@@ -33,7 +33,7 @@ class Transient_Cache implements Cache {
    * @return string
    */
   public function get( string $cache_key ): string {
-    return get_transient( $cache_key );
+    return (string) get_transient( $cache_key );
   }
 
   /**

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -167,6 +167,10 @@ class Main extends Lib_Core {
         Lib_Manifest\Manifest::class,
         Enqueue\Localization_Constants::class,
       ),
+      Enqueue\Enqueue_Admin::class => array(
+        Lib_Manifest\Manifest::class,
+        Enqueue\Localization_Constants::class,
+      ),
 
       // Admin.
       Admin\Forms::class,

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -200,6 +200,7 @@ class Main extends Lib_Core {
       // Integrations.
       Integrations\Mailchimp\Mailchimp::class => array(
         Mocks\MockMailchimpMarketingClient::class,
+        Cache\Transient_Cache::class,
       ),
 
       // HTTP.

--- a/src/enqueue/class-enqueue-admin.php
+++ b/src/enqueue/class-enqueue-admin.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * The Admin Enqueue specific functionality.
+ *
+ * @package Eightshift_Forms\Enqueue
+ */
+
+declare( strict_types=1 );
+
+namespace Eightshift_Forms\Enqueue;
+
+use Eightshift_Libs\Enqueue\Enqueue_Admin as Lib_Enqueue_Admin;
+use Eightshift_Libs\Manifest\Manifest_Data;
+
+/**
+ * Class Enqueue
+ */
+class Enqueue_Admin extends Lib_Enqueue_Admin {
+
+  /**
+   * Manifest obj.
+   *
+   * @var Manifest_Data
+   */
+  protected $manifest;
+
+  /**
+   * Object which holds all variables that need to be passed to the editor.
+   *
+   * @var Localization_Constants
+   */
+  private $localization_constants;
+
+  /**
+   * Create a new admin instance.
+   *
+   * @param Manifest_Data          $manifest               Inject manifest which holds data about assets from manifest.json.
+   * @param Localization_Constants $localization_constants Injected object which holds all localizations shared between editor and frontend.
+   */
+  public function __construct( Manifest_Data $manifest, Localization_Constants $localization_constants ) {
+    $this->manifest               = $manifest;
+    $this->localization_constants = $localization_constants;
+  }
+
+  /**
+   * Get localizations.
+   *
+   * @return array
+   */
+  public function get_localizations(): array {
+    return $this->localization_constants->get_admin_localizations();
+  }
+}

--- a/src/enqueue/class-localization-constants.php
+++ b/src/enqueue/class-localization-constants.php
@@ -26,6 +26,13 @@ class Localization_Constants implements Filters {
   const LOCALIZATION_KEY = 'eightshiftForms';
 
   /**
+   * Key under which all localizations are held. window.${LOCALIZATION_KEY}. Only loaded in admin.
+   *
+   * @var string
+   */
+  const LOCALIZATION_ADMIN_KEY = 'eightshiftFormsAdmin';
+
+  /**
    * Some variable.
    *
    * @var Active_Route
@@ -147,6 +154,25 @@ class Localization_Constants implements Filters {
       $localization[ self::LOCALIZATION_KEY ]['prefill']['multi'] = $this->add_prefill_generic_multi_constants();
     }
 
+    if ( has_filter( Filters::PREFILL_GENERIC_SINGLE ) ) {
+      $localization[ self::LOCALIZATION_KEY ]['prefill']['single'] = $this->add_prefill_generic_single_constants();
+    }
+
+    return $localization;
+  }
+
+  /**
+   * Define all variables we need in both editor and frontend.
+   *
+   * @return array
+   */
+  public function get_admin_localizations(): array {
+    $localization = [];
+
+    if ( has_filter( Filters::MAILCHIMP ) ) {
+      $localization = $this->add_mailchimp_admin_constants( $localization );
+    }
+
     return $localization;
   }
 
@@ -205,7 +231,7 @@ class Localization_Constants implements Filters {
   }
 
   /**
-   * Localize all constants required for Buckaroo integration.
+   * Localize all constants required for Mailchimp integration.
    *
    * @param  array $localization Existing localizations.
    * @return array
@@ -213,6 +239,19 @@ class Localization_Constants implements Filters {
   protected function add_mailchimp_constants( array $localization ): array {
     $localization[ self::LOCALIZATION_KEY ]['mailchimp'] = [
       'restUri' => $this->mailchimp_route->get_route_uri(),
+    ];
+
+    return $localization;
+  }
+
+  /**
+   * Localize all constants required for Mailchimp integration (only available in admin)
+   *
+   * @param  array $localization Existing localizations.
+   * @return array
+   */
+  protected function add_mailchimp_admin_constants( array $localization ): array {
+    $localization[ self::LOCALIZATION_ADMIN_KEY ]['mailchimp'] = [
       'audiences' => $this->fetch_mailchimp_audiences(),
     ];
 
@@ -245,7 +284,7 @@ class Localization_Constants implements Filters {
   }
 
   /**
-   * Localize all constants required for Dynamics CRM integration.
+   * Adds prefill options to multi option blocks (select, radio, etc).
    *
    * @return array
    */
@@ -266,5 +305,29 @@ class Localization_Constants implements Filters {
     }
 
     return $prefill_multi_formatted;
+  }
+
+  /**
+   * Adds prefill options to single option blocks (input, etc).
+   *
+   * @return array
+   */
+  protected function add_prefill_generic_single_constants(): array {
+    $prefill_single = apply_filters( Filters::PREFILL_GENERIC_SINGLE, [] );
+
+    if ( ! is_array( $prefill_single ) ) {
+      return [];
+    }
+
+    $prefill_single_formatted = [];
+    foreach ( $prefill_single as $source_name => $prefill_single_source ) {
+      if ( isset( $prefill_single_source['data'] ) ) {
+        unset( $prefill_single_source['data'] );
+      }
+
+      $prefill_single_formatted[] = $prefill_single_source;
+    }
+
+    return $prefill_single_formatted;
   }
 }

--- a/src/integrations/mailchimp/class-mailchimp.php
+++ b/src/integrations/mailchimp/class-mailchimp.php
@@ -9,13 +9,29 @@ declare( strict_types=1 );
 
 namespace Eightshift_Forms\Integrations\Mailchimp;
 
+use Eightshift_Forms\Cache\Cache;
 use Eightshift_Forms\Hooks\Filters;
 use Eightshift_Forms\Exception\Missing_Filter_Info_Exception;
 use \MailchimpMarketing\ApiClient;
+
 /**
  * Mailchimp integration class.
  */
 class Mailchimp {
+
+  /**
+   * Lists transient name
+   *
+   * @var string
+   */
+  const CACHE_LISTS = 'eightshift-forms-mailchimp-lists';
+
+  /**
+   * Lists transient expiration time.
+   *
+   * @var int
+   */
+  const CACHE_LIST_TIMEOUT = 60 * 15; // 15 min
 
   /**
    * Mailchimp Marketing Api client.
@@ -32,12 +48,21 @@ class Mailchimp {
   private $mailchimp_marketing_client;
 
   /**
+   * Cache object used for caching Mailchimp responses.
+   *
+   * @var Cache
+   */
+  private $cache;
+
+  /**
    * Constructs object
    *
    * @param Mailchimp_Marketing_Client_Interface $mailchimp_marketing_client Mailchimp marketing client.
+   * @param Cache                                $transient_cache            Transient cache object.
    */
-  public function __construct( Mailchimp_Marketing_Client_Interface $mailchimp_marketing_client ) {
+  public function __construct( Mailchimp_Marketing_Client_Interface $mailchimp_marketing_client, Cache $transient_cache ) {
     $this->mailchimp_marketing_client = $mailchimp_marketing_client;
+    $this->cache                      = $transient_cache;
   }
 
   /**
@@ -142,23 +167,33 @@ class Mailchimp {
   /**
    * Get information about all lists in the account.
    *
+   * @param bool $is_fresh Set to true if you want to fetch the lists regardless if we already have them cached.
    * @return mixed
    *
    * @throws \Exception When response is invalid.
    */
-  public function get_all_lists() {
-    $this->setup_client_config_and_verify();
-    $response = $this->client->lists->getAllLists();
+  public function get_all_lists( bool $is_fresh = false ) {
 
-    if ( ! isset( $response, $response->lists ) && ! is_array( $response->lists ) ) {
-      throw new \Exception( 'Lists response invalid' );
-    }
+    $cached_response = $this->cache->get( self::CACHE_LISTS );
 
-    foreach ( $response->lists as $list_obj ) {
+    if ( $is_fresh || empty( $cached_response ) ) {
+      $this->setup_client_config_and_verify();
+      $response = $this->client->lists->getAllLists();
 
-      if ( ! is_object( $list_obj ) || ! isset( $list_obj->id, $list_obj->name ) ) {
+      if ( ! isset( $response, $response->lists ) && ! is_array( $response->lists ) ) {
         throw new \Exception( 'Lists response invalid' );
       }
+
+      foreach ( $response->lists as $list_obj ) {
+
+        if ( ! is_object( $list_obj ) || ! isset( $list_obj->id, $list_obj->name ) ) {
+          throw new \Exception( 'Lists response invalid' );
+        }
+      }
+
+      $this->cache->save( self::CACHE_LISTS, (string) wp_json_encode( $response ), self::CACHE_LIST_TIMEOUT );
+    } else {
+      $response = json_decode( $cached_response );
     }
 
     return $response;


### PR DESCRIPTION
Currently (if Mailchimp used), Mailchimp `getLists` API is called on each request (which is bad). Now it's only called on admin requests (we don't need it on frontend) + it's cached for 15min as a transient so we don't call it on each admin request.