### PR TITLE
Custom form actions

### DIFF
--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -127,13 +127,13 @@ export class Form {
 			[...inputs].forEach((input) => {
 				this.setupInputField(input);
 			});
-	
+
 			// Setup select inputs.
 			this.customSelects[formId] = [];
 			[...selects].forEach((select) => {
 				this.setupSelectField(select, formId);
 			});
-	
+
 			// Setup textarea inputs.
 			this.customTextareas[formId] = [];
 			[...textareas].forEach((textarea) => {
@@ -227,7 +227,6 @@ export class Form {
 
 	// Handle form submit and all logic.
 	formSubmit = (element, singleSubmit = false) => {
-
 		// Dispatch event.
 		this.dispatchFormEvent(element, FORM_EVENTS.BEFORE_FORM_SUBMIT);
 
@@ -382,7 +381,7 @@ export class Form {
 						if (disabled) {
 							continue;
 						}
-		
+
 						groupInnerItems[id] = value;
 					}
 
@@ -401,6 +400,7 @@ export class Form {
 		`);
 
 		const formType = element.getAttribute(this.DATA_ATTR_FORM_TYPE);
+		const formAction = element.getAttribute('action');
 
 		// If single submit override items and pass only one item to submit.
 		if (singleSubmit) {
@@ -481,6 +481,12 @@ export class Form {
 		// Add form type field.
 		formData.append('es-form-type', JSON.stringify({
 			value: formType,
+			type: 'hidden',
+		}));
+
+		// Add form action field.
+		formData.append('action', JSON.stringify({
+			value: formAction,
 			type: 'hidden',
 		}));
 

--- a/src/Blocks/components/form/components/form-options.js
+++ b/src/Blocks/components/form/components/form-options.js
@@ -16,6 +16,7 @@ export const FormOptions = (attributes) => {
 	} = attributes;
 
 	const formName = checkAttr('formName', attributes, manifest);
+	const formAction = checkAttr('formAction', attributes, manifest);
 	const formId = checkAttr('formId', attributes, manifest);
 
 	return (
@@ -28,6 +29,13 @@ export const FormOptions = (attributes) => {
 			/>
 
 			<FancyDivider label={__('Advanced', 'eightshift-forms')} />
+
+			<TextControl
+				label={<IconLabel icon={icons.fieldName} label={__('Form Action', 'eightshift-forms')} />}
+				value={formAction}
+				help={__('Custom form action that will process form data. Setting this value will redirect user to the provided URL on succesfull form submit.' ,'eightshift-forms')}
+				onChange={(value) => setAttributes({ [getAttrKey('formAction', attributes, manifest)]: value })}
+			/>
 
 			<TextControl
 				label={<IconLabel icon={icons.id} label={__('Unique identifier', 'eightshift-forms')} />}

--- a/src/Blocks/custom/form/form.php
+++ b/src/Blocks/custom/form/form.php
@@ -14,11 +14,14 @@ $manifest = Components::getManifest(__DIR__);
 $blockClass = $attributes['blockClass'] ?? '';
 
 $formFormPostId = Components::checkAttr('formFormPostId', $attributes, $manifest);
+$formFormAction = Components::checkAttr('formFormAction', $attributes, $manifest);
 
 // Check if mailer data is set and valid.
 $formClass = Components::classnames([
 	Components::selector($blockClass, $blockClass),
 ]);
+
+$customFormType = !empty($formFormAction) ? ['formType' => 'custom'] : [];
 
 ?>
 
@@ -28,13 +31,14 @@ $formClass = Components::classnames([
 	echo Components::render(
 		'form',
 		Components::props('form', $attributes, array_merge(
-			[
-				'formContent' => $innerBlockContent,
-			],
 			apply_filters(
 				Form::FILTER_FORM_SETTINGS_OPTIONS_NAME,
 				$formFormPostId
-			)
+			),
+			[
+				'formContent' => $innerBlockContent,
+			],
+			$customFormType
 		))
 	);
 	?>

--- a/src/Labels/Labels.php
+++ b/src/Labels/Labels.php
@@ -51,7 +51,8 @@ class Labels implements LabelsInterface
 		$output = \array_merge(
 			$this->getGenericLabels(),
 			$this->getValidationLabels(),
-			$this->getMailerLabels()
+			$this->getMailerLabels(),
+			$this->getCutomLabels()
 		);
 
 		// Google reCaptcha.
@@ -127,6 +128,20 @@ class Labels implements LabelsInterface
 			'validationMinSize' => \__('The file is smaller than allowed. Minimum file size is %s kB.', 'eightshift-forms'),
 			// translators: %s used for displaying number value.
 			'validationMaxSize' => \__('The file is larger than allowed. Maximum file size is %s kB.', 'eightshift-forms'),
+		];
+	}
+
+	/**
+	 * Return labels - Custom action
+	 *
+	 * @return array<string, string>
+	 */
+	private function getCutomLabels(): array
+	{
+		return [
+			'customNoAction' => \__('There was an issue with form action. Check the form settings.', 'eightshift-forms'),
+			'customError' => \__('There was an error with your form submission.', 'eightshift-forms'),
+			'customSuccess' => \__('Form was successfuly submitted.', 'eightshift-forms'),
 		];
 	}
 

--- a/src/Rest/Routes/AbstractBaseRoute.php
+++ b/src/Rest/Routes/AbstractBaseRoute.php
@@ -281,6 +281,11 @@ abstract class AbstractBaseRoute extends AbstractRoute implements CallableRouteI
 	{
 		foreach ($params as $key => $value) {
 			if ($key === 'es-form-type') {
+				// Allow action parameter for forms with custom actions.
+				if ($value['value'] !== 'custom') {
+					unset($params['action']);
+				}
+
 				unset($params['es-form-type']);
 			}
 

--- a/src/Rest/Routes/FormSubmitCustomRoute.php
+++ b/src/Rest/Routes/FormSubmitCustomRoute.php
@@ -81,12 +81,12 @@ class FormSubmitCustomRoute extends AbstractFormSubmit
 			]);
 		}
 
-		// Format body parameters to a key/value array
+		// Format body parameters to a key/value array.
 		foreach ($params as $param) {
 			$body[$param['name']] = $param['value'];
 		}
 
-		// Create a custom form action request
+		// Create a custom form action request.
 		$customResponse = \wp_remote_request(
 			$formAction,
 			[

--- a/src/Rest/Routes/FormSubmitCustomRoute.php
+++ b/src/Rest/Routes/FormSubmitCustomRoute.php
@@ -94,11 +94,11 @@ class FormSubmitCustomRoute extends AbstractFormSubmit
 					'Content-Type' => 'application/x-www-form-urlencoded',
 				],
 				'method' => 'POST',
-				'body' => http_build_query($body),
+				'body' => \http_build_query($body),
 			]
 		);
 
-		$customResponseCode = wp_remote_retrieve_response_code($customResponse);
+		$customResponseCode = \wp_remote_retrieve_response_code($customResponse);
 
 		// If custom action request fails we'll return the generic error message.
 		if ($customResponseCode > 400) {
@@ -115,6 +115,5 @@ class FormSubmitCustomRoute extends AbstractFormSubmit
 			'code' => $customResponseCode,
 			'message' => $this->labels->getLabel('customSuccess', $formId),
 		]);
-
 	}
 }

--- a/src/Rest/Routes/FormSubmitCustomRoute.php
+++ b/src/Rest/Routes/FormSubmitCustomRoute.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * The class register route for public form submiting endpoint - custom
+ *
+ * @package EightshiftForms\Rest\Routes
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Rest\Routes;
+
+use EightshiftForms\Validation\ValidatorInterface;
+use EightshiftForms\Labels\LabelsInterface;
+
+/**
+ * Class FormSubmitCustomRoute
+ */
+class FormSubmitCustomRoute extends AbstractFormSubmit
+{
+	/**
+	 * Instance variable of ValidatorInterface data.
+	 *
+	 * @var ValidatorInterface
+	 */
+	public $validator;
+
+	/**
+	 * Instance variable of LabelsInterface data.
+	 *
+	 * @var LabelsInterface
+	 */
+	protected $labels;
+
+	/**
+	 * Create a new instance that injects classes
+	 *
+	 * @param ValidatorInterface $validator Inject ValidatorInterface which holds validation methods.
+	 * @param LabelsInterface $labels Inject LabelsInterface which holds labels data.
+	 */
+	public function __construct(
+		ValidatorInterface $validator,
+		LabelsInterface $labels
+	) {
+		$this->validator = $validator;
+		$this->labels = $labels;
+	}
+
+	/**
+	 * Get the base url of the route
+	 *
+	 * @return string The base URL for route you are adding.
+	 */
+	protected function getRouteName(): string
+	{
+		return '/form-submit-custom';
+	}
+
+	/**
+	 * Implement submit action.
+	 *
+	 * @param string $formId Form ID.
+	 * @param array<string, mixed> $params Params array.
+	 * @param array<string, array<int, array<string, mixed>>> $files Files array.
+	 *
+	 * @return mixed
+	 */
+	public function submitAction(string $formId, array $params = [], $files = [])
+	{
+		$body = [];
+
+		$formAction = $params['action']['value'];
+		unset($params['action']);
+
+		// If form action is not set or empty.
+		if (!$formAction) {
+			return \rest_ensure_response([
+				'status' => 'error',
+				'code' => 400,
+				'message' => $this->labels->getLabel('customNoAction', $formId),
+			]);
+		}
+
+		// Format body parameters to a key/value array
+		foreach ($params as $param) {
+			$body[$param['name']] = $param['value'];
+		}
+
+		// Create a custom form action request
+		$customResponse = \wp_remote_request(
+			$formAction,
+			[
+				'headers' => [
+					'Content-Type' => 'application/x-www-form-urlencoded',
+				],
+				'method' => 'POST',
+				'body' => http_build_query($body),
+			]
+		);
+
+		$customResponseCode = wp_remote_retrieve_response_code($customResponse);
+
+		// If custom action request fails we'll return the generic error message.
+		if ($customResponseCode > 400) {
+			return \rest_ensure_response([
+				'status' => 'error',
+				'code' => $customResponseCode,
+				'message' => $this->labels->getLabel('customError', $formId),
+			]);
+		}
+
+		// If form action is valid we'll return the generic success message.
+		return \rest_ensure_response([
+			'status' => 'success',
+			'code' => $customResponseCode,
+			'message' => $this->labels->getLabel('customSuccess', $formId),
+		]);
+
+	}
+}

--- a/tests/Validation/ValidationSettingsTest.php
+++ b/tests/Validation/ValidationSettingsTest.php
@@ -239,6 +239,30 @@ test('getSettingsGlobalData returns expected values', function() {
 			'inputFieldLabel' => 'MailerErrorEmailConfirmationSend',
 			'inputPlaceholder' => 'Confirmation e-mail was not sent due to unknown issue. Please try again.',
 			'inputValue' => 'es-forms-mailerErrorEmailConfirmationSend-HR',
+		],
+		[
+			'component' => 'input',
+			'inputName' => 'es-forms-customNoAction-HR',
+			'inputId' => 'es-forms-customNoAction-HR',
+			'inputFieldLabel' => 'CustomNoAction',
+			'inputPlaceholder' => 'There was an issue with form action. Check the form settings.',
+			'inputValue' => 'es-forms-customNoAction-HR',
+		],
+		[
+			'component' => 'input',
+			'inputName' => 'es-forms-customError-HR',
+			'inputId' => 'es-forms-customError-HR',
+			'inputFieldLabel' => 'CustomError',
+			'inputPlaceholder' => 'There was an error with your form submission.',
+			'inputValue' => 'es-forms-customError-HR',
+		],
+		[
+			'component' => 'input',
+			'inputName' => 'es-forms-customSuccess-HR',
+			'inputId' => 'es-forms-customSuccess-HR',
+			'inputFieldLabel' => 'CustomSuccess',
+			'inputPlaceholder' => 'Form was successfuly submitted.',
+			'inputValue' => 'es-forms-customSuccess-HR',
 		]
 	];
 	expect($this->validationSettings->getSettingsGlobalData())->toBe($expected);


### PR DESCRIPTION
Added a new option field to set a custom form action to which the form will send a request.
Updated form handlers to retrieve an process form action attribute
Updated form render to set the form type based on the form action

Added a new custom route for handling forms with custom actions.
Route takes all parameters and POSTs them to the provided action URL. Response from the action URL is processed and generic messages are sent. 