### PR TITLE
addings fixes for debug

### DIFF
--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 4.0.97
+ * Version: 4.0.98
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/AdminMenus/FormAdminBarMenu.php
+++ b/src/AdminMenus/FormAdminBarMenu.php
@@ -95,7 +95,7 @@ class FormAdminBarMenu implements ServiceInterface
 				'title' => ($isDevelopMode || $isDevelopModeQmLog) ? $mainLabel . Helper::getProjectIcons('warning') : $mainLabel,
 				'href' => Helper::getListingPageUrl(),
 				'meta' => [
-					'title' => ($isDevelopMode || $isDevelopModeQmLog) ? \esc_html__('Your Debug tools are active!', 'eightshift-forms') : $mainLabel,
+					'title' => ($isDevelopMode || $isDevelopModeQmLog) ? \esc_html__('Debug tools are active!', 'eightshift-forms') : $mainLabel,
 				]
 			],
 		);

--- a/src/AdminMenus/FormAdminBarMenu.php
+++ b/src/AdminMenus/FormAdminBarMenu.php
@@ -80,17 +80,23 @@ class FormAdminBarMenu implements ServiceInterface
 		}
 
 		$prefix = FormAdminMenu::ADMIN_MENU_SLUG;
-		$isDevelopMode = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$isDevelopMode = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
+		$isDevelopModeQmLog = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_QM_LOG);
 
 		$version = Config::getProjectVersion();
+
+		$mainLabel = \esc_html__('Eightshift Forms', 'eightshift-forms');
 
 		$adminBar->add_menu(
 			[
 				'id' => $prefix,
 				'parent' => null,
-				'group'  => null,
-				'title' => \esc_html__('Eightshift Forms', 'eightshift-forms'),
-				'href'  => Helper::getListingPageUrl(),
+				'group' => null,
+				'title' => ($isDevelopMode || $isDevelopModeQmLog) ? $mainLabel . Helper::getProjectIcons('warning') : $mainLabel,
+				'href' => Helper::getListingPageUrl(),
+				'meta' => [
+					'title' => ($isDevelopMode || $isDevelopModeQmLog) ? \esc_html__('Your Debug tools are active!', 'eightshift-forms') : $mainLabel,
+				]
 			],
 		);
 
@@ -100,7 +106,7 @@ class FormAdminBarMenu implements ServiceInterface
 				'id' => $listingPrefix,
 				'parent' => $prefix,
 				'title' => \esc_html__('View all forms', 'eightshift-forms'),
-				'href'  => Helper::getListingPageUrl(),
+				'href' => Helper::getListingPageUrl(),
 			],
 		);
 
@@ -128,7 +134,7 @@ class FormAdminBarMenu implements ServiceInterface
 						'id' => "{$listingPrefix}-{$id}",
 						'parent' => $listingPrefix,
 						'title' => $title,
-						'href'  => $url,
+						'href' => $url,
 					],
 				);
 
@@ -137,7 +143,7 @@ class FormAdminBarMenu implements ServiceInterface
 						'id' => "{$listingPrefix}-{$id}-edit",
 						'parent' => $link,
 						'title' => \esc_html__('Edit form', 'eightshift-forms'),
-						'href'  => $url,
+						'href' => $url,
 					],
 				);
 				$adminBar->add_menu(
@@ -145,7 +151,7 @@ class FormAdminBarMenu implements ServiceInterface
 						'id' => "{$listingPrefix}-{$id}-settings",
 						'parent' => $link,
 						'title' => \esc_html__('Settings', 'eightshift-forms'),
-						'href'  => $item['settingsLink'] ?? null,
+						'href' => $item['settingsLink'] ?? null,
 					],
 				);
 				$adminBar->add_menu(
@@ -153,7 +159,7 @@ class FormAdminBarMenu implements ServiceInterface
 						'id' => "{$listingPrefix}-{$id}-locations",
 						'parent' => $link,
 						'title' => \esc_html__('Locations', 'eightshift-forms'),
-						'href'  => $item['settingsLocationLink'] ?? null,
+						'href' => $item['settingsLocationLink'] ?? null,
 					],
 				);
 			}
