### PR TITLE
adding developer mode

### DIFF
--- a/src/AdminMenus/FormAdminMenu.php
+++ b/src/AdminMenus/FormAdminMenu.php
@@ -15,6 +15,8 @@ use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Hooks\Filters;
 use EightshiftForms\Settings\Listing\FormListingInterface;
 use EightshiftForms\Settings\Settings\Settings;
+use EightshiftForms\Settings\SettingsHelper;
+use EightshiftForms\Troubleshooting\SettingsDebug;
 use EightshiftFormsVendor\EightshiftLibs\AdminMenus\AbstractAdminMenu;
 
 /**
@@ -22,6 +24,11 @@ use EightshiftFormsVendor\EightshiftLibs\AdminMenus\AbstractAdminMenu;
  */
 class FormAdminMenu extends AbstractAdminMenu
 {
+	/**
+	 * Use general helper trait.
+	 */
+	use SettingsHelper;
+
 	/**
 	 * Instance variable for listing data.
 	 *
@@ -245,6 +252,7 @@ class FormAdminMenu extends AbstractAdminMenu
 			'adminListingType' => $status,
 			'adminListingListingLink' => $listingLink,
 			'adminListingIntegrations' => $filter,
+			'adminListingIsDeveloperMode' => $this->isCheckboxOptionChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY),
 		];
 	}
 }

--- a/src/AdminMenus/FormSettingsAdminSubMenu.php
+++ b/src/AdminMenus/FormSettingsAdminSubMenu.php
@@ -14,6 +14,8 @@ use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
 use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Settings\Settings\SettingsInterface;
 use EightshiftForms\Settings\Settings\SettingsGeneral;
+use EightshiftForms\Settings\SettingsHelper;
+use EightshiftForms\Troubleshooting\SettingsDebug;
 use EightshiftFormsVendor\EightshiftLibs\AdminMenus\AbstractAdminSubMenu;
 
 /**
@@ -21,6 +23,11 @@ use EightshiftFormsVendor\EightshiftLibs\AdminMenus\AbstractAdminSubMenu;
  */
 class FormSettingsAdminSubMenu extends AbstractAdminSubMenu
 {
+	/**
+	 * Use general helper trait.
+	 */
+	use SettingsHelper;
+
 	/**
 	 * Instance variable for all settings.
 	 *
@@ -181,7 +188,13 @@ class FormSettingsAdminSubMenu extends AbstractAdminSubMenu
 			return [];
 		}
 
+		$isDeveloperMode = $this->isCheckboxOptionChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+
 		$formTitle = \get_the_title((int) $formId);
+
+		if ($isDeveloperMode) {
+			$formTitle = "{$formId} - {$formTitle}";
+		}
 
 		if (!$formTitle) {
 			$formTitle = \esc_html__('No form title', 'eightshift-forms');
@@ -189,6 +202,7 @@ class FormSettingsAdminSubMenu extends AbstractAdminSubMenu
 
 		$integrationTypeUsed = Helper::getUsedFormTypeById($formId);
 		$formEditLink = Helper::getFormEditPageUrl($formId);
+
 		return [
 			// translators: %s replaces the form name.
 			'adminSettingsPageTitle' => \sprintf(\esc_html__('Form settings: %s', 'eightshift-forms'), $formTitle),

--- a/src/Blocks/components/admin-listing/admin-listing.php
+++ b/src/Blocks/components/admin-listing/admin-listing.php
@@ -27,6 +27,7 @@ $adminListingForms = Components::checkAttr('adminListingForms', $attributes, $ma
 $adminListingType = Components::checkAttr('adminListingType', $attributes, $manifest);
 $adminListingListingLink = Components::checkAttr('adminListingListingLink', $attributes, $manifest);
 $adminListingIntegrations = Components::checkAttr('adminListingIntegrations', $attributes, $manifest);
+$adminListingIsDeveloperMode = Components::checkAttr('adminListingIsDeveloperMode', $attributes, $manifest);
 
 $layoutClass = Components::classnames([
 	Components::selector($componentClass, $componentClass),
@@ -131,7 +132,15 @@ $layoutClass = Components::classnames([
 										<svg class="<?php echo esc_attr("{$componentClass}__label-icon"); ?>" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 11.75h5m-5 3h5" stroke="currentColor" stroke-opacity=".12" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M4.5 8.75h5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><circle cx="5" cy="11.75" r="1" fill="currentColor"/><circle cx="5" cy="14.75" r="1" fill="currentColor"/><path d="M1 2a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v4H1V2z" fill="currentColor" fill-opacity=".12"/><rect x="1" y="1" width="18" height="18" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M4.5 3.75h8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></svg>
 									<?php } ?>
 
-									<span><?php echo $title ? esc_html($title) : esc_html($id); ?></span>
+									<span>
+										<?php
+										if ($adminListingIsDeveloperMode) {
+											echo esc_html("{$id} - {$title}");
+										} else {
+											echo $title ? esc_html($title) : esc_html($id);
+										}
+										?>
+									</span>
 
 									<?php if ($activeIntegration) { ?>
 										<div class="<?php echo esc_attr("{$componentClass}__integration"); ?>">

--- a/src/Blocks/components/admin-listing/manifest.json
+++ b/src/Blocks/components/admin-listing/manifest.json
@@ -28,6 +28,10 @@
 		},
 		"adminListingIntegrations": {
 			"type": "string"
+		},
+		"adminListingIsDeveloperMode": {
+			"type": "boolean",
+			"default": false
 		}
 	}
 }

--- a/src/Blocks/components/admin-settings/partials/sidebar-section.php
+++ b/src/Blocks/components/admin-settings/partials/sidebar-section.php
@@ -35,11 +35,13 @@ foreach ($items as $key => $innerItems) {
 					$url = $item['url'] ?? '';
 					$internalType = $item['type'] ?? '';
 					$icon = $item['icon'] ?? '';
+					$internalKey = $item['key'] ?? '';
+
 					?>
 					<li class="<?php echo esc_attr("{$sectionClass}__menu-item"); ?>">
 						<a
 							href="<?php echo esc_url($url); ?>"
-							class="<?php echo esc_attr("{$sectionClass}__menu-link " . Components::selector($internalType === $adminSettingsType, $sectionClass, 'menu-link', 'active')); ?>"
+							class="<?php echo esc_attr("{$sectionClass}__menu-link " . Components::selector($internalKey === $adminSettingsType, $sectionClass, 'menu-link', 'active')); ?>"
 						>
 							<span class="<?php echo esc_attr("{$sectionClass}__menu-link-wrap"); ?>">
 								<?php echo wp_kses_post($icon); ?>

--- a/src/Settings/Settings/Settings.php
+++ b/src/Settings/Settings/Settings.php
@@ -83,7 +83,8 @@ class Settings extends AbstractFormBuilder implements SettingsInterface
 				'label' => Filters::getSettingsLabels($key),
 				'url' => $formId ? Helper::getSettingsPageUrl($formId, $key) : Helper::getSettingsGlobalPageUrl($key),
 				'icon' => $value['icon'],
-				'type' => $value['type'],
+				'type' => $type,
+				'key' => $key,
 			];
 		}
 

--- a/src/Settings/Settings/SettingsLocation.php
+++ b/src/Settings/Settings/SettingsLocation.php
@@ -12,6 +12,7 @@ namespace EightshiftForms\Settings\Settings;
 
 use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Settings\SettingsHelper;
+use EightshiftForms\Troubleshooting\SettingsDebug;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -106,15 +107,21 @@ class SettingsLocation implements SettingInterface, ServiceInterface
 			return [];
 		}
 
+		$isDeveloperMode = $this->isCheckboxOptionChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+
 		return \array_map(
-			static function ($item) {
+			static function ($item) use ($isDeveloperMode) {
+				$id = $item->ID;
+				$title = $item->post_title; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+				$title = $isDeveloperMode ? "{$id} - {$title}" : $title;
+
 				return [
-					'id' => $item->ID,
+					'id' => $id,
 					'postType' => $item->post_type, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-					'title' => $item->post_title, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+					'title' => $title,
 					'status' => $item->post_status, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-					'editLink' => Helper::getFormEditPageUrl((string) $item->ID),
-					'viewLink' => \get_permalink($item->ID),
+					'editLink' => Helper::getFormEditPageUrl((string) $id),
+					'viewLink' => \get_permalink($id),
 				];
 			},
 			$items

--- a/src/Settings/SettingsHelper.php
+++ b/src/Settings/SettingsHelper.php
@@ -16,6 +16,7 @@ use EightshiftForms\Hooks\Filters;
 use EightshiftForms\Integrations\ClientInterface;
 use EightshiftForms\Integrations\Greenhouse\SettingsGreenhouse;
 use EightshiftForms\Settings\Settings\SettingsDashboard;
+use EightshiftForms\Troubleshooting\SettingsDebug;
 
 /**
  * SettingsHelper trait.
@@ -1030,6 +1031,8 @@ trait SettingsHelper
 		$lastUpdatedTime = $items[ClientInterface::TRANSIENT_STORED_TIME]['title'] ?? '';
 		unset($items[ClientInterface::TRANSIENT_STORED_TIME]);
 
+		$isDeveloperMode = $this->isCheckboxOptionChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+
 		return [
 			[
 				'component' => 'select',
@@ -1047,11 +1050,14 @@ trait SettingsHelper
 						]
 					],
 					\array_map(
-						function ($option) use ($formId, $key) {
+						function ($option) use ($formId, $key, $isDeveloperMode) {
+							$title = $option['title'] ?? '';
+							$id = $option['id'] ?? '';
+
 							return [
 								'component' => 'select-option',
-								'selectOptionLabel' => $option['title'] ?? '',
-								'selectOptionValue' => $option['id'] ?? '',
+								'selectOptionLabel' => $isDeveloperMode ? "{$id} - {$title}" : $title,
+								'selectOptionValue' => $id,
 								'selectOptionIsSelected' => $this->isCheckedSettings($option['id'], $key, $formId),
 							];
 						},
@@ -1081,6 +1087,8 @@ trait SettingsHelper
 		string $selectedFormId,
 		string $key
 	): array {
+		$isDeveloperMode = $this->isCheckboxOptionChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+
 		return [
 			[
 				'component' => 'select',
@@ -1096,11 +1104,14 @@ trait SettingsHelper
 						]
 					],
 					\array_map(
-						function ($option) use ($formId, $key) {
+						function ($option) use ($formId, $key, $isDeveloperMode) {
+							$title = $option['title'] ?? '';
+							$id = $option['id'] ?? '';
+
 							return [
 								'component' => 'select-option',
-								'selectOptionLabel' => $option['title'] ?? '',
-								'selectOptionValue' => $option['id'] ?? '',
+								'selectOptionLabel' => $isDeveloperMode ? "{$id} - {$title}" : $title,
+								'selectOptionValue' => $id,
 								'selectOptionIsSelected' => $this->isCheckedSettings($option['id'], $key, $formId),
 							];
 						},

--- a/src/Troubleshooting/SettingsDebug.php
+++ b/src/Troubleshooting/SettingsDebug.php
@@ -53,6 +53,7 @@ class SettingsDebug implements ServiceInterface, SettingInterface
 	public const SETTINGS_DEBUG_SKIP_RESET_KEY = 'skip-reset';
 	public const SETTINGS_DEBUG_SKIP_CAPTCHA_KEY = 'skip-captcha';
 	public const SETTINGS_DEBUG_LOG_MODE_KEY = 'log-mode';
+	public const SETTINGS_DEBUG_DEVELOPER_MODE_KEY = 'developer-mode';
 
 	/**
 	 * Register all the hooks
@@ -151,7 +152,14 @@ class SettingsDebug implements ServiceInterface, SettingInterface
 										'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_DEBUG_LOG_MODE_KEY, self::SETTINGS_DEBUG_DEBUGGING_KEY),
 										'checkboxValue' => self::SETTINGS_DEBUG_LOG_MODE_KEY,
 										'checkboxAsToggle' => true,
-									]
+									],
+									[
+										'component' => 'checkbox',
+										'checkboxLabel' => \__('Developer mode', 'eightshift-forms'),
+										'checkboxIsChecked' => $this->isCheckboxOptionChecked(self::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, self::SETTINGS_DEBUG_DEBUGGING_KEY),
+										'checkboxValue' => self::SETTINGS_DEBUG_DEVELOPER_MODE_KEY,
+										'checkboxAsToggle' => true,
+									],
 								]
 							],
 						],


### PR DESCRIPTION
# Description

### Added
- Developer mode option. With this mode, you can see all the internal IDs for the forms, settings, and integrations.

### Fixed
- Active sidebar link selector.

# Screenshots / Videos

![Screenshot 2022-11-21 at 23 41 40](https://user-images.githubusercontent.com/23283324/203174495-5217d84e-b184-4a94-9992-18404ac0adb7.png)
![Screenshot 2022-11-21 at 23 41 45](https://user-images.githubusercontent.com/23283324/203174497-e4ebd676-c2a9-4c52-ab32-74e4ae0c23e5.png)
![Screenshot 2022-11-21 at 23 41 51](https://user-images.githubusercontent.com/23283324/203174499-b6cad61b-d7a3-4439-9c4e-985caa253cc6.png)
![Screenshot 2022-11-21 at 23 43 57](https://user-images.githubusercontent.com/23283324/203174504-ca8e3d67-8f82-43fb-a19b-8723f07a0ce3.png)
