### PR TITLE
Disabled field improvements

### DIFF
--- a/src/Blocks/components/checkbox/checkbox.php
+++ b/src/Blocks/components/checkbox/checkbox.php
@@ -29,6 +29,7 @@ $checkboxClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
+	Components::selector($checkboxIsDisabled, $componentClass, '', 'disabled'),
 ]);
 
 ?>

--- a/src/Blocks/components/field/field.php
+++ b/src/Blocks/components/field/field.php
@@ -39,11 +39,13 @@ $fieldContent = Components::checkAttr('fieldContent', $attributes, $manifest);
 $fieldType = Components::checkAttr('fieldType', $attributes, $manifest);
 $fieldUseError = Components::checkAttr('fieldUseError', $attributes, $manifest);
 $fieldHelp = Components::checkAttr('fieldHelp', $attributes, $manifest);
+$fieldDisabled = Components::checkAttr('fieldDisabled', $attributes, $manifest);
 
 $fieldClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
+	Components::selector($fieldDisabled, $componentClass, '', 'disabled'),
 ]);
 
 $fieldTag = 'div';

--- a/src/Blocks/components/field/manifest.json
+++ b/src/Blocks/components/field/manifest.json
@@ -48,6 +48,11 @@
 		},
 		"fieldWidthMobile": {
 			"type": "integer"
+		},
+
+		"fieldDisabled": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"responsiveAttributes": {

--- a/src/Blocks/components/input/input.php
+++ b/src/Blocks/components/input/input.php
@@ -61,5 +61,6 @@ echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputN
 		'fieldContent' => $input,
 		'fieldId' => $inputId,
 		'fieldName' => $inputName,
+		'fieldDisabled' => !empty($inputIsDisabled),
 	])
 );

--- a/src/Blocks/components/radio/radio.php
+++ b/src/Blocks/components/radio/radio.php
@@ -29,6 +29,7 @@ $radioClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
+	Components::selector($radioIsDisabled, $componentClass, '', 'disabled'),
 ]);
 
 ?>

--- a/src/Blocks/components/select/select.php
+++ b/src/Blocks/components/select/select.php
@@ -52,5 +52,6 @@ echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputN
 		'fieldContent' => $select,
 		'fieldId' => $selectId,
 		'fieldName' => $selectName,
+		'fieldDisabled' => !empty($selectIsDisabled),
 	])
 );

--- a/src/Blocks/components/submit/submit.php
+++ b/src/Blocks/components/submit/submit.php
@@ -56,6 +56,7 @@ echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputN
 	'field',
 	Components::props('field', $attributes, [
 		'fieldContent' => $submitType === 'button' ? $button : $submit,
-		'fieldId' => $submitId
+		'fieldId' => $submitId,
+		'fieldDisabled' => !empty($submitIsDisabled),
 	])
 );

--- a/src/Blocks/components/textarea/textarea.php
+++ b/src/Blocks/components/textarea/textarea.php
@@ -54,5 +54,6 @@ echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputN
 		'fieldContent' => $textarea,
 		'fieldId' => $textareaId,
 		'fieldName' => $textareaName,
+		'fieldDisabled' => !empty($textareaIsDisabled),
 	])
 );


### PR DESCRIPTION
Adds a `--disabled` class option to field (and to checkboxes/radios separately) to aid styling disabled labels, help fields, etc.