@@ -164,7 +170,7 @@ class FormAdminBarMenu implements ServiceInterface
 				'id' => "{$prefix}-new-form",
 				'parent' => $prefix,
 				'title' => \esc_html__('Add new form', 'eightshift-forms'),
-				'href'  => Helper::getNewFormPageUrl(),
+				'href' => Helper::getNewFormPageUrl(),
 			],
 		);
 
@@ -174,7 +180,7 @@ class FormAdminBarMenu implements ServiceInterface
 					'id' => "{$prefix}-global-settings",
 					'parent' => $prefix,
 					'title' => \esc_html__('Global settings', 'eightshift-forms'),
-					'href'  => Helper::getSettingsGlobalPageUrl(),
+					'href' => Helper::getSettingsGlobalPageUrl(),
 				],
 			);
 
@@ -184,7 +190,7 @@ class FormAdminBarMenu implements ServiceInterface
 					'id' => $troubleshootingPrefix,
 					'parent' => $prefix,
 					'title' => \esc_html__('Troubleshooting', 'eightshift-forms'),
-					'href'  => null,
+					'href' => null,
 				],
 			);
 
@@ -193,7 +199,7 @@ class FormAdminBarMenu implements ServiceInterface
 					'id' => "{$troubleshootingPrefix}-cache",
 					'parent' => $troubleshootingPrefix,
 					'title' => \esc_html__('Clear cache', 'eightshift-forms'),
-					'href'  => Helper::getSettingsGlobalPageUrl(SettingsCache::SETTINGS_TYPE_KEY),
+					'href' => Helper::getSettingsGlobalPageUrl(SettingsCache::SETTINGS_TYPE_KEY),
 				],
 			);
 
@@ -202,7 +208,7 @@ class FormAdminBarMenu implements ServiceInterface
 					'id' => "{$troubleshootingPrefix}-debug",
 					'parent' => $troubleshootingPrefix,
 					'title' => \esc_html__('Debug', 'eightshift-forms'),
-					'href'  => Helper::getSettingsGlobalPageUrl(SettingsDebug::SETTINGS_TYPE_KEY),
+					'href' => Helper::getSettingsGlobalPageUrl(SettingsDebug::SETTINGS_TYPE_KEY),
 				],
 			);
 
@@ -212,7 +218,7 @@ class FormAdminBarMenu implements ServiceInterface
 					'parent' => $troubleshootingPrefix,
 					// Translators: %s is the plugin version number.
 					'title' => \sprintf(\esc_html__('Version: %s', 'eightshift-forms'), \esc_html($version)),
-					'href'  => null,
+					'href' => null,
 				],
 			);
 		}

--- a/src/AdminMenus/FormAdminMenu.php
+++ b/src/AdminMenus/FormAdminMenu.php
@@ -269,7 +269,7 @@ class FormAdminMenu extends AbstractAdminMenu
 			'adminListingType' => $status,
 			'adminListingListingLink' => $listingLink,
 			'adminListingIntegrations' => $filter,
-			'adminListingIsDeveloperMode' => $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY),
+			'adminListingIsDeveloperMode' => \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY),
 		];
 	}
 }

--- a/src/AdminMenus/FormSettingsAdminSubMenu.php
+++ b/src/AdminMenus/FormSettingsAdminSubMenu.php
@@ -190,7 +190,7 @@ class FormSettingsAdminSubMenu extends AbstractAdminSubMenu
 			return [];
 		}
 
-		$isDeveloperMode = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$isDeveloperMode = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
 
 		$formTitle = \get_the_title((int) $formId);
 

--- a/src/Blocks/SettingsBlocks.php
+++ b/src/Blocks/SettingsBlocks.php
@@ -352,7 +352,7 @@ class SettingsBlocks implements SettingGlobalInterface, ServiceInterface
 		$output = \get_transient(SettingsBlocks::CACHE_BLOCK_COUNTRY_DATE_SET_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 

--- a/src/Blocks/components/admin-top-menu-bar/admin-top-menu-bar-admin.scss
+++ b/src/Blocks/components/admin-top-menu-bar/admin-top-menu-bar-admin.scss
@@ -1,5 +1,5 @@
 #wp-admin-bar-es-forms > a > svg { // stylelint-disable-line selector-max-specificity
-	color: red;
+	color: #FF6900;
 	margin-left: 0.625rem;
 	vertical-align: sub;
 }

