### PR TITLE
adding output log hook

### DIFF
--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -203,7 +203,7 @@ export class Form {
 		.then((response) => {
 			// On success state.
 			if (response.code === 200) {
-				this.formSubmit(element,);
+				this.formSubmit(element);
 			}
 
 			// Normal errors.

--- a/src/General/General.php
+++ b/src/General/General.php
@@ -44,7 +44,7 @@ class General implements ServiceInterface
 	 */
 	public function getHttpRequestArgs(array $args): array
 	{
-		$filterName = Filters::getGeneralSettingsFilterName('httpRequestTimeout');
+		$filterName = Filters::getGeneralFilterName('httpRequestTimeout');
 
 		$args['timeout'] = \apply_filters($filterName, self::HTTP_REQUEST_TIMEOUT_DEFAULT);
 

--- a/src/Geolocation/Geolocation.md
+++ b/src/Geolocation/Geolocation.md
@@ -35,3 +35,7 @@ All releases are listed here: https://datahub.io/core/country-list
 
 Files used:
 * manifest.json
+
+
+# License
+This product includes GeoLite2 data created by MaxMind, available from: [https://www.maxmind.com](https://www.maxmind.com).

--- a/src/Geolocation/SettingsGeolocation.php
+++ b/src/Geolocation/SettingsGeolocation.php
@@ -111,7 +111,8 @@ class SettingsGeolocation implements SettingsDataInterface, ServiceInterface
 			[
 				'component' => 'intro',
 				'introTitle' => \__('Geolocation', 'eightshift-forms'),
-				'introSubtitle' => \__('Allows conditionally rendering different forms based on the user\'s location. Uses a local geolocation API. Consult documentation for more info.', 'eightshift-forms'),
+				// translators: %s provides the link to external source.
+				'introSubtitle' => \sprintf(\__('Allows conditionally rendering different forms based on the user\'s location. Uses a local geolocation API. Consult documentation for more info. <br />This product includes GeoLite2 data created by MaxMind, available from <a href="%1$s">%1$s</a>.', 'eightshift-forms'), 'https://www.maxmind.com'),
 			],
 			[
 				'component' => 'checkboxes',

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -14,6 +14,7 @@ use EightshiftForms\AdminMenus\FormGlobalSettingsAdminSubMenu;
 use EightshiftForms\AdminMenus\FormSettingsAdminSubMenu;
 use EightshiftForms\AdminMenus\FormListingAdminSubMenu;
 use EightshiftForms\CustomPostType\Forms;
+use EightshiftForms\Hooks\Filters;
 use EightshiftForms\Settings\Settings\SettingsGeneral;
 
 /**
@@ -190,22 +191,28 @@ class Helper
 	/**
 	 * Provide error log output to a custom log file.
 	 *
-	 * @param array<mixed> $message Any type of message.
+	 * @param array<mixed> $data Data array to output.
 	 *
 	 * @return void
 	 */
-	public static function logger(array $message): void
+	public static function logger(array $data): void
 	{
 		$wpContentDir = \defined('WP_CONTENT_DIR') ? \WP_CONTENT_DIR : '';
 
 		if (!empty($wpContentDir)) {
-			$message['time'] = \gmdate("Y-m-d H:i:s");
+			$data['time'] = \gmdate("Y-m-d H:i:s");
 
-			if (isset($message['files'])) {
-				unset($message['files']);
+			if (isset($data['files'])) {
+				unset($data['files']);
 			}
 
-			\error_log((string) \wp_json_encode($message) . "\n -------------------------------------", 3, \WP_CONTENT_DIR . '/eightshift-forms-debug.log'); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			$filterName = Filters::getTroubleshootingFilterName('outputLog');
+
+			if (\has_filter($filterName)) {
+				\apply_filters($filterName, $data);
+			} else {
+				\error_log((string) \wp_json_encode($data) . "\n -------------------------------------", 3, \WP_CONTENT_DIR . '/eightshift-forms-debug.log'); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
 		}
 	}
 

--- a/src/Hooks/Filters.php
+++ b/src/Hooks/Filters.php
@@ -278,6 +278,9 @@ class Filters
 		'general' => [
 			'httpRequestTimeout' => 'http_request_timeout',
 		],
+		'troubleshooting' => [
+			'outputLog' => 'output_log',
+		],
 	];
 
 	/**
@@ -407,7 +410,7 @@ class Filters
 	 *
 	 * @example filter_name es_forms_validation_force_mimetype_from_fs
 	 */
-	public static function getValidationSettingsFilterName(string $name): string
+	public static function getValidationFilterName(string $name): string
 	{
 		$filter = self::ALL_PUBLIC['validation'][$name] ?? '';
 		if (!$filter) {
@@ -426,9 +429,9 @@ class Filters
 	 *
 	 * @return string
 	 *
-	 * @example filter_name es_forms_general_http_request_args
+	 * @example filter_name es_forms_general_http_request_timeout
 	 */
-	public static function getGeneralSettingsFilterName(string $name): string
+	public static function getGeneralFilterName(string $name): string
 	{
 		$filter = self::ALL_PUBLIC['general'][$name] ?? '';
 		if (!$filter) {
@@ -436,5 +439,26 @@ class Filters
 		}
 
 		return self::FILTER_PREFIX . "_general_{$filter}";
+	}
+
+	/**
+	 * Get Troubleshooting filter by name.
+	 *
+	 * @param string $name Filter name.
+	 *
+	 * @throws MissingFilterInfoException Throws error if filter name is missing or wrong.
+	 *
+	 * @return string
+	 *
+	 * @example filter_name es_forms_troubleshooting_output_log
+	 */
+	public static function getTroubleshootingFilterName(string $name): string
+	{
+		$filter = self::ALL_PUBLIC['troubleshooting'][$name] ?? '';
+		if (!$filter) {
+			throw MissingFilterInfoException::viewException('troubleshooting', '', $name);
+		}
+
+		return self::FILTER_PREFIX . "_troubleshooting_{$filter}";
 	}
 }

--- a/src/Hooks/FiltersTroubleshooting.md
+++ b/src/Hooks/FiltersTroubleshooting.md
@@ -1,0 +1,28 @@
+# Filters Troubleshooting
+This document will provide you with the code examples for forms filters used in troubleshooting.
+
+## Output debug logs to external source
+This filter provides you with the ability to output internal debug log to an external source.
+
+**Filter name:**
+`es_forms_troubleshooting_output_log`
+
+**Filter example:**
+```php
+// Change the default output log location.
+add_filter('es_forms_troubleshooting_output_log', [$this, 'getGeolocationCountriesList']);
+
+/**
+ * Change the default output log location.
+ *
+ * @param array<mixed> $data Data to output.
+ *
+ * @return bool
+ */
+public function getGeolocationCountriesList(array $data): bool
+{
+	// Do your magic here.
+
+	return true;
+}
+```

--- a/src/Integrations/Greenhouse/GreenhouseClient.php
+++ b/src/Integrations/Greenhouse/GreenhouseClient.php
@@ -146,7 +146,7 @@ class GreenhouseClient implements ClientInterface
 			$paramsFiles
 		);
 
-		$filterName = Filters::getGeneralSettingsFilterName('httpRequestTimeout');
+		$filterName = Filters::getGeneralFilterName('httpRequestTimeout');
 
 		$url = self::BASE_URL . "boards/{$this->getBoardToken()}/jobs/{$itemId}";
 

--- a/src/Rest/Routes/FormSubmitCaptchaRoute.php
+++ b/src/Rest/Routes/FormSubmitCaptchaRoute.php
@@ -14,6 +14,7 @@ use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Settings\SettingsHelper;
 use EightshiftForms\Labels\LabelsInterface;
+use EightshiftForms\Troubleshooting\SettingsTroubleshooting;
 use EightshiftForms\Validation\SettingsCaptcha;
 use Throwable;
 use WP_REST_Request;
@@ -80,6 +81,15 @@ class FormSubmitCaptchaRoute extends AbstractBaseRoute
 	 */
 	public function routeCallback(WP_REST_Request $request)
 	{
+		// Bailout if troubleshooting skip captcha is on.
+		if ($this->isCheckboxOptionChecked(SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_SKIP_CAPTCHA_KEY, SettingsTroubleshooting::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY)) {
+			return \rest_ensure_response([
+				'status' => 'success',
+				'code' => 200,
+				'message' => \esc_html__('Form captcha skipped due to troubleshooting config set in settings.', 'eightshift-forms'),
+			]);
+		}
+
 		try {
 			$params = \json_decode($request->get_body(), true, 512, JSON_THROW_ON_ERROR); // phpcs:ignore
 		} catch (Throwable $t) {

--- a/src/Troubleshooting/SettingsTroubleshooting.php
+++ b/src/Troubleshooting/SettingsTroubleshooting.php
@@ -61,6 +61,7 @@ class SettingsTroubleshooting implements ServiceInterface, SettingsTroubleshooti
 	public const SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY = 'troubleshooting-debugging';
 	public const SETTINGS_TROUBLESHOOTING_SKIP_VALIDATION_KEY = 'skip-validation';
 	public const SETTINGS_TROUBLESHOOTING_SKIP_RESET_KEY = 'skip-reset';
+	public const SETTINGS_TROUBLESHOOTING_SKIP_CAPTCHA_KEY = 'skip-captcha';
 	public const SETTINGS_TROUBLESHOOTING_LOG_MODE_KEY = 'log-mode';
 
 	/**
@@ -190,6 +191,12 @@ class SettingsTroubleshooting implements ServiceInterface, SettingsTroubleshooti
 						'checkboxLabel' => \__('Skip form reset after submit', 'eightshift-forms'),
 						'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_SKIP_RESET_KEY, self::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY),
 						'checkboxValue' => self::SETTINGS_TROUBLESHOOTING_SKIP_RESET_KEY,
+					],
+					[
+						'component' => 'checkbox',
+						'checkboxLabel' => \__('Skip captcha', 'eightshift-forms'),
+						'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_TROUBLESHOOTING_SKIP_CAPTCHA_KEY, self::SETTINGS_TROUBLESHOOTING_DEBUGGING_KEY),
+						'checkboxValue' => self::SETTINGS_TROUBLESHOOTING_SKIP_CAPTCHA_KEY,
 					],
 					[
 						'component' => 'checkbox',

--- a/src/Validation/AbstractValidation.php
+++ b/src/Validation/AbstractValidation.php
@@ -95,7 +95,7 @@ abstract class AbstractValidation implements ValidatorInterface
 	 */
 	public function isMimeTypeValid(array $file): bool
 	{
-		$denyIfFileIsNotUploaded = \apply_filters(Filters::getValidationSettingsFilterName('failMimetypeValidationWhenFileNotOnFS'), false); // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
+		$denyIfFileIsNotUploaded = \apply_filters(Filters::getValidationFilterName('failMimetypeValidationWhenFileNotOnFS'), false); // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
 
 		if (\getenv('TEST')) {
 			$denyIfFileIsNotUploaded = \getenv('test_force_option_eightshift_forms_force_mimetype_from_fs');


### PR DESCRIPTION
# Description

## Added
- new filter `es_forms_troubleshooting_output_log` provides the ability to output internal logs to an external source.
- new toggle button in troubleshooting settings will enable you to skip captcha validation.
- geolocation license copy

## Fixed
- internal filter naming for functions
