### PR TITLE
GitHub build action

### DIFF
--- a/.github/workflows/build-assets-on-release.yml
+++ b/.github/workflows/build-assets-on-release.yml
@@ -1,0 +1,72 @@
+name: Build assets on release and create archive
+on: 
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+          node: [14]
+
+    steps:
+    - name: 'Checkout master branch'
+      uses: actions/checkout@master
+
+    - name: PHP setup
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+        coverage: pcov
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: |
+        echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - name: Cache composer dependencies
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+    - name: Install composer packages
+      run: composer install --no-progress
+
+    - name: Set Node.js version
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
+
+    - name: Cache node modules
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-build-${{ env.cache-name }}-
+          ${{ runner.OS }}-build-
+          ${{ runner.OS }}-
+
+    - name: Install node packages
+      run: npm install
+
+    - name: Install node packages
+      run: npm run build --no-dev --no-progress
+
+    - name: Archive Release
+      uses: thedoctor0/zip-release@master
+      with:
+        filename: 'release.zip'
+        exclusions: '*.git* /*node_modules/* .editorconfig'
+
+    - name: Add artifacts to release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: release.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-assets-on-release.yml
+++ b/.github/workflows/build-assets-on-release.yml
@@ -20,7 +20,6 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 7.4
-        coverage: pcov
 
     - name: Get composer cache directory
       id: composer-cache

--- a/.github/workflows/build-assets-on-release.yml
+++ b/.github/workflows/build-assets-on-release.yml
@@ -2,7 +2,7 @@ name: Build assets on release and create archive
 on: 
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*.*'
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-assets-on-release.yml
+++ b/.github/workflows/build-assets-on-release.yml
@@ -21,20 +21,10 @@ jobs:
       with:
         php-version: 7.4
 
-    - name: Get composer cache directory
-      id: composer-cache
-      run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-    - name: Cache composer dependencies
-      uses: actions/cache@v1
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-    - name: Install composer packages
-      run: composer install --no-progress
+    # Install dependencies and handle caching in one go.
+    # @link https://github.com/marketplace/actions/install-composer-dependencies
+    - name: Install Composer dependencies
+      uses: ramsey/composer-install@v1
 
     - name: Set Node.js version
       uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ Clone the project + build to get started:
 
 **For more details about this and all other eightshift-boilerplate based plugins follow [this link](https://infinum.github.io/eightshift-docs).**
 
-## Tagging releases
-
-All releases should be tagged with the version in the following format:
-`v*.*.*` (for example `v1.2.23`)
 
 This is required for the github action which builds assets on new releases and adds them to the release as a zip file (so the plugin can be installed without manually building it)
 ## :mailbox: Who do I talk to?

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Clone the project + build to get started:
 
 **For more details about this and all other eightshift-boilerplate based plugins follow [this link](https://infinum.github.io/eightshift-docs).**
 
+## Tagging releases
+
+All releases should be tagged with the version in the following format:
+`v*.*.*` (for example `v1.2.23`)
+
+This is required for the github action which builds assets on new releases and adds them to the release as a zip file (so the plugin can be installed without manually building it)
 ## :mailbox: Who do I talk to?
 
 If you have any questions or problems, please [open an issue](https://github.com/infinum/eightshift-forms-plugin/issues) on github and we will do our best to give you a timely answer.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Clone the project + build to get started:
 
 **For more details about this and all other eightshift-boilerplate based plugins follow [this link](https://infinum.github.io/eightshift-docs).**
 
-
-This is required for the github action which builds assets on new releases and adds them to the release as a zip file (so the plugin can be installed without manually building it)
+This is required for the GitHub action which builds assets on new releases and adds them to the release as a zip file (so the plugin can be installed without manually building it)
 ## :mailbox: Who do I talk to?
 
 If you have any questions or problems, please [open an issue](https://github.com/infinum/eightshift-forms-plugin/issues) on github and we will do our best to give you a timely answer.


### PR DESCRIPTION
With the following action, a new release will automatically build a `release.zip` file which can be downloaded, unpacked and activated (without having to manually build assets). This is also required for the automatic plugin management provided by eightshift-boilerplate.