### PR TITLE
Revert overflow logical properties

### DIFF
--- a/src/Blocks/components/admin-settings-section/admin-settings-section-admin.scss
+++ b/src/Blocks/components/admin-settings-section/admin-settings-section-admin.scss
@@ -66,7 +66,7 @@
 		grid-area: main;
 
 		#{$this}__content {
-			overflow-inline: hidden;
+			overflow-x: hidden;
 			padding: var(--global-esf-spacing-xl);
 
 			block-size: 100%;

--- a/src/Blocks/components/global-msg/global-msg-admin.scss
+++ b/src/Blocks/components/global-msg/global-msg-admin.scss
@@ -5,7 +5,7 @@
 	z-index: 1;
 	max-inline-size: 18rem;
 	max-block-size: 80vh;
-	overflow-inline: hidden;
+	overflow-x: hidden;
 	border-radius: 0.5rem;
 	padding: 0.75rem 1rem;
 	opacity: 0;


### PR DESCRIPTION
# Description

Title says it all
Logical overflow properties are widely unsupported with Firefox as an exception