### PR TITLE
WIP: Adding fallback email for integrations

### DIFF
--- a/src/AdminMenus/FormGlobalSettingsAdminSubMenu.php
+++ b/src/AdminMenus/FormGlobalSettingsAdminSubMenu.php
@@ -173,13 +173,18 @@ class FormGlobalSettingsAdminSubMenu extends AbstractAdminSubMenu
 	{
 		$type = isset($_GET['type']) ? \sanitize_text_field(\wp_unslash($_GET['type'])) : SettingsGeneral::SETTINGS_TYPE_KEY; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
+		$settingsSidebarOutput = [];
+		foreach ($this->settingsGlobal->getSettingsSidebar($type) as $item) {
+			$settingsSidebarOutput[$item['type'] ?? 'general'][] = $item;
+		}
+
 		return [
 			// translators: %s replaces form title name.
 			'adminSettingsPageTitle' => \esc_html__('Settings', 'eightshift-forms'),
 			'adminSettingsSubTitle' => \esc_html__('These settings apply to all forms.', 'eightshift-forms'),
 			'adminSettingsBackLink' => Helper::getListingPageUrl(),
 			'adminSettingsLink' => Helper::getSettingsGlobalPageUrl(''),
-			'adminSettingsSidebar' => $this->settingsGlobal->getSettingsSidebar($type),
+			'adminSettingsSidebar' => $settingsSidebarOutput,
 			'adminSettingsForm' => $this->settingsGlobal->getSettingsForm($type),
 			'adminSettingsType' => $type,
 			'adminSettingsIsGlobal' => true,

--- a/src/AdminMenus/FormSettingsAdminSubMenu.php
+++ b/src/AdminMenus/FormSettingsAdminSubMenu.php
@@ -186,13 +186,18 @@ class FormSettingsAdminSubMenu extends AbstractAdminSubMenu
 			$formTitle = \esc_html__('No form title', 'eightshift-forms');
 		}
 
+		$settingsSidebarOutput = [];
+		foreach ($this->settingsAll->getSettingsSidebar($formId, $type) as $item) {
+			$settingsSidebarOutput[$item['type'] ?? 'general'][] = $item;
+		}
+
 		return [
 			// translators: %s replaces the form name.
 			'adminSettingsPageTitle' => \sprintf(\esc_html__('Form settings: %s', 'eightshift-forms'), $formTitle),
 			'adminSettingsBackLink' => Helper::getListingPageUrl(),
 			'adminSettingsFormEditLink' => Helper::getFormEditPageUrl($formId),
 			'adminSettingsLink' => Helper::getSettingsPageUrl($formId, ''),
-			'adminSettingsSidebar' => $this->settingsAll->getSettingsSidebar($formId, $type),
+			'adminSettingsSidebar' => $settingsSidebarOutput,
 			'adminSettingsForm' => $this->settingsAll->getSettingsForm($formId, $type),
 			'adminSettingsType' => $type,
 		];

--- a/src/Blocks/components/admin-settings-section/admin-settings-section-admin.scss
+++ b/src/Blocks/components/admin-settings-section/admin-settings-section-admin.scss
@@ -13,10 +13,24 @@
 
 	&__sidebar {
 		background-color: var(--global-colors-es-white);
+		height: 100vh;
+		overflow-x: hidden;
 
 		> * {
 			margin-bottom: var(--global-es-spacing-horizontal);
+			border-top: 1px solid var(--global-colors-es-ebb);
+
+			&:first-child {
+				border-top: 0;
+			}
 		}
+	}
+
+	&__sidebar-label {
+		padding: 1rem 1.1rem 0.5rem;
+		font-size: 1.1rem;
+		font-weight: bold;
+		line-height: 1.2;
 	}
 
 	&__main {
@@ -87,7 +101,7 @@
 		}
 
 		&:hover,
-		&:focus, {
+		&:focus {
 			color: var(--global-colors-es-matisse);
 			background-color: var(--global-colors-es-matisse-05);
 		}

--- a/src/Blocks/components/admin-settings/admin-settings.php
+++ b/src/Blocks/components/admin-settings/admin-settings.php
@@ -13,6 +13,7 @@ $manifestSection = Components::getManifest(dirname(__DIR__, 1) . '/admin-setting
 
 echo Components::outputCssVariablesGlobal(); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 
+$componentName = $manifest['componentName'] ?? '';
 $componentClass = $manifest['componentClass'] ?? '';
 $sectionClass = $manifestSection['componentClass'] ?? '';
 
@@ -47,30 +48,19 @@ if (!$adminSettingsSidebar || !$adminSettingsForm) {
 			</a>
 		</div>
 
-		<div class="<?php echo esc_attr("{$sectionClass}__section"); ?>">
-			<div class="<?php echo esc_attr("{$sectionClass}__content"); ?>">
-				<ul class="<?php echo esc_attr("{$sectionClass}__menu"); ?>">
-					<?php foreach ($adminSettingsSidebar as $item) { ?>
-						<?php
-						$label = $item['label'] ?? '';
-						$value = $item['value'] ?? '';
-						$icon = $item['icon'] ?? '';
-						?>
-						<li class="<?php echo esc_attr("{$sectionClass}__menu-item"); ?>">
-							<a
-								href="<?php echo esc_url("{$adminSettingsLink}&type={$value}"); ?>"
-								class="<?php echo esc_attr("{$sectionClass}__menu-link " . Components::selector($value === $adminSettingsType, $sectionClass, 'menu-link', 'active')); ?>"
-							>
-								<span class="<?php echo esc_attr("{$sectionClass}__menu-link-wrap"); ?>">
-									<?php echo $icon; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
-									<?php echo esc_html($label); ?>
-								</span>
-							</a>
-						</li>
-					<?php } ?>
-				</ul>
-			</div>
-		</div>
+		<?php
+		echo Components::renderPartial( // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
+			'component',
+			$componentName,
+			'sidebar-section',
+			[
+				'items' => $adminSettingsSidebar,
+				'sectionClass' => $sectionClass,
+				'adminSettingsLink' => $adminSettingsLink,
+				'adminSettingsType' => $adminSettingsType,
+			]
+		);
+		?>
 	</div>
 	<div class="<?php echo esc_attr("{$sectionClass}__main"); ?>">
 		<div class="<?php echo esc_attr("{$sectionClass}__section"); ?>">

--- a/src/Blocks/components/admin-settings/partials/sidebar-section.php
+++ b/src/Blocks/components/admin-settings/partials/sidebar-section.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Template for admin settings page - sidebar section partial.
+ *
+ * @package EightshiftForms\Blocks.
+ */
+
+use EightshiftForms\Settings\Settings\SettingsAll;
+use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
+
+$items = $attributes['items'] ?? [];
+
+$output = [];
+
+if (!$items) {
+	return $output;
+}
+
+$sectionClass = $attributes['sectionClass'] ?? '';
+$adminSettingsLink = $attributes['adminSettingsLink'] ?? '';
+$adminSettingsType = $attributes['adminSettingsType'] ?? '';
+
+// Provide order we want on output.
+$sortOrder = SettingsAll::SIDEBAR_SORT_ORDER;
+uksort($items, function ($key1, $key2) use ($sortOrder) {
+	return ((array_search($key1, $sortOrder, true) > array_search($key2, $sortOrder, true)) ? 1 : -1);
+});
+
+foreach ($items as $key => $innerItems) {
+	switch ($key) {
+		case SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION:
+			$sidebarTitle = __('Integrations', 'eightshift-forms');
+			break;
+		case SettingsAll::SETTINGS_SIEDBAR_TYPE_TROUBLESHOOTING:
+			$sidebarTitle = __('Troubleshooting', 'eightshift-forms');
+			break;
+		case SettingsAll::SETTINGS_SIEDBAR_TYPE_DEVELOP:
+			$sidebarTitle = __('Develop Mode', 'eightshift-forms');
+			break;
+		default:
+			$sidebarTitle = __('General', 'eightshift-forms');
+			break;
+	}
+	?>
+
+<div class="<?php echo esc_attr("{$sectionClass}__section"); ?>">
+	<div class="<?php echo esc_attr("{$sectionClass}__content"); ?>">
+		<div class="<?php echo esc_attr("{$sectionClass}__sidebar-label"); ?>">
+			<?php echo esc_html($sidebarTitle); ?>
+		</div>
+		<ul class="<?php echo esc_attr("{$sectionClass}__menu"); ?>">
+			<?php foreach ($innerItems as $item) { ?>
+				<?php
+				$label = $item['label'] ?? '';
+				$value = $item['value'] ?? '';
+				$icon = $item['icon'] ?? '';
+				?>
+				<li class="<?php echo esc_attr("{$sectionClass}__menu-item"); ?>">
+					<a
+						href="<?php echo esc_url("{$adminSettingsLink}&type={$value}"); ?>"
+						class="<?php echo esc_attr("{$sectionClass}__menu-link " . Components::selector($value === $adminSettingsType, $sectionClass, 'menu-link', 'active')); ?>"
+					>
+						<span class="<?php echo esc_attr("{$sectionClass}__menu-link-wrap"); ?>">
+							<?php echo $icon; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
+							<?php echo esc_html($label); ?>
+						</span>
+					</a>
+				</li>
+			<?php } ?>
+		</ul>
+	</div>
+</div>
+
+<?php }

--- a/src/Cache/SettingsCache.php
+++ b/src/Cache/SettingsCache.php
@@ -19,6 +19,7 @@ use EightshiftForms\Integrations\Mailchimp\MailchimpClient;
 use EightshiftForms\Integrations\Mailerlite\MailerliteClient;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Settings\GlobalSettings\SettingsGlobalDataInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -95,6 +96,7 @@ class SettingsCache implements SettingsGlobalDataInterface, ServiceInterface
 			'label' => \__('Clear cache', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_TROUBLESHOOTING,
 		];
 	}
 

--- a/src/Enqueue/Blocks/EnqueueBlocks.php
+++ b/src/Enqueue/Blocks/EnqueueBlocks.php
@@ -19,6 +19,7 @@ use EightshiftForms\Rest\Routes\GeolocationCountriesRoute;
 use EightshiftForms\Settings\Settings\SettingsGeneral;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Tracking\TrackingInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshooting;
 use EightshiftForms\Validation\SettingsCaptcha;
 use EightshiftForms\Validation\ValidatorInterface;
 use EightshiftFormsVendor\EightshiftLibs\Enqueue\Blocks\AbstractEnqueueBlocks;
@@ -228,7 +229,7 @@ class EnqueueBlocks extends AbstractEnqueueBlocks
 				SettingsGeneral::SETTINGS_GENERAL_DISABLE_AUTOINIT_ENQUEUE_SCRIPT_KEY,
 				SettingsGeneral::SETTINGS_GENERAL_DISABLE_DEFAULT_ENQUEUE_KEY
 			);
-			$output['formResetOnSuccess'] = !Variables::isDevelopMode();
+			$output['formResetOnSuccess'] = !$this->isCheckboxOptionChecked(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_SKIP_RESET_KEY, SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY);
 			$output['formServerErrorMsg'] = \esc_html__('An server error occurred while submitting your form. Please try again.', 'eightshift-forms');
 			$output['captcha'] = '';
 			$output['storageConfig'] = '';

--- a/src/Geolocation/Geolocation.php
+++ b/src/Geolocation/Geolocation.php
@@ -15,6 +15,7 @@ use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Hooks\Filters;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Settings\SettingsHelper;
+use EightshiftForms\Troubleshooting\SettingsTroubleshooting;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 use Throwable;
 
@@ -23,6 +24,9 @@ use Throwable;
  */
 class Geolocation implements ServiceInterface, GeolocationInterface
 {
+	/**
+	 * Use general helper trait.
+	 */
 	use SettingsHelper;
 
 	/**
@@ -111,15 +115,20 @@ class Geolocation implements ServiceInterface, GeolocationInterface
 			return $formId;
 		}
 
+		$useLogger = $this->isCheckboxOptionChecked(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_LOG_MODE_KEY, SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY);
+
 		// Add ability to disable geolocation from external source. (Generaly used for GDPR).
 		$filterName = Filters::getGeolocationFilterName('disable');
 		if (\has_filter($filterName) && \apply_filters($filterName, null)) {
-			Helper::logger([
-				'geolocation' => 'Filter disabled active, skip geolocation.',
-				'formIdOriginal' => $formId,
-				'formIdUsed' => $formId,
-				'userLocation' => '',
-			]);
+			if ($useLogger) {
+				Helper::logger([
+					'geolocation' => 'Filter disabled active, skip geolocation.',
+					'formIdOriginal' => $formId,
+					'formIdUsed' => $formId,
+					'userLocation' => '',
+				]);
+			}
+
 			return $formId;
 		}
 
@@ -155,12 +164,14 @@ class Geolocation implements ServiceInterface, GeolocationInterface
 
 			// If additional locations match output that new form.
 			if ($matchAdditionalLocations) {
-				Helper::logger([
-					'geolocation' => 'Locations exists, locations match. Outputing new form.',
-					'formIdOriginal' => $formId,
-					'formIdUsed' => $matchAdditionalLocations['formId'] ?? '',
-					'userLocation' => $userLocation,
-				]);
+				if ($useLogger) {
+					Helper::logger([
+						'geolocation' => 'Locations exists, locations match. Outputing new form.',
+						'formIdOriginal' => $formId,
+						'formIdUsed' => $matchAdditionalLocations['formId'] ?? '',
+						'userLocation' => $userLocation,
+					]);
+				}
 				return $matchAdditionalLocations['formId'] ?? '';
 			}
 		}
@@ -181,32 +192,38 @@ class Geolocation implements ServiceInterface, GeolocationInterface
 
 			// If default locations match output that new form.
 			if ($matchDefaultLocations) {
-				Helper::logger([
-					'geolocation' => 'Locations doesn\'t match or exist, default location match. Outputing new form.',
-					'formIdOriginal' => $formId,
-					'formIdUsed' => $formId,
-					'userLocation' => $userLocation,
-				]);
+				if ($useLogger) {
+					Helper::logger([
+						'geolocation' => 'Locations doesn\'t match or exist, default location match. Outputing new form.',
+						'formIdOriginal' => $formId,
+						'formIdUsed' => $formId,
+						'userLocation' => $userLocation,
+					]);
+				}
 				return $formId;
 			}
 
 			// If we have set default locations but no match return empty form.
-			Helper::logger([
-				'geolocation' => 'Locations doesn\'t exists, default location doesn\'t match. Outputing nothing.',
-				'formIdOriginal' => $formId,
-				'formIdUsed' => '',
-				'userLocation' => $userLocation,
-			]);
+			if ($useLogger) {
+				Helper::logger([
+					'geolocation' => 'Locations doesn\'t exists, default location doesn\'t match. Outputing nothing.',
+					'formIdOriginal' => $formId,
+					'formIdUsed' => '',
+					'userLocation' => $userLocation,
+				]);
+			}
 			return '';
 		}
 
 		// Final fallback if the user has no locations, no default locations or they didn't match. Just return the current form.
-		Helper::logger([
-			'geolocation' => 'Final fallback that returns the current form. Outputing the original form.',
-			'formIdOriginal' => $formId,
-			'formIdUsed' => $formId,
-			'userLocation' => $userLocation,
-		]);
+		if ($useLogger) {
+			Helper::logger([
+				'geolocation' => 'Final fallback that returns the current form. Outputing the original form.',
+				'formIdOriginal' => $formId,
+				'formIdUsed' => $formId,
+				'userLocation' => $userLocation,
+			]);
+		}
 		return $formId;
 	}
 

--- a/src/Geolocation/SettingsGeolocation.php
+++ b/src/Geolocation/SettingsGeolocation.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftForms\Geolocation;
 
 use EightshiftForms\Hooks\Filters;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
@@ -83,6 +84,7 @@ class SettingsGeolocation implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Geolocation', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_GENERAL,
 		];
 	}
 

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -202,6 +202,11 @@ class Helper
 
 			if (!empty($wpContentDir)) {
 				$message['time'] = \gmdate("Y-m-d H:i:s");
+			
+				if (isset($message['files'])) {
+					unset($message['files']);
+				}
+
 				\error_log((string) \wp_json_encode($message) . "\n -------------------------------------", 3, \WP_CONTENT_DIR . '/eightshift-forms-debug.log'); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			}
 		}

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -202,7 +202,7 @@ class Helper
 
 			if (!empty($wpContentDir)) {
 				$message['time'] = \gmdate("Y-m-d H:i:s");
-			
+
 				if (isset($message['files'])) {
 					unset($message['files']);
 				}

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -14,7 +14,6 @@ use EightshiftForms\AdminMenus\FormGlobalSettingsAdminSubMenu;
 use EightshiftForms\AdminMenus\FormSettingsAdminSubMenu;
 use EightshiftForms\AdminMenus\FormListingAdminSubMenu;
 use EightshiftForms\CustomPostType\Forms;
-use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Settings\Settings\SettingsGeneral;
 
 /**
@@ -197,18 +196,16 @@ class Helper
 	 */
 	public static function logger(array $message): void
 	{
-		if (Variables::isLogMode()) {
-			$wpContentDir = \defined('WP_CONTENT_DIR') ? \WP_CONTENT_DIR : '';
+		$wpContentDir = \defined('WP_CONTENT_DIR') ? \WP_CONTENT_DIR : '';
 
-			if (!empty($wpContentDir)) {
-				$message['time'] = \gmdate("Y-m-d H:i:s");
+		if (!empty($wpContentDir)) {
+			$message['time'] = \gmdate("Y-m-d H:i:s");
 
-				if (isset($message['files'])) {
-					unset($message['files']);
-				}
-
-				\error_log((string) \wp_json_encode($message) . "\n -------------------------------------", 3, \WP_CONTENT_DIR . '/eightshift-forms-debug.log'); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			if (isset($message['files'])) {
+				unset($message['files']);
 			}
+
+			\error_log((string) \wp_json_encode($message) . "\n -------------------------------------", 3, \WP_CONTENT_DIR . '/eightshift-forms-debug.log'); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
 

--- a/src/Hooks/Filters.php
+++ b/src/Hooks/Filters.php
@@ -31,6 +31,7 @@ use EightshiftForms\Mailer\SettingsMailer;
 use EightshiftForms\Settings\Settings\SettingsGeneral;
 use EightshiftForms\Settings\Settings\SettingsLocation;
 use EightshiftForms\Settings\Settings\SettingsTest;
+use EightshiftForms\Troubleshooting\SettingsTroubleshooting;
 use EightshiftForms\Validation\SettingsCaptcha;
 use EightshiftForms\Validation\SettingsValidation;
 
@@ -123,7 +124,7 @@ class Filters
 			'global' => SettingsClearbit::FILTER_SETTINGS_GLOBAL_NAME,
 			'settingsSidebar' => SettingsClearbit::FILTER_SETTINGS_SIDEBAR_NAME,
 			'fields' => Goodbits::FILTER_FORM_FIELDS_NAME,
-			'icon' => '<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" fill="none"><path d="M10 0h7.324C18.8 0 20 1.2 20 2.676V10H10V0Z" fill="#31C2C2"/><path d="M0 10h10v10H3.19A3.191 3.191 0 0 1 0 16.81V10Z" fill="#29A3A3"/><path d="M10 10h10v7.431c0 1.42-1.15 2.57-2.57 2.57H10V10Z" fill="#E7F2FC"/><path d="M3.273 0H10v10H0V3.273A3.275 3.275 0 0 1 3.273 0Z" fill="#2CB7B7"/></g></svg>',
+			'icon' => '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M1 3a2 2 0 0 1 2-2h7v18H3a2 2 0 0 1-2-2V3z" fill="#29A3A3"/><path opacity=".7" d="M10 1h7a2 2 0 0 1 2 2v7h-9V1z" fill="#29A3A3"/><path opacity=".4" d="M10 10h9v7a2 2 0 0 1-2 2h-7v-9z" fill="#29A3A3"/></svg>',
 			'integration' => [
 				SettingsHubspot::SETTINGS_TYPE_KEY => [
 					'use' => SettingsHubspot::SETTINGS_HUBSPOT_USE_CLEARBIT_KEY,
@@ -149,6 +150,12 @@ class Filters
 			'global' => SettingsGeolocation::FILTER_SETTINGS_GLOBAL_NAME,
 			'settingsSidebar' => SettingsGeolocation::FILTER_SETTINGS_SIDEBAR_NAME,
 			'icon' => '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><ellipse cx="10" cy="18.625" rx="2.5" ry=".625" fill="#29A3A3" fill-opacity=".12"/><path d="m10 18-.53.53a.75.75 0 0 0 1.06 0L10 18zm4.75-10.5c0 2.261-1.26 4.726-2.618 6.7a27.012 27.012 0 0 1-2.442 3.04 14.893 14.893 0 0 1-.208.218l-.01.01-.002.002.53.53.53.53h.001l.001-.002a2.19 2.19 0 0 0 .018-.018l.05-.05.183-.193a28.473 28.473 0 0 0 2.585-3.217c1.393-2.026 2.882-4.811 2.882-7.55h-1.5zM10 18l.53-.53-.002-.002-.01-.01a8.665 8.665 0 0 1-.208-.217 27 27 0 0 1-2.442-3.04C6.511 12.225 5.25 9.76 5.25 7.5h-1.5c0 2.739 1.49 5.524 2.882 7.55a28.494 28.494 0 0 0 2.585 3.217 16.44 16.44 0 0 0 .233.244l.014.013.004.004v.002h.001L10 18zM5.25 7.5A4.75 4.75 0 0 1 10 2.75v-1.5A6.25 6.25 0 0 0 3.75 7.5h1.5zM10 2.75a4.75 4.75 0 0 1 4.75 4.75h1.5A6.25 6.25 0 0 0 10 1.25v1.5z" fill="#29A3A3"/><circle cx="10" cy="7.5" r="1.5" fill="#29A3A3" fill-opacity=".3"/></svg>',
+		],
+		SettingsTroubleshooting::SETTINGS_TYPE_KEY => [
+			'global' => SettingsTroubleshooting::FILTER_SETTINGS_GLOBAL_NAME,
+			'settingsSidebar' => SettingsTroubleshooting::FILTER_SETTINGS_SIDEBAR_NAME,
+			'valid' => SettingsTroubleshooting::FILTER_SETTINGS_IS_VALID_NAME,
+			'icon' => '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 1H7l2.25 6h1.5L13 1zm6 12V7l-6 2.25v1.5L19 13zm-6 6H7l2.25-6h1.5L13 19zM1 13V7l6 2.25v1.5L1 13z" fill="#29A3A3" fill-opacity=".3"/><circle cx="10" cy="10" r="9" stroke="#29A3A3" stroke-width="1.5" fill="none"/><circle cx="10" cy="10" r="3" stroke="#29A3A3" stroke-width="1.5" fill="none"/><path d="M8.8 7 7 2m4.2 5L13 2m0 6.8L18 7m-5 4.2 5 1.8m-9.2 0L7 18m4.2-5 1.8 5M7 8.8 2 7m5 4.2L2 13" stroke="#29A3A3" stroke-width="1.5" fill="none"/><circle opacity=".6" cx="17" cy="3" r="1" stroke="#29A3A3" fill="none"/><circle opacity=".6" cx="17" cy="17" r="1" stroke="#29A3A3" fill="none"/><circle opacity=".6" cx="3" cy="17" r="1" stroke="#29A3A3" fill="none"/><circle opacity=".6" cx="3" cy="3" r="1" stroke="#29A3A3" fill="none"/></svg>',
 		],
 		SettingsTest::SETTINGS_TYPE_KEY => [
 			'global' => SettingsTest::FILTER_SETTINGS_GLOBAL_NAME,

--- a/src/Hooks/Variables.md
+++ b/src/Hooks/Variables.md
@@ -5,26 +5,10 @@ This document will provide you with the code examples for forms global variables
 ## Set forms to develop mode
 
 This variable will set forms to develop mode that will do the following actions:
-* disable value removal after the form is successfully submitted. 
+* output new global settings for testing inputs
 
 ```php
 define('ES_DEVELOP_MODE', true);
-```
-
-## Set forms to skip validation.
-
-This variable will set forms to skip validation when submitting. This is useful when adding a new integration or testing API responses.
-
-```php
-define('ES_DEVELOP_MODE_SKIP_VALIDATION', true);
-```
-
-## Set forms to output log.
-
-This variable will set forms to output log file for all requests and responses. This is useful when adding a new integration or testing API responses.
-
-```php
-define('ES_LOG_MODE', true);
 ```
 
 ## Set Hubspot api key

--- a/src/Hooks/Variables.php
+++ b/src/Hooks/Variables.php
@@ -16,33 +16,13 @@ namespace EightshiftForms\Hooks;
 class Variables
 {
 	/**
-	 * Get forms mode.
+	 * Get forms develop mode, this will output new global settings for testing inputs.
 	 *
 	 * @return bool
 	 */
 	public static function isDevelopMode(): bool
 	{
 		return \defined('ES_DEVELOP_MODE') ? true : false;
-	}
-
-	/**
-	 * Get forms to skip validation used for development of integration.
-	 *
-	 * @return bool
-	 */
-	public static function skipFormValidation(): bool
-	{
-		return \defined('ES_DEVELOP_MODE_SKIP_VALIDATION') ? true : false;
-	}
-
-	/**
-	 * Get forms to log out requests/responses.
-	 *
-	 * @return bool
-	 */
-	public static function isLogMode(): bool
-	{
-		return \defined('ES_LOG_MODE') ? true : false;
 	}
 
 	/**

--- a/src/Integrations/ActiveCampaign/ActiveCampaignClient.php
+++ b/src/Integrations/ActiveCampaign/ActiveCampaignClient.php
@@ -140,16 +140,6 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
-		// Bailout if wp error.
-		if (\is_wp_error($response)) {
-			return $this->getApiWpErrorOutput(
-				SettingsActiveCampaign::SETTINGS_TYPE_KEY,
-				$details,
-				$requestBody,
-				$response->get_error_message()
-			);
-		}
-
 		switch ($code) {
 			case 200:
 			case 201:

--- a/src/Integrations/ActiveCampaign/SettingsActiveCampaign.php
+++ b/src/Integrations/ActiveCampaign/SettingsActiveCampaign.php
@@ -18,7 +18,9 @@ use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Integrations\ActiveCampaign\ActiveCampaignClientInterface;
 use EightshiftForms\Integrations\MapperInterface;
 use EightshiftForms\Settings\GlobalSettings\SettingsGlobalDataInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshootingDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -96,17 +98,27 @@ class SettingsActiveCampaign implements SettingsDataInterface, SettingsGlobalDat
 	private $activeCampaign;
 
 	/**
+	 * Instance variable for Troubleshooting settings.
+	 *
+	 * @var SettingsTroubleshootingDataInterface
+	 */
+	protected $settingsTroubleshooting;
+
+	/**
 	 * Create a new instance.
 	 *
 	 * @param ActiveCampaignClientInterface $activeCampaignClient Inject ActiveCampaign which holds ActiveCampaign connect data.
 	 * @param MapperInterface $activeCampaign Inject ActiveCampaign which holds ActiveCampaign form data.
+	 * @param SettingsTroubleshootingDataInterface $settingsTroubleshooting Inject Troubleshooting which holds Troubleshooting settings data.
 	 */
 	public function __construct(
 		ActiveCampaignClientInterface $activeCampaignClient,
-		MapperInterface $activeCampaign
+		MapperInterface $activeCampaign,
+		SettingsTroubleshootingDataInterface $settingsTroubleshooting
 	) {
 		$this->activeCampaignClient = $activeCampaignClient;
 		$this->activeCampaign = $activeCampaign;
+		$this->settingsTroubleshooting = $settingsTroubleshooting;
 	}
 
 	/**
@@ -173,6 +185,7 @@ class SettingsActiveCampaign implements SettingsDataInterface, SettingsGlobalDat
 			'label' => \__('ActiveCampaign', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
 		];
 	}
 
@@ -376,6 +389,9 @@ class SettingsActiveCampaign implements SettingsDataInterface, SettingsGlobalDat
 			);
 		}
 
-		return $output;
+		return [
+			...$output,
+			...$this->settingsTroubleshooting->getOutputGlobalTroubleshooting(SettingsActiveCampaign::SETTINGS_TYPE_KEY),
+		];
 	}
 }

--- a/src/Integrations/Clearbit/ClearbitClientInterface.php
+++ b/src/Integrations/Clearbit/ClearbitClientInterface.php
@@ -21,13 +21,15 @@ interface ClearbitClientInterface
 	public function getParams(): array;
 
 	/**
-	 * API request to get application.
+	 * API request to post application.
 	 *
-	 * @param string $emailKey Email key to map in params.
+	 * @param string $email Email key to map in params.
 	 * @param array<string, mixed> $params Params array.
 	 * @param array<string, string> $mapData Map data from settings.
+	 * @param string $itemId Item id to search.
+	 * @param string $formId FormId value.
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function getApplication(string $emailKey, array $params, array $mapData): array;
+	public function getApplication(string $email, array $params, array $mapData, string $itemId, string $formId): array;
 }

--- a/src/Integrations/Clearbit/SettingsClearbit.php
+++ b/src/Integrations/Clearbit/SettingsClearbit.php
@@ -13,6 +13,7 @@ namespace EightshiftForms\Integrations\Clearbit;
 use EightshiftForms\Hooks\Filters;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Hooks\Variables;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -164,6 +165,7 @@ class SettingsClearbit implements SettingsClearbitDataInterface, ServiceInterfac
 			'label' => \__('Clearbit', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
 		];
 	}
 

--- a/src/Integrations/Goodbits/GoodbitsClient.php
+++ b/src/Integrations/Goodbits/GoodbitsClient.php
@@ -113,23 +113,9 @@ class GoodbitsClient implements ClientInterface
 			]
 		);
 
-		if (\is_wp_error($response)) {
-			Helper::logger([
-				'integration' => 'goodbits',
-				'type' => 'wp',
-				'body' => $body,
-				'response' => $response,
-			]);
-			return [
-				'status' => 'error',
-				'code' => 400,
-				'message' => $this->getErrorMsg('submitWpError'),
-			];
-		}
-
 		$code = $response['response']['code'] ? $response['response']['code'] : 200;
 
-		if ($code === 200 || $code === 201) {
+		if ($code >= 200 && $code <= 299) {
 			return [
 				'status' => 'success',
 				'code' => 200,
@@ -141,20 +127,23 @@ class GoodbitsClient implements ClientInterface
 		$responseMessage = !\is_array($responseBody['errors']) ? $responseBody['errors'] : '';
 		$responseErrors = \is_array($responseBody['errors']) ? $responseBody['errors']['message'] : [];
 
+		$outputData = [
+			'integration' => SettingsGoodbits::SETTINGS_TYPE_KEY,
+			'params' => $this->prepareParams($params),
+			'files' => $files,
+			'response' => $response['body'],
+			'listId' => $itemId,
+			'formId' => $formId,
+		];
+
 		$output = [
 			'status' => 'error',
 			'code' => $code,
 			'message' => $this->getErrorMsg($responseMessage, $responseErrors),
+			'data' => $outputData,
 		];
 
-		Helper::logger([
-			'integration' => 'goodbits',
-			'type' => 'service',
-			'body' => $body,
-			'response' => $response['response'],
-			'responseBody' => $responseBody,
-			'output' => $output,
-		]);
+		Helper::logger($outputData);
 
 		return $output;
 	}

--- a/src/Integrations/Goodbits/SettingsGoodbits.php
+++ b/src/Integrations/Goodbits/SettingsGoodbits.php
@@ -16,7 +16,9 @@ use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\MapperInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshootingDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -89,17 +91,27 @@ class SettingsGoodbits implements SettingsDataInterface, ServiceInterface
 	protected $goodbits;
 
 	/**
+	 * Instance variable for Troubleshooting settings.
+	 *
+	 * @var SettingsTroubleshootingDataInterface
+	 */
+	protected $settingsTroubleshooting;
+
+	/**
 	 * Create a new instance.
 	 *
 	 * @param ClientInterface $goodbitsClient Inject Goodbits which holds Goodbits connect data.
 	 * @param MapperInterface $goodbits Inject Goodbits which holds Goodbits form data.
+	 * @param SettingsTroubleshootingDataInterface $settingsTroubleshooting Inject Troubleshooting which holds Troubleshooting settings data.
 	 */
 	public function __construct(
 		ClientInterface $goodbitsClient,
-		MapperInterface $goodbits
+		MapperInterface $goodbits,
+		SettingsTroubleshootingDataInterface $settingsTroubleshooting
 	) {
 		$this->goodbitsClient = $goodbitsClient;
 		$this->goodbits = $goodbits;
+		$this->settingsTroubleshooting = $settingsTroubleshooting;
 	}
 	/**
 	 * Register all the hooks
@@ -164,6 +176,7 @@ class SettingsGoodbits implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Goodbits', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
 		];
 	}
 
@@ -348,6 +361,9 @@ class SettingsGoodbits implements SettingsDataInterface, ServiceInterface
 			);
 		}
 
-		return $output;
+		return [
+			...$output,
+			...$this->settingsTroubleshooting->getOutputGlobalTroubleshooting(SettingsGoodbits::SETTINGS_TYPE_KEY),
+		];
 	}
 }

--- a/src/Integrations/Greenhouse/SettingsGreenhouse.php
+++ b/src/Integrations/Greenhouse/SettingsGreenhouse.php
@@ -17,7 +17,9 @@ use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\MapperInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshootingDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -95,17 +97,27 @@ class SettingsGreenhouse implements SettingsDataInterface, ServiceInterface
 	protected $greenhouse;
 
 	/**
+	 * Instance variable for Troubleshooting settings.
+	 *
+	 * @var SettingsTroubleshootingDataInterface
+	 */
+	protected $settingsTroubleshooting;
+
+	/**
 	 * Create a new instance.
 	 *
 	 * @param ClientInterface $greenhouseClient Inject Greenhouse which holds Greenhouse connect data.
 	 * @param MapperInterface $greenhouse Inject Greenhouse which holds Greenhouse form data.
+	 * @param SettingsTroubleshootingDataInterface $settingsTroubleshooting Inject Troubleshooting which holds Troubleshooting settings data.
 	 */
 	public function __construct(
 		ClientInterface $greenhouseClient,
-		MapperInterface $greenhouse
+		MapperInterface $greenhouse,
+		SettingsTroubleshootingDataInterface $settingsTroubleshooting
 	) {
 		$this->greenhouseClient = $greenhouseClient;
 		$this->greenhouse = $greenhouse;
+		$this->settingsTroubleshooting = $settingsTroubleshooting;
 	}
 
 	/**
@@ -172,6 +184,7 @@ class SettingsGreenhouse implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Greenhouse', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
 		];
 	}
 
@@ -389,6 +402,9 @@ class SettingsGreenhouse implements SettingsDataInterface, ServiceInterface
 			);
 		}
 
-		return $output;
+		return [
+			...$output,
+			...$this->settingsTroubleshooting->getOutputGlobalTroubleshooting(SettingsGreenhouse::SETTINGS_TYPE_KEY),
+		];
 	}
 }

--- a/src/Integrations/Hubspot/HubspotClient.php
+++ b/src/Integrations/Hubspot/HubspotClient.php
@@ -243,20 +243,6 @@ class HubspotClient implements HubspotClientInterface
 			]
 		);
 
-		if (\is_wp_error($response)) {
-			Helper::logger([
-				'integration' => 'hubspot',
-				'type' => 'wp',
-				'body' => $body,
-				'response' => $response,
-			]);
-			return [
-				'status' => 'error',
-				'code' => 400,
-				'message' => $this->getErrorMsg('submitWpError'),
-			];
-		}
-
 		$code = $response['response']['code'] ? $response['response']['code'] : 200;
 
 		if ($code === 200) {
@@ -271,20 +257,26 @@ class HubspotClient implements HubspotClientInterface
 		$responseMessage = $responseBody['message'] ?? '';
 		$responseErrors = $responseBody['errors'] ?? [];
 
+		$outputData = [
+			'integration' => SettingsHubspot::SETTINGS_TYPE_KEY,
+			'params' => $body,
+			'files' => $files,
+			'response' => $response['body'],
+			'listId' => $itemId,
+			'formId' => $formId,
+		];
+
 		$output = [
 			'status' => 'error',
 			'code' => $code,
 			'message' => $this->getErrorMsg($responseMessage, $responseErrors),
+			'data' => $outputData,
 		];
 
-		Helper::logger([
-			'integration' => 'hubspot',
-			'type' => 'service',
-			'body' => $body,
-			'response' => $response['response'],
-			'responseBody' => $responseBody,
-			'output' => $output,
-		]);
+		Helper::logger($outputData);
+
+		error_log( print_r( ( $output ), true ) );
+		
 
 		return $output;
 	}

--- a/src/Integrations/Hubspot/SettingsHubspot.php
+++ b/src/Integrations/Hubspot/SettingsHubspot.php
@@ -19,7 +19,9 @@ use EightshiftForms\Integrations\Clearbit\ClearbitClientInterface;
 use EightshiftForms\Integrations\Clearbit\SettingsClearbitDataInterface;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\MapperInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshootingDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -136,23 +138,33 @@ class SettingsHubspot implements SettingsDataInterface, ServiceInterface
 	protected $hubspot;
 
 	/**
+	 * Instance variable for Troubleshooting settings.
+	 *
+	 * @var SettingsTroubleshootingDataInterface
+	 */
+	protected $settingsTroubleshooting;
+
+	/**
 	 * Create a new instance.
 	 *
 	 * @param ClearbitClientInterface $clearbitClient Inject Clearbit which holds Clearbit connect data.
 	 * @param SettingsClearbitDataInterface $settingsClearbit Inject Clearbit which holds Clearbit settings data.
 	 * @param HubspotClientInterface $hubspotClient Inject Hubspot which holds Hubspot connect data.
 	 * @param MapperInterface $hubspot Inject HubSpot which holds HubSpot form data.
+	 * @param SettingsTroubleshootingDataInterface $settingsTroubleshooting Inject Troubleshooting which holds Troubleshooting settings data.
 	 */
 	public function __construct(
 		ClearbitClientInterface $clearbitClient,
 		SettingsClearbitDataInterface $settingsClearbit,
 		HubspotClientInterface $hubspotClient,
-		MapperInterface $hubspot
+		MapperInterface $hubspot,
+		SettingsTroubleshootingDataInterface $settingsTroubleshooting
 	) {
 		$this->clearbitClient = $clearbitClient;
 		$this->settingsClearbit = $settingsClearbit;
 		$this->hubspotClient = $hubspotClient;
 		$this->hubspot = $hubspot;
+		$this->settingsTroubleshooting = $settingsTroubleshooting;
 	}
 
 	/**
@@ -218,6 +230,7 @@ class SettingsHubspot implements SettingsDataInterface, ServiceInterface
 			'label' => \__('HubSpot', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
 		];
 	}
 
@@ -379,10 +392,11 @@ class SettingsHubspot implements SettingsDataInterface, ServiceInterface
 			);
 		}
 
-		return \array_merge(
-			$output,
-			$outputValid
-		);
+		return [
+			...$output,
+			...$outputValid,
+			...$this->settingsTroubleshooting->getOutputGlobalTroubleshooting(SettingsHubspot::SETTINGS_TYPE_KEY),
+		];
 	}
 
 	/**

--- a/src/Integrations/Mailchimp/MailchimpClient.php
+++ b/src/Integrations/Mailchimp/MailchimpClient.php
@@ -177,24 +177,9 @@ class MailchimpClient implements MailchimpClientInterface
 			]
 		);
 
-		if (\is_wp_error($response)) {
-			Helper::logger([
-				'integration' => 'mailchimp',
-				'type' => 'wp',
-				'body' => $body,
-				'response' => $response,
-			]);
-
-			return [
-				'status' => 'error',
-				'code' => 400,
-				'message' => $this->getErrorMsg('submitWpError'),
-			];
-		}
-
 		$code = $response['response']['code'] ? $response['response']['code'] : 200;
 
-		if ($code === 200) {
+		if ($code >= 200 && $code <= 299) {
 			return [
 				'status' => 'success',
 				'code' => $code,
@@ -206,20 +191,23 @@ class MailchimpClient implements MailchimpClientInterface
 		$responseMessage = $responseBody['detail'] ?? '';
 		$responseErrors = $responseBody['errors'] ?? [];
 
+		$outputData = [
+			'integration' => SettingsMailchimp::SETTINGS_TYPE_KEY,
+			'params' => $body,
+			'files' => $files,
+			'response' => $response['body'],
+			'listId' => $itemId,
+			'formId' => $formId,
+		];
+
 		$output = [
 			'status' => 'error',
 			'code' => $code,
 			'message' => $this->getErrorMsg($responseMessage, $responseErrors),
+			'data' => $outputData,
 		];
 
-		Helper::logger([
-			'integration' => 'mailchimp',
-			'type' => 'service',
-			'body' => $body,
-			'response' => $response['response'],
-			'responseBody' => $responseBody,
-			'output' => $output,
-		]);
+		Helper::logger($outputData);
 
 		return $output;
 	}

--- a/src/Integrations/Mailchimp/MailchimpClient.php
+++ b/src/Integrations/Mailchimp/MailchimpClient.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 
 namespace EightshiftForms\Integrations\Mailchimp;
 
-use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Integrations\ClientInterface;
+use EightshiftForms\Rest\ApiHelper;
 use EightshiftForms\Rest\Routes\AbstractBaseRoute;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
@@ -26,6 +26,11 @@ class MailchimpClient implements MailchimpClientInterface
 	 * Use general helper trait.
 	 */
 	use SettingsHelper;
+
+	/**
+	 * Use API helper trait.
+	 */
+	use ApiHelper;
 
 	/**
 	 * Transient cache name for items.
@@ -168,8 +173,10 @@ class MailchimpClient implements MailchimpClientInterface
 			$body['merge_fields'] = $prepareParams;
 		}
 
+		$url = "{$this->getBaseUrl()}lists/{$itemId}/members/{$emailHash}";
+
 		$response = \wp_remote_request(
-			"{$this->getBaseUrl()}lists/{$itemId}/members/{$emailHash}",
+			$url,
 			[
 				'headers' => $this->getHeaders(),
 				'method' => 'PUT',
@@ -177,51 +184,44 @@ class MailchimpClient implements MailchimpClientInterface
 			]
 		);
 
-		$code = $response['response']['code'] ? $response['response']['code'] : 200;
+		// Structure response details.
+		$details = $this->getApiReponseDetails(
+			SettingsMailchimp::SETTINGS_TYPE_KEY,
+			$response,
+			$url,
+			$body,
+			$files,
+			$itemId,
+			$formId
+		);
 
+		$code = $details['code'];
+		$body = $details['body'];
+
+		// On success return output.
 		if ($code >= 200 && $code <= 299) {
-			return [
-				'status' => 'success',
-				'code' => $code,
-				'message' => 'mailchimpSuccess',
-			];
+			return $this->getApiSuccessOutput($details);
 		}
 
-		$responseBody = \json_decode(\wp_remote_retrieve_body($response), true);
-		$responseMessage = $responseBody['detail'] ?? '';
-		$responseErrors = $responseBody['errors'] ?? [];
-
-		$outputData = [
-			'integration' => SettingsMailchimp::SETTINGS_TYPE_KEY,
-			'params' => $body,
-			'files' => $files,
-			'response' => $response['body'],
-			'listId' => $itemId,
-			'formId' => $formId,
-		];
-
-		$output = [
-			'status' => 'error',
-			'code' => $code,
-			'message' => $this->getErrorMsg($responseMessage, $responseErrors),
-			'data' => $outputData,
-		];
-
-		Helper::logger($outputData);
-
-		return $output;
+		// Output error.
+		return $this->getApiErrorOutput(
+			$details,
+			$this->getErrorMsg($body),
+		);
 	}
 
 	/**
 	 * Map service messages with our own.
 	 *
-	 * @param string $msg Message got from the API.
-	 * @param array<string, mixed> $errors Additional errors got from the API.
+	 * @param array<mixed> $body API response body.
 	 *
 	 * @return string
 	 */
-	private function getErrorMsg(string $msg, array $errors = []): string
+	private function getErrorMsg(array $body): string
 	{
+		$msg = $body['detail'] ?? '';
+		$errors = $body['errors'] ?? [];
+
 		if ($errors) {
 			$invalidEmail = \array_filter(
 				$errors,
@@ -259,21 +259,31 @@ class MailchimpClient implements MailchimpClientInterface
 	 */
 	private function getMailchimpTags(string $itemId): array
 	{
+		$url = "{$this->getBaseUrl()}lists/{$itemId}/tag-search";
+
 		$response = \wp_remote_get(
-			"{$this->getBaseUrl()}lists/{$itemId}/tag-search",
+			$url,
 			[
 				'headers' => $this->getHeaders(),
-				'timeout' => 60,
 			]
 		);
 
-		$body = \json_decode(\wp_remote_retrieve_body($response), true);
+		// Structure response details.
+		$details = $this->getApiReponseDetails(
+			SettingsMailchimp::SETTINGS_TYPE_KEY,
+			$response,
+			$url,
+		);
 
-		if (!isset($body['tags'])) {
-			return [];
+		$code = $details['code'];
+		$body = $details['body'];
+
+		// On success return output.
+		if ($code >= 200 && $code <= 299) {
+			return $body['tags'] ?? [];
 		}
 
-		return $body['tags'];
+		return [];
 	}
 
 	/**
@@ -300,21 +310,31 @@ class MailchimpClient implements MailchimpClientInterface
 	 */
 	private function getMailchimpListFields(string $listId)
 	{
+		$url = "{$this->getBaseUrl()}lists/{$listId}/merge-fields?count=1000";
+
 		$response = \wp_remote_get(
-			"{$this->getBaseUrl()}lists/{$listId}/merge-fields?count=1000",
+			$url,
 			[
 				'headers' => $this->getHeaders(),
-				'timeout' => 60,
 			]
 		);
 
-		$body = \json_decode(\wp_remote_retrieve_body($response), true);
+		// Structure response details.
+		$details = $this->getApiReponseDetails(
+			SettingsMailchimp::SETTINGS_TYPE_KEY,
+			$response,
+			$url,
+		);
 
-		if (!isset($body['merge_fields'])) {
-			return [];
+		$code = $details['code'];
+		$body = $details['body'];
+
+		// On success return output.
+		if ($code >= 200 && $code <= 299) {
+			return $body['merge_fields'] ?? [];
 		}
 
-		return $body['merge_fields'];
+		return [];
 	}
 
 	/**
@@ -324,21 +344,31 @@ class MailchimpClient implements MailchimpClientInterface
 	 */
 	private function getMailchimpLists()
 	{
+		$url = "{$this->getBaseUrl()}lists?count=100";
+
 		$response = \wp_remote_get(
-			"{$this->getBaseUrl()}lists?count=100",
+			$url,
 			[
 				'headers' => $this->getHeaders(),
-				'timeout' => 60,
 			]
 		);
 
-		$body = \json_decode(\wp_remote_retrieve_body($response), true);
+		// Structure response details.
+		$details = $this->getApiReponseDetails(
+			SettingsMailchimp::SETTINGS_TYPE_KEY,
+			$response,
+			$url,
+		);
 
-		if (!isset($body['lists'])) {
-			return [];
+		$code = $details['code'];
+		$body = $details['body'];
+
+		// On success return output.
+		if ($code >= 200 && $code <= 299) {
+			return $body['lists'] ?? [];
 		}
 
-		return $body['lists'];
+		return [];
 	}
 
 	/**

--- a/src/Integrations/Mailchimp/SettingsMailchimp.php
+++ b/src/Integrations/Mailchimp/SettingsMailchimp.php
@@ -18,7 +18,9 @@ use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\MapperInterface;
 use EightshiftForms\Settings\GlobalSettings\SettingsGlobalDataInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshootingDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -106,17 +108,27 @@ class SettingsMailchimp implements SettingsDataInterface, SettingsGlobalDataInte
 	protected $mailchimp;
 
 	/**
+	 * Instance variable for Troubleshooting settings.
+	 *
+	 * @var SettingsTroubleshootingDataInterface
+	 */
+	protected $settingsTroubleshooting;
+
+	/**
 	 * Create a new instance.
 	 *
 	 * @param MailchimpClientInterface $mailchimpClient Inject Mailchimp which holds Mailchimp connect data.
 	 * @param MapperInterface $mailchimp Inject Mailchimp which holds Mailchimp form data.
+	 * @param SettingsTroubleshootingDataInterface $settingsTroubleshooting Inject Troubleshooting which holds Troubleshooting settings data.
 	 */
 	public function __construct(
 		MailchimpClientInterface $mailchimpClient,
-		MapperInterface $mailchimp
+		MapperInterface $mailchimp,
+		SettingsTroubleshootingDataInterface $settingsTroubleshooting
 	) {
 		$this->mailchimpClient = $mailchimpClient;
 		$this->mailchimp = $mailchimp;
+		$this->settingsTroubleshooting = $settingsTroubleshooting;
 	}
 
 	/**
@@ -182,6 +194,7 @@ class SettingsMailchimp implements SettingsDataInterface, SettingsGlobalDataInte
 			'label' => \__('Mailchimp', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
 		];
 	}
 
@@ -491,6 +504,9 @@ class SettingsMailchimp implements SettingsDataInterface, SettingsGlobalDataInte
 			);
 		}
 
-		return $output;
+		return [
+			...$output,
+			...$this->settingsTroubleshooting->getOutputGlobalTroubleshooting(SettingsMailchimp::SETTINGS_TYPE_KEY),
+		];
 	}
 }

--- a/src/Integrations/Mailerlite/SettingsMailerlite.php
+++ b/src/Integrations/Mailerlite/SettingsMailerlite.php
@@ -17,7 +17,9 @@ use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\MapperInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshootingDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -90,17 +92,27 @@ class SettingsMailerlite implements SettingsDataInterface, ServiceInterface
 	protected $mailerlite;
 
 	/**
+	 * Instance variable for Troubleshooting settings.
+	 *
+	 * @var SettingsTroubleshootingDataInterface
+	 */
+	protected $settingsTroubleshooting;
+
+	/**
 	 * Create a new instance.
 	 *
 	 * @param ClientInterface $mailerliteClient Inject Mailerlite which holds Mailerlite connect data.
 	 * @param MapperInterface $mailerlite Inject Mailerlite which holds Mailerlite form data.
+	 * @param SettingsTroubleshootingDataInterface $settingsTroubleshooting Inject Troubleshooting which holds Troubleshooting settings data.
 	 */
 	public function __construct(
 		ClientInterface $mailerliteClient,
-		MapperInterface $mailerlite
+		MapperInterface $mailerlite,
+		SettingsTroubleshootingDataInterface $settingsTroubleshooting
 	) {
 		$this->mailerliteClient = $mailerliteClient;
 		$this->mailerlite = $mailerlite;
+		$this->settingsTroubleshooting = $settingsTroubleshooting;
 	}
 	/**
 	 * Register all the hooks
@@ -165,6 +177,7 @@ class SettingsMailerlite implements SettingsDataInterface, ServiceInterface
 			'label' => \__('MailerLite', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
 		];
 	}
 
@@ -356,6 +369,9 @@ class SettingsMailerlite implements SettingsDataInterface, ServiceInterface
 			);
 		}
 
-		return $output;
+		return [
+			...$output,
+			...$this->settingsTroubleshooting->getOutputGlobalTroubleshooting(SettingsMailerlite::SETTINGS_TYPE_KEY),
+		];
 	}
 }

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -143,11 +143,18 @@ class Mailer implements MailerInterface
 		}
 
 		$to = $this->getOptionValue(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY);
+		$cc = $this->getOptionValue(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY . '-' . $integration);
 		// translators: %1$s replaces the integration name and %2$s formId.
 		$subject = \sprintf(\__('Your %1$s form failed: %2$s', 'eightshift-forms'), $integration, $formId);
-		$headers = $this->getType();
 		// translators: %s replaces the parameters list html.
 		$templateHtml = \sprintf(\__("<p>It looks like something went wrong with the users form submition, here is all the data to debug.</p>%s", 'eightshift-forms'), $paramsOutput);
+		$headers = [
+			$this->getType()
+		];
+
+		if ($cc) {
+			$headers[] = "Cc: {$cc}";
+		}
 
 		// Send email.
 		return \wp_mail($to, $subject, $templateHtml, $headers, $filesOutput);

--- a/src/Mailer/MailerInterface.php
+++ b/src/Mailer/MailerInterface.php
@@ -43,5 +43,5 @@ interface MailerInterface
 	 *
 	 * @return boolean
 	 */
-	public function fallbackEmail (array $data): bool;
+	public function fallbackEmail(array $data): bool;
 }

--- a/src/Mailer/MailerInterface.php
+++ b/src/Mailer/MailerInterface.php
@@ -35,4 +35,13 @@ interface MailerInterface
 		array $files = [],
 		array $fields = []
 	): bool;
+
+	/**
+	 * Send fallback email.
+	 *
+	 * @param array<mixed> $data Data to extract data from.
+	 *
+	 * @return boolean
+	 */
+	public function fallbackEmail (array $data): bool;
 }

--- a/src/Mailer/SettingsMailer.php
+++ b/src/Mailer/SettingsMailer.php
@@ -12,6 +12,7 @@ namespace EightshiftForms\Mailer;
 
 use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Hooks\Filters;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
@@ -135,6 +136,7 @@ class SettingsMailer implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Mailer', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_GENERAL,
 		];
 	}
 

--- a/src/Rest/ApiHelper.php
+++ b/src/Rest/ApiHelper.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 namespace EightshiftForms\Rest;
 
 use EightshiftForms\Helpers\Helper;
+use EightshiftForms\Settings\SettingsHelper;
+use EightshiftForms\Troubleshooting\SettingsTroubleshooting;
 use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
 
 /**
@@ -18,6 +20,11 @@ use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
  */
 trait ApiHelper
 {
+	/**
+	 * Use general helper trait.
+	 */
+	use SettingsHelper;
+
 	/**
 	 * Return API response array details.
 	 *
@@ -80,7 +87,9 @@ trait ApiHelper
 	 */
 	public function getApiErrorOutput(array $details, string $msg): array
 	{
-		Helper::logger($details);
+		if ($this->isCheckboxOptionChecked(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_LOG_MODE_KEY, SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY)) {
+			Helper::logger($details);
+		}
 
 		return [
 			'status' => 'error',

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -14,7 +14,7 @@ use EightshiftForms\Exception\UnverifiedRequestException;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Helpers\UploadHelper;
 use EightshiftForms\Hooks\Filters;
-use EightshiftForms\Hooks\Variables;
+use EightshiftForms\Troubleshooting\SettingsTroubleshooting;
 use WP_REST_Request;
 
 /**
@@ -81,7 +81,7 @@ abstract class AbstractFormSubmit extends AbstractBaseRoute
 			$formData = isset(Filters::ALL[$formType]['fields']) ? \apply_filters(Filters::ALL[$formType]['fields'], $formId) : [];
 
 			// Validate request.
-			if (!Variables::skipFormValidation()) {
+			if (!$this->isCheckboxOptionChecked(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_SKIP_VALIDATION_KEY, SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY)) {
 				$this->verifyRequest(
 					$params,
 					$request->get_file_params(),

--- a/src/Rest/Routes/FormSettingsSubmitRoute.php
+++ b/src/Rest/Routes/FormSettingsSubmitRoute.php
@@ -14,7 +14,8 @@ use EightshiftForms\AdminMenus\FormGlobalSettingsAdminSubMenu;
 use EightshiftForms\Cache\SettingsCache;
 use EightshiftForms\Exception\UnverifiedRequestException;
 use EightshiftForms\Hooks\Filters;
-use EightshiftForms\Hooks\Variables;
+use EightshiftForms\Settings\SettingsHelper;
+use EightshiftForms\Troubleshooting\SettingsTroubleshooting;
 use EightshiftForms\Validation\ValidatorInterface;
 use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
 use WP_REST_Request;
@@ -24,6 +25,11 @@ use WP_REST_Request;
  */
 class FormSettingsSubmitRoute extends AbstractBaseRoute
 {
+	/**
+	 * Use general helper trait.
+	 */
+	use SettingsHelper;
+
 	/**
 	 * Instance variable of ValidatorInterface data.
 	 *
@@ -103,7 +109,7 @@ class FormSettingsSubmitRoute extends AbstractBaseRoute
 			$formData = isset(Filters::ALL[$formType][$formInternalType]) ? \apply_filters(Filters::ALL[$formType][$formInternalType], $formId) : [];
 
 			// Validate request.
-			if (!Variables::skipFormValidation()) {
+			if (!$this->isCheckboxOptionChecked(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_SKIP_VALIDATION_KEY, SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY)) {
 				$this->verifyRequest(
 					$params,
 					$request->get_file_params(),

--- a/src/Rest/Routes/FormSubmitCustomRoute.php
+++ b/src/Rest/Routes/FormSubmitCustomRoute.php
@@ -107,13 +107,12 @@ class FormSubmitCustomRoute extends AbstractFormSubmit
 		}
 
 		// Create a custom form action request.
-		$customResponse = \wp_remote_request(
+		$customResponse = \wp_remote_post(
 			$formAction,
 			[
 				'headers' => [
 					'Content-Type' => 'application/x-www-form-urlencoded',
 				],
-				'method' => 'POST',
 				'body' => \http_build_query($body),
 			]
 		);

--- a/src/Rest/Routes/FormSubmitGoodbitsRoute.php
+++ b/src/Rest/Routes/FormSubmitGoodbitsRoute.php
@@ -15,6 +15,7 @@ use EightshiftForms\Helpers\UploadHelper;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\Goodbits\SettingsGoodbits;
 use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Mailer\MailerInterface;
 use EightshiftForms\Validation\ValidatorInterface;
 
 /**
@@ -54,20 +55,30 @@ class FormSubmitGoodbitsRoute extends AbstractFormSubmit
 	protected $goodbitsClient;
 
 	/**
+	 * Instance variable of MailerInterface data.
+	 *
+	 * @var MailerInterface
+	 */
+	public $mailer;
+
+	/**
 	 * Create a new instance that injects classes
 	 *
 	 * @param ValidatorInterface $validator Inject ValidatorInterface which holds validation methods.
 	 * @param LabelsInterface $labels Inject LabelsInterface which holds labels data.
 	 * @param ClientInterface $goodbitsClient Inject Goodbits which holds Goodbits connect data.
+	 * @param MailerInterface $mailer Inject MailerInterface which holds mailer methods.
 	 */
 	public function __construct(
 		ValidatorInterface $validator,
 		LabelsInterface $labels,
-		ClientInterface $goodbitsClient
+		ClientInterface $goodbitsClient,
+		MailerInterface $mailer
 	) {
 		$this->validator = $validator;
 		$this->labels = $labels;
 		$this->goodbitsClient = $goodbitsClient;
+		$this->mailer = $mailer;
 	}
 
 	/**
@@ -111,6 +122,11 @@ class FormSubmitGoodbitsRoute extends AbstractFormSubmit
 			[],
 			$formId
 		);
+
+		if ($response['status'] === 'error') {
+			// Send fallback email.
+			$this->mailer->fallbackEmail($response['data'] ?? []);
+		}
 
 		// Finish.
 		return \rest_ensure_response([

--- a/src/Rest/Routes/FormSubmitGreenhouseRoute.php
+++ b/src/Rest/Routes/FormSubmitGreenhouseRoute.php
@@ -15,6 +15,7 @@ use EightshiftForms\Helpers\UploadHelper;
 use EightshiftForms\Integrations\Greenhouse\SettingsGreenhouse;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Mailer\MailerInterface;
 use EightshiftForms\Validation\ValidatorInterface;
 
 /**
@@ -54,20 +55,30 @@ class FormSubmitGreenhouseRoute extends AbstractFormSubmit
 	protected $greenhouseClient;
 
 	/**
+	 * Instance variable of MailerInterface data.
+	 *
+	 * @var MailerInterface
+	 */
+	public $mailer;
+
+	/**
 	 * Create a new instance that injects classes
 	 *
 	 * @param ValidatorInterface $validator Inject ValidatorInterface which holds validation methods.
 	 * @param LabelsInterface $labels Inject LabelsInterface which holds labels data.
 	 * @param ClientInterface $greenhouseClient Inject ClientInterface which holds Greenhouse connect data.
+	 * @param MailerInterface $mailer Inject MailerInterface which holds mailer methods.
 	 */
 	public function __construct(
 		ValidatorInterface $validator,
 		LabelsInterface $labels,
-		ClientInterface $greenhouseClient
+		ClientInterface $greenhouseClient,
+		MailerInterface $mailer
 	) {
 		$this->validator = $validator;
 		$this->labels = $labels;
 		$this->greenhouseClient = $greenhouseClient;
+		$this->mailer = $mailer;
 	}
 
 	/**
@@ -111,6 +122,11 @@ class FormSubmitGreenhouseRoute extends AbstractFormSubmit
 			$files,
 			$formId
 		);
+
+		if ($response['status'] === 'error') {
+			// Send fallback email.
+			$this->mailer->fallbackEmail($response['data'] ?? []);
+		}
 
 		// Always delete the files from the disk.
 		if ($files) {

--- a/src/Rest/Routes/FormSubmitHubspotRoute.php
+++ b/src/Rest/Routes/FormSubmitHubspotRoute.php
@@ -18,6 +18,7 @@ use EightshiftForms\Integrations\Clearbit\SettingsClearbit;
 use EightshiftForms\Integrations\Hubspot\HubspotClientInterface;
 use EightshiftForms\Integrations\Hubspot\SettingsHubspot;
 use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Mailer\MailerInterface;
 use EightshiftForms\Validation\ValidatorInterface;
 
 /**
@@ -64,23 +65,33 @@ class FormSubmitHubspotRoute extends AbstractFormSubmit
 	protected $clearbitClient;
 
 	/**
+	 * Instance variable of MailerInterface data.
+	 *
+	 * @var MailerInterface
+	 */
+	public $mailer;
+
+	/**
 	 * Create a new instance that injects classes
 	 *
 	 * @param ValidatorInterface $validator Inject ValidatorInterface which holds validation methods.
 	 * @param LabelsInterface $labels Inject LabelsInterface which holds labels data.
 	 * @param HubspotClientInterface $hubspotClient Inject HubSpot which holds HubSpot connect data.
 	 * @param ClearbitClientInterface $clearbitClient Inject Clearbit which holds clearbit connect data.
+	 * @param MailerInterface $mailer Inject MailerInterface which holds mailer methods.
 	 */
 	public function __construct(
 		ValidatorInterface $validator,
 		LabelsInterface $labels,
 		HubspotClientInterface $hubspotClient,
-		ClearbitClientInterface $clearbitClient
+		ClearbitClientInterface $clearbitClient,
+		MailerInterface $mailer
 	) {
 		$this->validator = $validator;
 		$this->labels = $labels;
 		$this->hubspotClient = $hubspotClient;
 		$this->clearbitClient = $clearbitClient;
+		$this->mailer = $mailer;
 	}
 
 	/**
@@ -141,6 +152,11 @@ class FormSubmitHubspotRoute extends AbstractFormSubmit
 					$clearbitResponse['data'] ?? []
 				);
 			}
+		}
+
+		if ($response['status'] === 'error') {
+			// Send fallback email.
+			$this->mailer->fallbackEmail($response['data'] ?? []);
 		}
 
 		// Always delete the files from the disk.

--- a/src/Rest/Routes/FormSubmitMailchimpRoute.php
+++ b/src/Rest/Routes/FormSubmitMailchimpRoute.php
@@ -13,6 +13,7 @@ namespace EightshiftForms\Rest\Routes;
 use EightshiftForms\Integrations\Mailchimp\MailchimpClientInterface;
 use EightshiftForms\Integrations\Mailchimp\SettingsMailchimp;
 use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Mailer\MailerInterface;
 use EightshiftForms\Validation\ValidatorInterface;
 
 /**
@@ -42,20 +43,30 @@ class FormSubmitMailchimpRoute extends AbstractFormSubmit
 	protected $mailchimpClient;
 
 	/**
+	 * Instance variable of MailerInterface data.
+	 *
+	 * @var MailerInterface
+	 */
+	public $mailer;
+
+	/**
 	 * Create a new instance that injects classes
 	 *
 	 * @param ValidatorInterface $validator Inject ValidatorInterface which holds validation methods.
 	 * @param LabelsInterface $labels Inject LabelsInterface which holds labels data.
 	 * @param MailchimpClientInterface $mailchimpClient Inject Mailchimp which holds Mailchimp connect data.
+	 * @param MailerInterface $mailer Inject MailerInterface which holds mailer methods.
 	 */
 	public function __construct(
 		ValidatorInterface $validator,
 		LabelsInterface $labels,
-		MailchimpClientInterface $mailchimpClient
+		MailchimpClientInterface $mailchimpClient,
+		MailerInterface $mailer
 	) {
 		$this->validator = $validator;
 		$this->labels = $labels;
 		$this->mailchimpClient = $mailchimpClient;
+		$this->mailer = $mailer;
 	}
 
 	/**
@@ -98,6 +109,11 @@ class FormSubmitMailchimpRoute extends AbstractFormSubmit
 			[],
 			$formId
 		);
+
+		if ($response['status'] === 'error') {
+			// Send fallback email.
+			$this->mailer->fallbackEmail($response['data'] ?? []);
+		}
 
 		// Finish.
 		return \rest_ensure_response([

--- a/src/Rest/Routes/FormSubmitMailerliteRoute.php
+++ b/src/Rest/Routes/FormSubmitMailerliteRoute.php
@@ -15,6 +15,7 @@ use EightshiftForms\Helpers\UploadHelper;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\Mailerlite\SettingsMailerlite;
 use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Mailer\MailerInterface;
 use EightshiftForms\Validation\ValidatorInterface;
 
 /**
@@ -54,20 +55,31 @@ class FormSubmitMailerliteRoute extends AbstractFormSubmit
 	protected $mailerliteClient;
 
 	/**
+	 * Instance variable of MailerInterface data.
+	 *
+	 * @var MailerInterface
+	 */
+	public $mailer;
+
+	/**
 	 * Create a new instance that injects classes
 	 *
 	 * @param ValidatorInterface $validator Inject ValidatorInterface which holds validation methods.
 	 * @param LabelsInterface $labels Inject LabelsInterface which holds labels data.
 	 * @param ClientInterface $mailerliteClient Inject Mailerlite which holds Mailerlite connect data.
+	 * @param MailerInterface $mailer Inject MailerInterface which holds mailer methods.
 	 */
 	public function __construct(
 		ValidatorInterface $validator,
 		LabelsInterface $labels,
-		ClientInterface $mailerliteClient
+		ClientInterface $mailerliteClient,
+		MailerInterface $mailer
+		
 	) {
 		$this->validator = $validator;
 		$this->labels = $labels;
 		$this->mailerliteClient = $mailerliteClient;
+		$this->mailer = $mailer;
 	}
 
 	/**
@@ -111,6 +123,11 @@ class FormSubmitMailerliteRoute extends AbstractFormSubmit
 			[],
 			$formId
 		);
+
+		if ($response['status'] === 'error') {
+			// Send fallback email.
+			$this->mailer->fallbackEmail($response['data'] ?? []);
+		}
 
 		// Finish.
 		return \rest_ensure_response([

--- a/src/Rest/Routes/FormSubmitMailerliteRoute.php
+++ b/src/Rest/Routes/FormSubmitMailerliteRoute.php
@@ -74,7 +74,6 @@ class FormSubmitMailerliteRoute extends AbstractFormSubmit
 		LabelsInterface $labels,
 		ClientInterface $mailerliteClient,
 		MailerInterface $mailer
-		
 	) {
 		$this->validator = $validator;
 		$this->labels = $labels;

--- a/src/Settings/Settings/SettingsAll.php
+++ b/src/Settings/Settings/SettingsAll.php
@@ -20,6 +20,46 @@ use EightshiftForms\Hooks\Filters;
 class SettingsAll extends AbstractFormBuilder implements SettingsAllInterface
 {
 	/**
+	 * Settings sidebar type - general
+	 *
+	 * @var string
+	 */
+	public const SETTINGS_SIEDBAR_TYPE_GENERAL = 'general';
+
+	/**
+	 * Settings sidebar type - integration
+	 *
+	 * @var string
+	 */
+	public const SETTINGS_SIEDBAR_TYPE_INTEGRATION = 'integration';
+
+	/**
+	 * Settings sidebar type - troubleshooting
+	 *
+	 * @var string
+	 */
+	public const SETTINGS_SIEDBAR_TYPE_TROUBLESHOOTING = 'troubleshooting';
+
+	/**
+	 * Settings sidebar type - develop
+	 *
+	 * @var string
+	 */
+	public const SETTINGS_SIEDBAR_TYPE_DEVELOP = 'develop';
+
+	/**
+	 * Sidebar Sort order.
+	 *
+	 * @var array<string>
+	 */
+	public const SIDEBAR_SORT_ORDER = [
+		self::SETTINGS_SIEDBAR_TYPE_GENERAL,
+		self::SETTINGS_SIEDBAR_TYPE_INTEGRATION,
+		self::SETTINGS_SIEDBAR_TYPE_TROUBLESHOOTING,
+		self::SETTINGS_SIEDBAR_TYPE_DEVELOP
+	];
+
+	/**
 	 * Get all settings sidebar array for building settings page.
 	 *
 	 * @param string $formId Form ID.

--- a/src/Settings/Settings/SettingsGeneral.php
+++ b/src/Settings/Settings/SettingsGeneral.php
@@ -101,6 +101,7 @@ class SettingsGeneral implements SettingsDataInterface, ServiceInterface
 			'label' => \__('General', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_GENERAL,
 		];
 	}
 

--- a/src/Settings/Settings/SettingsLocation.php
+++ b/src/Settings/Settings/SettingsLocation.php
@@ -62,6 +62,7 @@ class SettingsLocation implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Display locations', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_TROUBLESHOOTING,
 		];
 	}
 

--- a/src/Settings/Settings/SettingsTest.php
+++ b/src/Settings/Settings/SettingsTest.php
@@ -61,6 +61,7 @@ class SettingsTest implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Test', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_DEVELOP,
 		];
 	}
 

--- a/src/Troubleshooting/SettingsTroubleshooting.php
+++ b/src/Troubleshooting/SettingsTroubleshooting.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Troubleshooting Settings class.
+ *
+ * @package EightshiftForms\Troubleshooting
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Troubleshooting;
+
+use EightshiftForms\Hooks\Filters;
+use EightshiftForms\Labels\Labels;
+use EightshiftForms\Settings\SettingsHelper;
+use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Helpers\Helper;
+use EightshiftForms\Settings\Settings\SettingsDataInterface;
+use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
+
+/**
+ * SettingsTroubleshooting class.
+ */
+class SettingsTroubleshooting implements SettingsDataInterface, ServiceInterface
+{
+	/**
+	 * Use general helper trait.
+	 */
+	use SettingsHelper;
+
+		/**
+	 * Filter settings sidebar key.
+	 */
+	public const FILTER_SETTINGS_SIDEBAR_NAME = 'es_forms_settings_sidebar_troubleshooting';
+
+	/**
+	 * Filter global settings key.
+	 */
+	public const FILTER_SETTINGS_GLOBAL_NAME = 'es_forms_settings_global_troubleshooting';
+
+	/**
+	 * Filter settings is Valid key.
+	 */
+	public const FILTER_SETTINGS_IS_VALID_NAME = 'es_forms_settings_is_valid_troubleshooting';
+
+	/**
+	 * Settings key.
+	 */
+	public const SETTINGS_TYPE_KEY = 'troubleshooting';
+
+	/**
+	 * Troubleshooting Use key.
+	 */
+	public const SETTINGS_TROUBLESHOOTING_USE_KEY = 'troubleshooting-use';
+
+	/**
+	 * Fallback Email key.
+	 */
+	public const SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY = 'troubleshooting-fallback-email';
+
+	/**
+	 * Register all the hooks
+	 *
+	 * @return void
+	 */
+	public function register(): void
+	{
+		\add_filter(self::FILTER_SETTINGS_SIDEBAR_NAME, [$this, 'getSettingsSidebar']);
+		\add_filter(self::FILTER_SETTINGS_GLOBAL_NAME, [$this, 'getSettingsGlobalData']);
+		\add_filter(self::FILTER_SETTINGS_IS_VALID_NAME, [$this, 'isSettingsGlobalValid']);
+	}
+
+	/**
+	 * Determine if settings global are valid.
+	 *
+	 * @return boolean
+	 */
+	public function isSettingsGlobalValid(): bool
+	{
+		$isUsed = $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_USE_KEY, self::SETTINGS_TROUBLESHOOTING_USE_KEY);
+		$email = $this->getOptionValue(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY);
+
+		if (!$isUsed || empty($email)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get Settings sidebar data.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getSettingsSidebar(): array
+	{
+		return [
+			'label' => \__('Troubleshooting', 'eightshift-forms'),
+			'value' => self::SETTINGS_TYPE_KEY,
+			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+		];
+	}
+
+	/**
+	 * Get Form settings data array
+	 *
+	 * @param string $formId Form Id.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getSettingsData(string $formId): array
+	{
+		return [];
+	}
+
+	/**
+	 * Get global settings array for building settings page.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getSettingsGlobalData(): array
+	{
+		$output = [
+			[
+				'component' => 'intro',
+				'introTitle' => \__('Fallback emails', 'eightshift-forms'),
+				'introSubtitle' => \__('Your forms will send email fallbacks with all the data if there is any kind of error. This can email can be used to debug or provide manual input of the data to any integration.', 'eightshift-forms'),
+			],
+			[
+				'component' => 'checkboxes',
+				'checkboxesFieldLabel' => '',
+				'checkboxesName' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_USE_KEY),
+				'checkboxesId' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_USE_KEY),
+				'checkboxesContent' => [
+					[
+						'component' => 'checkbox',
+						'checkboxLabel' => \__('Use Fallback emails', 'eightshift-forms'),
+						'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_USE_KEY, self::SETTINGS_TROUBLESHOOTING_USE_KEY),
+						'checkboxValue' => self::SETTINGS_TROUBLESHOOTING_USE_KEY,
+						'checkboxSingleSubmit' => true,
+					]
+				]
+			],
+		];
+
+		$isUsedFallbackEmails = $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_USE_KEY, self::SETTINGS_TROUBLESHOOTING_USE_KEY);
+
+		if ($isUsedFallbackEmails) {
+			$output[] = [
+				'component' => 'input',
+				'inputName' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY),
+				'inputId' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY),
+				'inputFieldLabel' => \__('Fallback e-mail', 'eightshift-forms'),
+				'inputFieldHelp' => \__('Set email where all fallback emails will be sent.', 'eightshift-forms'),
+				'inputType' => 'text',
+				'inputIsEmail' => true,
+				'inputIsRequired' => true,
+				'inputValue' => $this->getOptionValue(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY),
+			];
+		}
+
+		return $output;
+	}
+}

--- a/src/Troubleshooting/SettingsTroubleshooting.php
+++ b/src/Troubleshooting/SettingsTroubleshooting.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 namespace EightshiftForms\Troubleshooting;
 
 use EightshiftForms\Hooks\Filters;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\SettingsHelper;
-use EightshiftForms\Settings\Settings\SettingsDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
  * SettingsTroubleshooting class.
  */
-class SettingsTroubleshooting implements SettingsDataInterface, ServiceInterface
+class SettingsTroubleshooting implements ServiceInterface, SettingsTroubleshootingDataInterface
 {
 	/**
 	 * Use general helper trait.
@@ -54,6 +54,14 @@ class SettingsTroubleshooting implements SettingsDataInterface, ServiceInterface
 	 * Fallback Email key.
 	 */
 	public const SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY = 'troubleshooting-fallback-email';
+
+	/**
+	 * Troubleshooting debugging key.
+	 */
+	public const SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY = 'troubleshooting-debugging';
+	public const SETTINGS_TROUBLESHOOTING_SKIP_VALIDATION_KEY = 'skip-validation';
+	public const SETTINGS_TROUBLESHOOTING_SKIP_RESET_KEY = 'skip-reset';
+	public const SETTINGS_TROUBLESHOOTING_LOG_MODE_KEY = 'log-mode';
 
 	/**
 	 * Register all the hooks
@@ -95,6 +103,7 @@ class SettingsTroubleshooting implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Troubleshooting', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_TROUBLESHOOTING,
 		];
 	}
 
@@ -121,7 +130,7 @@ class SettingsTroubleshooting implements SettingsDataInterface, ServiceInterface
 			[
 				'component' => 'intro',
 				'introTitle' => \__('Fallback emails', 'eightshift-forms'),
-				'introSubtitle' => \__('Your forms will send email fallbacks with all the data if there is any kind of error. This can email can be used to debug or provide manual input of the data to any integration.', 'eightshift-forms'),
+				'introSubtitle' => \__('Your forms will send email fallbacks with all the data if there is any kind of error. This email can be used to debug or provide manual input of the data to any integration.', 'eightshift-forms'),
 			],
 			[
 				'component' => 'checkboxes',
@@ -148,14 +157,91 @@ class SettingsTroubleshooting implements SettingsDataInterface, ServiceInterface
 				'inputName' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY),
 				'inputId' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY),
 				'inputFieldLabel' => \__('Fallback e-mail', 'eightshift-forms'),
-				'inputFieldHelp' => \__('Set email where all fallback emails will be sent.', 'eightshift-forms'),
+				'inputFieldHelp' => \__('Set email where all fallback emails will be sent. Use comma to separate multiple emails.', 'eightshift-forms'),
 				'inputType' => 'text',
-				'inputIsEmail' => true,
 				'inputIsRequired' => true,
 				'inputValue' => $this->getOptionValue(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY),
 			];
 		}
 
-		return $output;
+		$outputDebugging = [
+			[
+				'component' => 'divider',
+			],
+			[
+				'component' => 'intro',
+				'introTitle' => \__('Debugging', 'eightshift-forms'),
+				'introSubtitle' => \__('Settings used for debugging forms. USE WITH CAUTION!', 'eightshift-forms'),
+			],
+			[
+				'component' => 'checkboxes',
+				'checkboxesFieldLabel' => '',
+				'checkboxesName' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY),
+				'checkboxesId' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY),
+				'checkboxesContent' => [
+					[
+						'component' => 'checkbox',
+						'checkboxLabel' => \__('Skip validation', 'eightshift-forms'),
+						'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_SKIP_VALIDATION_KEY, self::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY),
+						'checkboxValue' => self::SETTINGS_TROUBLESHOOTING_SKIP_VALIDATION_KEY,
+					],
+					[
+						'component' => 'checkbox',
+						'checkboxLabel' => \__('Skip form reset after submit', 'eightshift-forms'),
+						'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_SKIP_RESET_KEY, self::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY),
+						'checkboxValue' => self::SETTINGS_TROUBLESHOOTING_SKIP_RESET_KEY,
+					],
+					[
+						'component' => 'checkbox',
+						'checkboxLabel' => \__('Output logs', 'eightshift-forms'),
+						'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_LOG_MODE_KEY, self::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY),
+						'checkboxValue' => self::SETTINGS_TROUBLESHOOTING_LOG_MODE_KEY,
+					]
+				]
+			],
+		];
+
+		return [
+			...$output,
+			...$outputDebugging,
+		];
+	}
+
+	/**
+	 * Output array settings for form.
+	 *
+	 * @param string $integration Integration name used for troubleshooting.
+	 *
+	 * @return array<int, array<string, array<int|string, array<string, mixed>>|bool|string>>
+	 */
+	public function getOutputGlobalTroubleshooting(string $integration): array
+	{
+		$isValid = $this->isSettingsGlobalValid();
+
+		if (!$isValid) {
+			return [];
+		}
+
+		return [
+			[
+				'component' => 'divider',
+			],
+			[
+				'component' => 'intro',
+				'introTitle' => \__('Troubleshooting', 'eightshift-forms'),
+				'introSubtitle' => \__('Your forms will send email fallbacks with all the data if there is any kind of error. This email can be used to debug or provide manual input of the data to any integration.', 'eightshift-forms'),
+				'introTitleSize' => 'medium',
+			],
+			[
+				'component' => 'input',
+				'inputName' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY . '-' . $integration),
+				'inputId' => $this->getSettingsName(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY . '-' . $integration),
+				'inputFieldLabel' => \__('Fallback e-mail', 'eightshift-forms'),
+				'inputFieldHelp' => \__('Set email where this integration fallback emails will be sent. This field will be used as "cc", main "from" field will be used from the main Troubleshooting global setting page. Use comma to separate multiple emails.', 'eightshift-forms'),
+				'inputType' => 'text',
+				'inputIsRequired' => true,
+				'inputValue' => $this->getOptionValue(self::SETTINGS_TROUBLESHOOTING_FALLBACK_EMAIL_KEY . '-' . $integration),
+			],
+		];
 	}
 }

--- a/src/Troubleshooting/SettingsTroubleshooting.php
+++ b/src/Troubleshooting/SettingsTroubleshooting.php
@@ -11,10 +11,7 @@ declare(strict_types=1);
 namespace EightshiftForms\Troubleshooting;
 
 use EightshiftForms\Hooks\Filters;
-use EightshiftForms\Labels\Labels;
 use EightshiftForms\Settings\SettingsHelper;
-use EightshiftForms\Labels\LabelsInterface;
-use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
@@ -28,7 +25,7 @@ class SettingsTroubleshooting implements SettingsDataInterface, ServiceInterface
 	 */
 	use SettingsHelper;
 
-		/**
+	/**
 	 * Filter settings sidebar key.
 	 */
 	public const FILTER_SETTINGS_SIDEBAR_NAME = 'es_forms_settings_sidebar_troubleshooting';

--- a/src/Troubleshooting/SettingsTroubleshootingDataInterface.php
+++ b/src/Troubleshooting/SettingsTroubleshootingDataInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Interface that holds all methods for Troubleshooting settings.
+ *
+ * @package EightshiftForms\Troubleshooting
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Troubleshooting;
+
+use EightshiftForms\Settings\Settings\SettingsDataInterface;
+
+/**
+ * Interface for SettingsTroubleshootingDataInterface.
+ */
+interface SettingsTroubleshootingDataInterface extends SettingsDataInterface
+{
+	/**
+	 * Output array settings for form.
+	 *
+	 * @param string $integration Integration name used for troubleshooting.
+	 *
+	 * @return array<int, array<string, array<int|string, array<string, mixed>>|bool|string>>
+	 */
+	public function getOutputGlobalTroubleshooting(string $integration): array;
+}

--- a/src/Validation/SettingsCaptcha.php
+++ b/src/Validation/SettingsCaptcha.php
@@ -14,6 +14,7 @@ use EightshiftForms\Hooks\Filters;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
@@ -130,6 +131,7 @@ class SettingsCaptcha implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Captcha', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_GENERAL,
 		];
 	}
 

--- a/src/Validation/SettingsValidation.php
+++ b/src/Validation/SettingsValidation.php
@@ -15,6 +15,7 @@ use EightshiftForms\Labels\Labels;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Labels\LabelsInterface;
 use EightshiftForms\Helpers\Helper;
+use EightshiftForms\Settings\Settings\SettingsAll;
 use EightshiftForms\Settings\Settings\SettingsDataInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
@@ -101,6 +102,7 @@ class SettingsValidation implements SettingsDataInterface, ServiceInterface
 			'label' => \__('Validation', 'eightshift-forms'),
 			'value' => self::SETTINGS_TYPE_KEY,
 			'icon' => Filters::ALL[self::SETTINGS_TYPE_KEY]['icon'],
+			'type' => SettingsAll::SETTINGS_SIEDBAR_TYPE_GENERAL,
 		];
 	}
 


### PR DESCRIPTION
# Description

New feature in forms for the end of the week:
you will now be able to send a fallback email for all integrations, if the integrations fails you will get the email with all the data and all files that user sent for the debugging. This is really helpful feature to see how many forms are failing in production and why. In the end you will always have the data and you can manually add the entry in the application.
This feature will be optional and could be set from settings page.
Also after consultations with Karlo I  will be adding the option to add additional emails for individual integrations. So the developers can get all emails, marketing could get HubSpot integration emails, HR could get Greenhouse and etc.

# Screenshots / Videos
![Screenshot 2022-09-02 at 15 13 09](https://user-images.githubusercontent.com/23283324/188155288-4bd08c5c-bc99-43bf-b413-8b8f73e58d11.png)
![Screenshot 2022-09-02 at 15 13 13](https://user-images.githubusercontent.com/23283324/188155305-d14fa895-faf6-4740-b023-d80e3d60db74.png)
![Screenshot 2022-09-02 at 15 17 13](https://user-images.githubusercontent.com/23283324/188155309-f523519b-1b0b-4af7-9daa-370937542e0a.png)