--- a/src/Blocks/components/admin-top-menu-bar/admin-top-menu-bar-admin.scss
+++ b/src/Blocks/components/admin-top-menu-bar/admin-top-menu-bar-admin.scss
@@ -1,0 +1,5 @@
+#wp-admin-bar-es-forms > a > svg { // stylelint-disable-line selector-max-specificity
+	color: red;
+	margin-left: 0.625rem;
+	vertical-align: sub;
+}

--- a/src/Blocks/components/admin-top-menu-bar/manifest.json
+++ b/src/Blocks/components/admin-top-menu-bar/manifest.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"componentName": "admin-top-menu-bar",
+	"title": "Admin Top Menu Bar",
+	"componentClass": "es-admin-top-menu-bar"
+}

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -147,19 +147,14 @@ export class Form {
 		// Set state initial data for form.
 		setStateFormInitial(formId);
 
-		if (this.state.getStateFormIsConfigured(formId)) {
-			// Init all form elements.
-			this.initOne(formId);
+		// Init all form elements.
+		this.initOne(formId);
 
-			// Init conditional tags.
-			this.conditionalTags.initOne(formId);
+		// Init conditional tags.
+		this.conditionalTags.initOne(formId);
 
-			// Init steps.
-			this.steps.initOne(formId);
-		} else {
-			this.utils.removeFormById(formId);
-		}
-
+		// Init steps.
+		this.steps.initOne(formId);
 	}
 
 	/**

--- a/src/Blocks/components/form/assets/state.js
+++ b/src/Blocks/components/form/assets/state.js
@@ -76,9 +76,6 @@ export class State {
 	getStateFormLoader = (formId) => {
 		return getState([StateEnum.FORM, StateEnum.LOADER], formId);
 	};
-	getStateFormIsConfigured = (formId) => {
-		return getState([StateEnum.FORM, StateEnum.ISCONFIGURED], formId);
-	};
 
 	setStateFormIsLoaded = (value, formId) => {
 		setState([StateEnum.FORM, StateEnum.ISLOADED], value, formId);

--- a/src/Blocks/components/form/assets/state/init.js
+++ b/src/Blocks/components/form/assets/state/init.js
@@ -13,7 +13,6 @@ export const prefix = 'esForms';
 export const StateEnum = {
 	// State names.
 	ISLOADED: 'isloaded',
-	ISCONFIGURED: 'isConfigured',
 	ELEMENTS: 'elements',
 	FORM: 'form',
 	FORMS: 'forms',
@@ -329,7 +328,6 @@ export function setStateFormInitial(formId) {
 
 	setState([StateEnum.FORM, StateEnum.POST_ID],formElement?.getAttribute(getStateAttribute('postId')), formId);
 	setState([StateEnum.FORM, StateEnum.ISLOADED], false, formId);
-	setState([StateEnum.FORM, StateEnum.ISCONFIGURED], true, formId);
 	setState([StateEnum.FORM, StateEnum.IS_SINGLE_SUBMIT], false, formId);
 	setState([StateEnum.FORM, StateEnum.ELEMENT], formElement, formId);
 	setState([StateEnum.FORM, StateEnum.TYPE], formElement?.getAttribute(getStateAttribute('formType')), formId);
@@ -370,10 +368,6 @@ export function setStateFormInitial(formId) {
 			type,
 			disabled,
 		} = item;
-
-		if (name in getState([StateEnum.ELEMENTS], formId) && getState([StateEnum.ELEMENTS], formId)?.[name]?.[StateEnum.TYPE] === type) {
-			setState([StateEnum.FORM, StateEnum.ISCONFIGURED], false, formId);
-		}
 
 		if (name === 'search_terms') {
 			continue;

--- a/src/Blocks/components/form/assets/utilities.js
+++ b/src/Blocks/components/form/assets/utilities.js
@@ -757,19 +757,6 @@ export class Utils {
 	}
 
 	/**
-	 * Remove form by Id.
-	 *
-	 * @returns {void}
-	 */
-	removeFormById(formId) {
-		const form = this.state.getStateFormElement(formId);
-
-		if (form) {
-			form.innerHTML = this.state.getStateSettingsFormMisconfiguredMsg();
-		}
-	}
-
-	/**
 	 * Set select value.
 	 * 
 	 * @param {string} formId Form Id.
@@ -887,9 +874,6 @@ export class Utils {
 			},
 			removeFormsWithMissingFormsBlock: () => {
 				this.removeFormsWithMissingFormsBlock();
-			},
-			removeFormById: (formId) => {
-				this.removeFormById(formId);
 			},
 			setSelectValue: (formId, name, value) => {
 				this.setSelectValue(formId, name, value);

--- a/src/Enqueue/Blocks/EnqueueBlocks.php
+++ b/src/Enqueue/Blocks/EnqueueBlocks.php
@@ -230,7 +230,7 @@ class EnqueueBlocks extends AbstractEnqueueBlocks
 			SettingsSettings::SETTINGS_GENERAL_DISABLE_AUTOINIT_ENQUEUE_SCRIPT_KEY,
 			SettingsSettings::SETTINGS_GENERAL_DISABLE_DEFAULT_ENQUEUE_KEY
 		);
-		$output['formResetOnSuccess'] = !$this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_RESET_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$output['formResetOnSuccess'] = !\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_RESET_KEY);
 		$output['formServerErrorMsg'] = \esc_html__('A server error occurred while submitting your form. Please try again.', 'eightshift-forms');
 		$output['formMisconfigured'] = \is_user_logged_in() ? \esc_html__('You form is missing forms block or it is missconfigured.', 'eightshift-forms') : '';
 
@@ -315,7 +315,7 @@ class EnqueueBlocks extends AbstractEnqueueBlocks
 
 		$output['wpAdminUrl'] = \get_admin_url();
 		$output['nonce'] = \wp_create_nonce('wp_rest');
-		$output['isDeveloperMode'] =  $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$output['isDeveloperMode'] = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
 		$output['isAdmin'] = true;
 
 		$output = \wp_json_encode($output);

--- a/src/Helpers/Helper.php
+++ b/src/Helpers/Helper.php
@@ -24,6 +24,7 @@ use EightshiftForms\Dashboard\SettingsDashboard;
 use EightshiftForms\General\SettingsGeneral;
 use EightshiftForms\Integrations\Pipedrive\SettingsPipedrive;
 use EightshiftForms\Misc\SettingsWpml;
+use EightshiftForms\Troubleshooting\SettingsDebug;
 use EightshiftFormsVendor\EightshiftLibs\Helpers\Components;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
@@ -902,5 +903,19 @@ class Helper
 	public static function cleanPageUrl(string $url): string
 	{
 		return \preg_replace('/\\?.*/', '', $url);
