### PR TITLE
Temporarily disable auto-scroll to error fields

### DIFF
--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -197,7 +197,7 @@ export class Form {
 			}
 		}
 
-		if (typeof fields !== 'undefined') {
+		if (typeof fields !== 'undefined' && element?.dataset?.scrollToErrors) {
 			const firstItem = Object.keys(fields)[0];
 
 			this.scrollToElement(element.querySelector(`${this.errorSelector}[data-id="${firstItem}"]`).parentElement);


### PR DESCRIPTION
Temporarily gate auto-scrolling to fields with errors behind a data-attr on forms as it works a bit weird on live sites.