### PR TITLE
Adding fix for sync diff if there is an error with the integration

### DIFF
--- a/src/Blocks/components/utils/index.js
+++ b/src/Blocks/components/utils/index.js
@@ -16,6 +16,18 @@ import { AnimatedContentVisibility, camelize, classnames, IconLabel, icons, STOR
  *
  * @returns {boolean}
  */
+export const isDeveloperMode = () => {
+	return Boolean(esFormsLocalization?.isDeveloperMode);
+};
+
+/**
+ * check if block options is disabled by integration or other component.
+ *
+ * @param {string} key Key to check.
+ * @param {array} options Options array to check.
+ *
+ * @returns {boolean}
+ */
 export const isOptionDisabled = (key, options) => {
 	return options.includes(key);
 };
@@ -55,23 +67,25 @@ export const updateIntegrationBlocks = (clientId, postId, type, itemId, innerId 
  */
 export const syncIntegrationBlocks = (clientId, postId) => {
 	return apiFetch({ path: `${esFormsLocalization.restPrefixProject}${esFormsLocalization.restRoutes.integrationsEditorSync}/?id=${postId}` }).then((response) => {
-		resetInnerBlocks(clientId);
-
-		if (response.code === 200) {
-			const builtBlocks = createBlocksFromInnerBlocksTemplate(response?.data?.data?.output);
-
-			updateInnerBlocks(clientId, builtBlocks);
-
-			return {
-				update: response?.data?.data?.update,
-				removed: response?.data?.data?.removed,
-				added: response?.data?.data?.added,
-				replaced: response?.data?.data?.replaced,
-				changed: response?.data?.data?.changed,
-			};
+		if (isDeveloperMode()) {
+			console.log(response);
 		}
 
-		return null;
+		if (response.code === 200) {
+			resetInnerBlocks(clientId);
+			updateInnerBlocks(clientId, createBlocksFromInnerBlocksTemplate(response?.data?.data?.output));
+		}
+
+		return {
+			message: response?.message,
+			debugType: response?.data?.debugType,
+			status: response?.status,
+			update: response?.data?.data?.update,
+			removed: response?.data?.data?.removed,
+			added: response?.data?.data?.added,
+			replaced: response?.data?.data?.replaced,
+			changed: response?.data?.data?.changed,
+		};
 	});
 };
 

--- a/src/Blocks/custom/form-selector/components/form-selector-options.js
+++ b/src/Blocks/custom/form-selector/components/form-selector-options.js
@@ -16,7 +16,7 @@ export const FormSelectorOptions = ({
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [modalContent, setModalContent] = useState({});
 
-	const { createSuccessNotice, createNotice } = useDispatch(noticesStore);
+	const { createNotice } = useDispatch(noticesStore);
 
 	const activeIntegration = getActiveIntegrationBlockName(clientId);
 
@@ -108,18 +108,34 @@ export const FormSelectorOptions = ({
 						onClick={() => {
 							// Sync integration blocks.
 							syncIntegrationBlocks(clientId, postId).then((val) => {
-								setModalContent(val);
-
-								createNotice(val?.update ? 'success' : 'info', val?.update ? __('Sync complete!', 'eightshift-forms') : __('Nothing synced, form is up-to-date', 'eightshift-forms'), {
-									type: 'snackbar',
-									explicitDismiss: val?.update,
-									actions: val?.update ? [
+								if (val?.status === 'error') {
+									createNotice(
+										'error',
+										val?.message,
 										{
-											label: __('View report', 'eightshift-forms'),
-											onClick: () => setIsModalOpen(true),
+											type: 'snackbar',
+											icon: '❌',
 										}
-									] : [],
-								});
+									);
+								} else {
+									setModalContent(val);
+
+									createNotice(
+										val?.update ? 'success' : 'info',
+										val?.update ? __('Sync complete!', 'eightshift-forms') : __('Nothing synced, form is up-to-date', 'eightshift-forms'),
+										{
+											type: 'snackbar',
+											icon: '✅',
+											explicitDismiss: val?.update,
+											actions: val?.update ? [
+												{
+													label: __('View report', 'eightshift-forms'),
+													onClick: () => setIsModalOpen(true),
+												}
+											] : [],
+										}
+									);
+								}
 							});
 						}}
 						className='es-rounded-1 es-border-cool-gray-300 es-hover-border-cool-gray-400 es-transition'
@@ -133,7 +149,7 @@ export const FormSelectorOptions = ({
 						icon={icons.data}
 						onClick={() => {
 							// Sync integration blocks.
-							clearTransientCache(activeIntegration).then((msg) => createSuccessNotice(msg, {
+							clearTransientCache(activeIntegration).then((msg) => createNotice('success', msg, {
 								type: 'snackbar',
 							}));
 						}}

--- a/src/Enqueue/Blocks/EnqueueBlocks.php
+++ b/src/Enqueue/Blocks/EnqueueBlocks.php
@@ -304,6 +304,7 @@ class EnqueueBlocks extends AbstractEnqueueBlocks
 
 		$output['wpAdminUrl'] = \get_admin_url();
 		$output['nonce'] = \wp_create_nonce('wp_rest');
+		$output['isDeveloperMode'] =  $this->isCheckboxOptionChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
 
 		$output = \wp_json_encode($output);
 


### PR DESCRIPTION
# Description

- I have implemented a solution to prevent the deletion of forms in cases where the output is empty during differential synchronization. This ensures that forms remain accessible even if the integrations fail.
