### PR TITLE
Replace nl2br with str_replace

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -123,7 +123,7 @@ class Mailer implements MailerInterface
 			$template = str_replace("{" . $name . "}", $value, $template);
 		}
 
-		return nl2br($template);
+		return str_replace("\n", '<br />', $template);
 	}
 
 	/**


### PR DESCRIPTION
As `nl2br` doesn't replace `\n` with `<br />`, it adds the HTML line break before the `\n`, there were some email clients that were escaping the `\n`s, and just leavings `n`s in there, which would cause some weird emails like:

```
Hi!nnWe're looking to learn more about xyz.nnHope to hear from you soon!
```

which should be

```
Hi!

We're looking to learn more about xyz.

Hope to hear from you soon!
```