### PR TITLE
Additional actions for 'refactor' branch

### DIFF
--- a/.github/workflows/build-assets-on-release.yml
+++ b/.github/workflows/build-assets-on-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '*.*.*'
+      - '!*.*.*-alpha'
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-refactor-assets-on-release.yml
+++ b/.github/workflows/build-refactor-assets-on-release.yml
@@ -56,6 +56,6 @@ jobs:
     - name: Add artifacts to release
       uses: softprops/action-gh-release@v1
       with:
-        files: release-alpha.zip
+        files: release.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-refactor-assets-on-release.yml
+++ b/.github/workflows/build-refactor-assets-on-release.yml
@@ -50,12 +50,12 @@ jobs:
     - name: Archive Release
       uses: thedoctor0/zip-release@master
       with:
-        filename: 'release.zip'
+        filename: 'eightshift-forms.zip'
         exclusions: '*.git* /*node_modules/* .editorconfig'
 
     - name: Add artifacts to release
       uses: softprops/action-gh-release@v1
       with:
-        files: release.zip
+        files: eightshift-forms.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-refactor-assets-on-release.yml
+++ b/.github/workflows/build-refactor-assets-on-release.yml
@@ -1,0 +1,61 @@
+name: Build assets on release and create archive
+on: 
+  push:
+    tags:
+      - '*.*.*-alpha'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+          node: [14]
+
+    steps:
+    - name: 'Checkout refactor branch'
+      uses: actions/checkout@refactor
+
+    - name: PHP setup
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+
+    # Install dependencies and handle caching in one go.
+    # @link https://github.com/marketplace/actions/install-composer-dependencies
+    - name: Install Composer dependencies
+      uses: ramsey/composer-install@v1
+
+    - name: Set Node.js version
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
+
+    - name: Cache node modules
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-build-${{ env.cache-name }}-
+          ${{ runner.OS }}-build-
+          ${{ runner.OS }}-
+
+    - name: Install node packages
+      run: npm install
+
+    - name: Install node packages
+      run: npm run build --no-dev --no-progress
+
+    - name: Archive Release
+      uses: thedoctor0/zip-release@master
+      with:
+        filename: 'release.zip'
+        exclusions: '*.git* /*node_modules/* .editorconfig'
+
+    - name: Add artifacts to release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: release-alpha.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that is triggered on releases tagged with `*.*.*-alpha` (and adds ignore for them on the main release workflow).

The _new_ action is a clone of the current one with different rules and branch set. I'm not an expert with GitHub actions so if you see anything suspicious let me know 😄 