### PR TITLE
Span around button submit

### DIFF
--- a/src/Blocks/components/submit/submit.php
+++ b/src/Blocks/components/submit/submit.php
@@ -48,8 +48,8 @@ $button = '
 		name="es-form-submit"
 		data-tracking="' . $submitTracking . '"
 		' . $submitIsDisabled . '
-	>' . esc_html($submitValue) . '
-	</button>
+	><span>' . esc_html($submitValue) . '
+	</span></button>
 ';
 
 echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
Adds span around submit button content to ease styling in some cases (e.g. buttons with gradient backgrounds).