### PR TITLE
Allow passing additional classes through Gutenberg

### DIFF
--- a/src/Blocks/components/form/form.php
+++ b/src/Blocks/components/form/form.php
@@ -31,6 +31,7 @@ $formClass = Components::classnames([
 	Components::selector($blockClass, $blockClass, $selectorClass),
 	Components::selector($additionalClass, $additionalClass),
 	Components::selector($componentJsClass, $componentJsClass),
+	$attributes['className'] ?? '',
 ]);
 
 ?>

--- a/src/Blocks/custom/forms/forms.php
+++ b/src/Blocks/custom/forms/forms.php
@@ -24,7 +24,8 @@ $formsStyle = Components::checkAttr('formsStyle', $attributes, $manifest);
 $formsClass = Components::classnames([
 	Components::selector($blockClass, $blockClass),
 	Components::selector($formsStyle, $blockClass, '', $formsStyle),
-	Components::selector(!$formsFormPostId, $blockClass, '', 'not-set')
+	Components::selector(!$formsFormPostId, $blockClass, '', 'not-set'),
+	$attributes['className'] ?? '',
 ]);
 
 ?>


### PR DESCRIPTION
Makes "Additional CSS class" field work for the Form block.