### PR TITLE
formDataTypeSelector filter

### DIFF
--- a/src/Blocks/components/form/form.php
+++ b/src/Blocks/components/form/form.php
@@ -7,6 +7,7 @@
  */
 
 use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
+use EightshiftForms\Hooks\Filters;
 
 $manifest = Components::getManifest(__DIR__);
 
@@ -25,7 +26,14 @@ $formContent = Components::checkAttr('formContent', $attributes, $manifest);
 $formSuccessRedirect = Components::checkAttr('formSuccessRedirect', $attributes, $manifest);
 $formTrackingEventName = Components::checkAttr('formTrackingEventName', $attributes, $manifest);
 $formType = Components::checkAttr('formType', $attributes, $manifest);
-$formDataTypeSelector = Components::checkAttr('formDataTypeSelector', $attributes, $manifest);
+
+$formDataTypeSelectorFilterName = Filters::getBlockFilterName('form', 'dataTypeSelector');
+$formDataTypeSelector = apply_filters(
+	$formDataTypeSelectorFilterName,
+	Components::checkAttr('formDataTypeSelector', $attributes, $manifest),
+	$attributes
+);
+
 $formServerSideRender = Components::checkAttr('formServerSideRender', $attributes, $manifest);
 $formAttrs = Components::checkAttr('formAttrs', $attributes, $manifest);
 

--- a/src/Hooks/Filters.php
+++ b/src/Hooks/Filters.php
@@ -206,6 +206,7 @@ class Filters
 				'hideLoadingStateTimeout' => 'hide_loading_state_timeout',
 				'successRedirectUrl' => 'success_redirect_url',
 				'trackingEventName' => 'tracking_event_name',
+				'dataTypeSelector' => 'data_type_selector',
 			],
 			'formSelector' => [
 				'additionalContent' => 'additional_content',

--- a/src/Hooks/FiltersBlock.md
+++ b/src/Hooks/FiltersBlock.md
@@ -409,3 +409,39 @@ public function getBlockFilePreviewRemoveLabel(): string
 	return 'Remove item'; // This can be string or svg.
 }
 ```
+
+## Changing the form type selector on render
+This filter will override the attribute-provided type selector for a Form component.
+Passes form component attributes to the callback function as well, so you can check all sorts of conditions when filtering.
+
+In other words, you can use this filter to change the value of the `formDataTypeSelector` attribute during a form render.
+The attribute is used to output a `data-type-selector` HTML attribute of the form element.
+
+**Filter name:**
+`es_forms_block_form_data_type_selector`
+
+**Default:**
+Attribute-provided value, editable in the Block Editor.
+
+**Filter example:**
+```php
+// Change data type selector.
+add_filter('es_forms_block_form_data_type_selector', [$this, 'setIntegrationGreenhouseTypeSelector'], 10, 2);
+
+/**
+ * Change data type selector.
+ * 
+ * @param string $selector The data type selector to filter.
+ * @param array<mixed> $attr Form component attributes.
+ *
+ * @return string Filtered value.
+ */
+public function getBlockFilePreviewRemoveLabel(string $selector, array $attr): string
+{
+	if (($attr['formType'] ?? '') === 'mailchimp') {
+		return;
+	}
+	
+	return 'my-new-selector';
+}
+```


### PR DESCRIPTION
# Description

Allows filtering the `formDataTypeSelector` attribute during `form` component renders.

# Screenshots / Videos

N/A

# Linked documentation PR

See `FilterBlocks.md` changes.
