### PR TITLE
WP 5.9 readonly deprecated fix

### DIFF
--- a/src/Blocks/components/checkbox/checkbox.php
+++ b/src/Blocks/components/checkbox/checkbox.php
@@ -56,6 +56,7 @@ if ($checkboxAttrs) {
 	}
 }
 
+$isWpFiveNine = \is_wp_version_compatible('5.9');
 ?>
 
 <div class="<?php echo esc_attr($checkboxClass); ?>">
@@ -68,7 +69,7 @@ if ($checkboxAttrs) {
 			<?php echo $checkboxAttrsOutput; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<?php checked($checkboxIsChecked); ?>
 			<?php disabled($checkboxIsDisabled); ?>
-			<?php readonly($checkboxIsReadOnly); ?>
+			<?php $isWpFiveNine ? wp_readonly($checkboxIsReadOnly) : readonly($checkboxIsReadOnly); ?>
 		/>
 		<label
 			for="<?php echo esc_attr($checkboxId); ?>"

--- a/src/Blocks/components/input/input.php
+++ b/src/Blocks/components/input/input.php
@@ -73,6 +73,7 @@ if (has_filter($filterName)) {
 	$additionalContent = apply_filters($filterName, $attributes ?? []);
 }
 
+$isWpFiveNine = \is_wp_version_compatible('5.9');
 $input = '
 	<input
 		class="' . esc_attr($inputClass) . '"
@@ -80,7 +81,7 @@ $input = '
 		id="' . esc_attr($inputId) . '"
 		type="' . esc_attr($inputType) . '"
 		' . disabled($inputIsDisabled, true, false) . '
-		' . readonly($inputIsReadOnly, true, false) . '
+		' . ($isWpFiveNine ? wp_readonly($inputIsReadOnly, true, false) : readonly($inputIsReadOnly, true, false)) . '
 		' . $inputAttrsOutput . '
 	/>
 	' . $additionalContent . '

--- a/src/Blocks/components/textarea/textarea.php
+++ b/src/Blocks/components/textarea/textarea.php
@@ -71,12 +71,13 @@ if (has_filter($filterName)) {
 	$additionalContent = apply_filters($filterName, $attributes ?? []);
 }
 
+$isWpFiveNine = \is_wp_version_compatible('5.9');
 $textarea = '<textarea
 		class="' . esc_attr($textareaClass) . '"
 		name="' . esc_attr($textareaName) . '"
 		id="' . esc_attr($textareaId) . '"
 		' . disabled($textareaIsDisabled, true, false) . '
-		' . readonly($textareaIsReadOnly, true, false) . '
+		' . ($isWpFiveNine ? wp_readonly($textareaIsReadOnly, true, false) : readonly($textareaIsReadOnly, true, false)) . '
 		' . $textareaAttrsOutput . '
 	>' . \apply_filters('the_content', $textareaValue) . '</textarea>
 	' . $additionalContent . '


### PR DESCRIPTION
# Description

Fixes #208.

`readonly` is used on WP < 5.9, `wp_readonly` on 5.9, since `wp_readonly` was only introduced with 5.9.

https://developer.wordpress.org/reference/functions/readonly/
https://developer.wordpress.org/reference/functions/wp_readonly/

# Screenshots / Videos

\-

# Linked documentation PR

\-