+	}
+
+	/**
+	 * Set and output data to output log using Query Monitor plugin.
+	 *
+	 * @param mixed $data Data to output.
+	 *
+	 * @return void
+	 */
+	public static function setQmLogsOutput($data = ''): void
+	{
+		if (\is_plugin_active('query-monitor/query-monitor.php') && \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_QM_LOG) && $data) {
+			\do_action('qm/debug', $data); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		}
 	}
 }

--- a/src/Integrations/ActiveCampaign/ActiveCampaignClient.php
+++ b/src/Integrations/ActiveCampaign/ActiveCampaignClient.php
@@ -69,7 +69,7 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 		$output = \get_transient(self::CACHE_ACTIVE_CAMPAIGN_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -174,6 +174,8 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput(
@@ -256,6 +258,8 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput($details);
@@ -308,6 +312,8 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput($details);
@@ -350,6 +356,8 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -413,6 +421,8 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -506,6 +516,8 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// Bailout if fields are missing.
 		if (!isset($body['form']['cfields'])) {
 			return [];
@@ -582,6 +594,8 @@ class ActiveCampaignClient implements ActiveCampaignClientInterface
 		$details = $this->getTestApi();
 
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		if (!isset($body['forms'])) {
 			return [];

--- a/src/Integrations/Airtable/AirtableClient.php
+++ b/src/Integrations/Airtable/AirtableClient.php
@@ -77,7 +77,7 @@ class AirtableClient implements ClientInterface
 		$output = \get_transient(self::CACHE_AIRTABLE_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -124,7 +124,7 @@ class AirtableClient implements ClientInterface
 		$output = \get_transient(self::CACHE_AIRTABLE_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -195,6 +195,8 @@ class AirtableClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -278,6 +280,8 @@ class AirtableClient implements ClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $body ?? [];
@@ -321,6 +325,8 @@ class AirtableClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Clearbit/ClearbitClient.php
+++ b/src/Integrations/Clearbit/ClearbitClient.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace EightshiftForms\Integrations\Clearbit;
 
+use EightshiftForms\Helpers\Helper;
 use EightshiftForms\Hooks\Filters;
 use EightshiftForms\Hooks\Variables;
 use EightshiftForms\Rest\ApiHelper;
@@ -82,6 +83,8 @@ class ClearbitClient implements ClearbitClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Goodbits/GoodbitsClient.php
+++ b/src/Integrations/Goodbits/GoodbitsClient.php
@@ -153,6 +153,8 @@ class GoodbitsClient implements ClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput($details);

--- a/src/Integrations/Greenhouse/GreenhouseClient.php
+++ b/src/Integrations/Greenhouse/GreenhouseClient.php
@@ -79,7 +79,7 @@ class GreenhouseClient implements ClientInterface
 		$output = \get_transient(self::CACHE_GREENHOUSE_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -215,6 +215,8 @@ class GreenhouseClient implements ClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput($details);
@@ -323,6 +325,8 @@ class GreenhouseClient implements ClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $body['jobs'] ?? [];
@@ -358,6 +362,8 @@ class GreenhouseClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Hubspot/HubspotClient.php
+++ b/src/Integrations/Hubspot/HubspotClient.php
@@ -102,7 +102,7 @@ class HubspotClient implements HubspotClientInterface
 		$output = \get_transient(self::CACHE_HUBSPOT_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -171,7 +171,7 @@ class HubspotClient implements HubspotClientInterface
 		$output = \get_transient(self::CACHE_HUBSPOT_CONTACT_PROPERTIES_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -276,6 +276,8 @@ class HubspotClient implements HubspotClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput($details);
@@ -343,6 +345,8 @@ class HubspotClient implements HubspotClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -552,6 +556,8 @@ class HubspotClient implements HubspotClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $body ?? [];
@@ -595,6 +601,8 @@ class HubspotClient implements HubspotClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/IntegrationSyncDiff.php
+++ b/src/Integrations/IntegrationSyncDiff.php
@@ -49,8 +49,7 @@ class IntegrationSyncDiff implements ServiceInterface, IntegrationSyncInterface
 	public function updateFormOnBlockEditorLoad(): void
 	{
 		// Prevent forms sync.
-		$skipFormsSync = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_FORMS_SYNC_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
-		if ($skipFormsSync) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_FORMS_SYNC_KEY)) {
 			return;
 		}
 

--- a/src/Integrations/Jira/JiraClient.php
+++ b/src/Integrations/Jira/JiraClient.php
@@ -86,7 +86,7 @@ class JiraClient implements JiraClientInterface
 		$output = \get_transient(self::CACHE_JIRA_PROJECTS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -137,7 +137,7 @@ class JiraClient implements JiraClientInterface
 		$output = \get_transient(self::CACHE_JIRA_PROJECTS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -206,6 +206,8 @@ class JiraClient implements JiraClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -347,6 +349,8 @@ class JiraClient implements JiraClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			if ($this->isSelfHosted()) {
@@ -391,6 +395,8 @@ class JiraClient implements JiraClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			if ($this->isSelfHosted()) {
@@ -432,6 +438,8 @@ class JiraClient implements JiraClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Mailchimp/MailchimpClient.php
+++ b/src/Integrations/Mailchimp/MailchimpClient.php
@@ -71,7 +71,7 @@ class MailchimpClient implements MailchimpClientInterface
 		$output = \get_transient(self::CACHE_MAILCHIMP_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -218,6 +218,8 @@ class MailchimpClient implements MailchimpClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput($details);
@@ -328,6 +330,8 @@ class MailchimpClient implements MailchimpClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $body['tags'] ?? [];
@@ -378,6 +382,8 @@ class MailchimpClient implements MailchimpClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -436,6 +442,8 @@ class MailchimpClient implements MailchimpClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Mailerlite/MailerliteClient.php
+++ b/src/Integrations/Mailerlite/MailerliteClient.php
@@ -77,7 +77,7 @@ class MailerliteClient implements ClientInterface
 		$output = \get_transient(self::CACHE_MAILERLITE_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -186,6 +186,8 @@ class MailerliteClient implements ClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $this->getIntegrationApiSuccessOutput($details);
@@ -288,6 +290,8 @@ class MailerliteClient implements ClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $body ?? [];
@@ -331,6 +335,8 @@ class MailerliteClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Moments/MomentsClient.php
+++ b/src/Integrations/Moments/MomentsClient.php
@@ -76,7 +76,7 @@ class MomentsClient implements ClientInterface
 		$output = \get_transient(self::CACHE_MOMENTS_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -161,6 +161,8 @@ class MomentsClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -400,6 +402,8 @@ class MomentsClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Pipedrive/PipedriveClient.php
+++ b/src/Integrations/Pipedrive/PipedriveClient.php
@@ -93,7 +93,7 @@ class PipedriveClient implements PipedriveClientInterface
 		$output = \get_transient(self::CACHE_PIPEDRIVE_PERSON_FIELDS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -164,7 +164,7 @@ class PipedriveClient implements PipedriveClientInterface
 		$output = \get_transient(self::CACHE_PIPEDRIVE_LEADS_FIELDS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -432,6 +432,8 @@ class PipedriveClient implements PipedriveClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $body['data'] ?? [];
@@ -464,6 +466,8 @@ class PipedriveClient implements PipedriveClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Integrations/Workable/WorkableClient.php
+++ b/src/Integrations/Workable/WorkableClient.php
@@ -76,7 +76,7 @@ class WorkableClient implements ClientInterface
 		$output = \get_transient(self::CACHE_WORKABLE_ITEMS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 
@@ -192,6 +192,8 @@ class WorkableClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
@@ -328,6 +330,8 @@ class WorkableClient implements ClientInterface
 		$code = $details['code'];
 		$body = $details['body'];
 
+		Helper::setQmLogsOutput($details);
+
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {
 			return $body['jobs'] ?? [];
@@ -363,6 +367,8 @@ class WorkableClient implements ClientInterface
 
 		$code = $details['code'];
 		$body = $details['body'];
+
+		Helper::setQmLogsOutput($details);
 
 		// On success return output.
 		if ($code >= 200 && $code <= 299) {

--- a/src/Location/SettingsLocation.php
+++ b/src/Location/SettingsLocation.php
@@ -112,7 +112,7 @@ class SettingsLocation implements SettingInterface, ServiceInterface, SettingsLo
 			return [];
 		}
 
-		$isDeveloperMode = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$isDeveloperMode = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
 
 		return \array_map(
 			function ($item) use ($isDeveloperMode) {

--- a/src/Rest/ApiHelper.php
+++ b/src/Rest/ApiHelper.php
@@ -207,7 +207,7 @@ trait ApiHelper
 			$output['data'] = $additional;
 		}
 
-		$isDeveloperMode = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$isDeveloperMode = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
 
 		if ($isDeveloperMode && $debug) {
 			$output['debug'] = $debug;
@@ -237,7 +237,7 @@ trait ApiHelper
 			$output['data'] = $additional;
 		}
 
-		$isDeveloperMode = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$isDeveloperMode = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
 
 		if ($isDeveloperMode && $debug) {
 			$output['debug'] = $debug;
@@ -267,7 +267,7 @@ trait ApiHelper
 			$output['data'] = $additional;
 		}
 
-		$isDeveloperMode = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$isDeveloperMode = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
 
 		if ($isDeveloperMode && $debug) {
 			$output['debug'] = $debug;

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -100,7 +100,7 @@ abstract class AbstractFormSubmit extends AbstractBaseRoute
 			switch ($this->routeGetType()) {
 				case self::ROUTE_TYPE_FILE:
 					// Validate files.
-					if (!$this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_VALIDATION_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+					if (!\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_VALIDATION_KEY)) {
 						$validate = $this->getValidator()->validateFiles($formDataReference); // @phpstan-ignore-line
 
 						if ($validate) {
@@ -140,7 +140,7 @@ abstract class AbstractFormSubmit extends AbstractBaseRoute
 					break;
 				case self::ROUTE_TYPE_STEP_VALIDATION:
 					// Validate params.
-					if (!$this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_VALIDATION_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+					if (!\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_VALIDATION_KEY)) {
 						$validate = $this->getValidator()->validateParams($formDataReference, false); // @phpstan-ignore-line
 
 						if ($validate) {
@@ -158,7 +158,7 @@ abstract class AbstractFormSubmit extends AbstractBaseRoute
 					}
 
 					// Validate params.
-					if (!$this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_VALIDATION_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+					if (!\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_VALIDATION_KEY)) {
 						$validate = $this->getValidator()->validateParams($formDataReference); // @phpstan-ignore-line
 
 						if ($validate) {

--- a/src/Rest/Routes/SubmitCaptchaRoute.php
+++ b/src/Rest/Routes/SubmitCaptchaRoute.php
@@ -100,7 +100,7 @@ class SubmitCaptchaRoute extends AbstractBaseRoute
 		];
 
 		// Bailout if troubleshooting skip captcha is on.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CAPTCHA_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CAPTCHA_KEY)) {
 			return \rest_ensure_response(
 				$this->getApiSuccessOutput(
 					\esc_html__('Form captcha skipped due to troubleshooting config set in settings.', 'eightshift-forms'),

--- a/src/Transfer/SettingsTransfer.php
+++ b/src/Transfer/SettingsTransfer.php
@@ -328,7 +328,7 @@ class SettingsTransfer implements ServiceInterface, SettingGlobalInterface
 
 		$output = [];
 
-		$isDeveloperMode = $this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY);
+		$isDeveloperMode = \apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_DEVELOPER_MODE_KEY);
 
 		while ($theQuery->have_posts()) {
 			$theQuery->the_post();

--- a/src/Troubleshooting/SettingsDebug.php
+++ b/src/Troubleshooting/SettingsDebug.php
@@ -35,6 +35,11 @@ class SettingsDebug implements ServiceInterface, SettingGlobalInterface
 	public const FILTER_SETTINGS_IS_VALID_NAME = 'es_forms_settings_is_valid_debug';
 
 	/**
+	 * Filter settings is debug active key.
+	 */
+	public const FILTER_SETTINGS_IS_DEBUG_ACTIVE = 'es_forms_settings_is_debug_active';
+
+	/**
 	 * Settings key.
 	 */
 	public const SETTINGS_TYPE_KEY = 'debug';
@@ -55,6 +60,7 @@ class SettingsDebug implements ServiceInterface, SettingGlobalInterface
 	public const SETTINGS_DEBUG_DEVELOPER_MODE_KEY = 'developer-mode';
 	public const SETTINGS_DEBUG_SKIP_FORMS_SYNC_KEY = 'skip-forms-sync';
 	public const SETTINGS_DEBUG_SKIP_CACHE_KEY = 'skip-cache';
+	public const SETTINGS_DEBUG_QM_LOG = 'skip-qm-log';
 
 	/**
 	 * Register all the hooks
@@ -65,6 +71,7 @@ class SettingsDebug implements ServiceInterface, SettingGlobalInterface
 	{
 		\add_filter(self::FILTER_SETTINGS_GLOBAL_NAME, [$this, 'getSettingsGlobalData']);
 		\add_filter(self::FILTER_SETTINGS_IS_VALID_NAME, [$this, 'isSettingsGlobalValid']);
+		\add_filter(self::FILTER_SETTINGS_IS_DEBUG_ACTIVE, [$this, 'isDebugActive']);
 	}
 
 	/**
@@ -202,10 +209,39 @@ class SettingsDebug implements ServiceInterface, SettingGlobalInterface
 								'checkboxSingleSubmit' => true,
 								'checkboxHelp' => \__('Prevents storing integration data to the temporary internal cache to optimize load time and API calls. Turning on this option can cause many API calls in a short time, which may cause a temporary ban from the external integration service. Use with caution.', 'eightshift-forms'),
 							],
+							[
+								'component' => 'divider',
+								'dividerExtraVSpacing' => 'true',
+							],
+							[
+								'component' => 'checkbox',
+								'checkboxLabel' => \__('Output Query Monitor log', 'eightshift-forms'),
+								'checkboxIsChecked' => $this->isOptionCheckboxChecked(self::SETTINGS_DEBUG_QM_LOG, self::SETTINGS_DEBUG_DEBUGGING_KEY),
+								'checkboxValue' => self::SETTINGS_DEBUG_QM_LOG,
+								'checkboxAsToggle' => true,
+								'checkboxSingleSubmit' => true,
+								'checkboxHelp' => \__('You can preview the output logs for internal API responses not handled by JavaScript. To use this feature, the Query Monitor plugin must be active on your project.', 'eightshift-forms'),
+							],
 						]
 					],
 				],
 			],
 		];
+	}
+
+	/**
+	 * Determine if settings global is valid and debug item is active.
+	 *
+	 * @param string $settingKey Setting key to check.
+	 *
+	 * @return boolean
+	 */
+	public function isDebugActive(string $settingKey): bool
+	{
+		if (!$this->isSettingsGlobalValid()) {
+			return false;
+		}
+
+		return $this->isOptionCheckboxChecked($settingKey, self::SETTINGS_DEBUG_DEBUGGING_KEY);
 	}
 }

--- a/src/Troubleshooting/SettingsDebug.php
+++ b/src/Troubleshooting/SettingsDebug.php
@@ -220,7 +220,7 @@ class SettingsDebug implements ServiceInterface, SettingGlobalInterface
 								'checkboxValue' => self::SETTINGS_DEBUG_QM_LOG,
 								'checkboxAsToggle' => true,
 								'checkboxSingleSubmit' => true,
-								'checkboxHelp' => \__('You can preview the output logs for internal API responses not handled by JavaScript. To use this feature, the Query Monitor plugin must be active on your project.', 'eightshift-forms'),
+								'checkboxHelp' => \__('You can preview the output logs for internal API responses not handled by JavaScript. To use this feature, the Query Monitor plugin must be installed and active in your project.', 'eightshift-forms'),
 							],
 						]
 					],

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -465,7 +465,7 @@ class Validator extends AbstractValidation
 		$output = \get_transient(self::CACHE_VALIDATOR_LABELS_TRANSIENT_NAME) ?: []; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		// Prevent cache.
-		if ($this->isOptionCheckboxChecked(SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY, SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY)) {
+		if (\apply_filters(SettingsDebug::FILTER_SETTINGS_IS_DEBUG_ACTIVE, SettingsDebug::SETTINGS_DEBUG_SKIP_CACHE_KEY)) {
 			$output = [];
 		}
 


### PR DESCRIPTION
# Description

* If you have developed tools active, it will output this new warning in the top nav bar
* We have a new development key to use the Query Monitor plugin output log to show data that are pulled from the external API using PHP.
* All development checks now also check if the top level Dashboard key is active, so you can turn off the main feature and everything else will turn off


![Screenshot 2023-10-25 at 15 36 27](https://github.com/infinum/eightshift-forms/assets/23283324/c8df9b33-8bb9-4e09-aa24-77daab194203)
![Screenshot 2023-10-25 at 15 36 37](https://github.com/infinum/eightshift-forms/assets/23283324/9ad02d12-0a70-458f-91ef-70248cc86ee4)
![Screenshot 2023-10-25 at 15 37 55](https://github.com/infinum/eightshift-forms/assets/23283324/c2b51c9e-d655-4933-803b-0a7ab4f5e466)
