### PR TITLE
Add Category Taxonomy to Forms

### DIFF
--- a/src/CustomPostType/Forms.php
+++ b/src/CustomPostType/Forms.php
@@ -105,6 +105,7 @@ class Forms extends AbstractPostType
 			'rest_base' => static::REST_API_ENDPOINT_SLUG,
 			'template_lock' => 'all',
 			'template' => $template,
+			'taxonomies' => ['category'],
 		];
 	}
 }


### PR DESCRIPTION
# Description

I have a lot of different Greenhouse Forms on the site, and I have to get number of forms related to a certain topic (Careers in this case).

Adding category allows to get only specific Greenhouse Forms with `WP_Query`

# Screenshots / Videos

![image](https://user-images.githubusercontent.com/81157133/153417769-76341265-5efd-4a5c-94e4-9a68f86e22c0.png)
