### PR TITLE
adding empty entires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ### Changed
 - The security validation feature will no longer trigger count files and step requests.
+- Entries now have ability to save empty fields based on the settings.
 
 ### Fixed
 - Typo for fallback function.
+- Custom mailer now supports saving entires.
 
 ## [3.0.2]
 

--- a/src/Entries/EntriesHelper.php
+++ b/src/Entries/EntriesHelper.php
@@ -13,6 +13,7 @@ namespace EightshiftForms\Entries;
 use EightshiftFormsVendor\EightshiftFormsUtils\Config\UtilsConfig;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsGeneralHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsHooksHelper;
+use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsSettingsHelper;
 
 /**
  * EntriesHelper class.
@@ -48,11 +49,17 @@ class EntriesHelper
 
 		$params = UtilsGeneralHelper::removeUneceseryParamFields($params);
 
+		$saveEmptyFields = UtilsSettingsHelper::isSettingCheckboxChecked(SettingsEntries::SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS, SettingsEntries::SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS, $formId);
+
 		foreach ($params as $param) {
 			$name = $param['name'] ?? '';
 			$value = $param['value'] ?? '';
 
-			if (!$name || !$value) {
+			if (!$name) {
+				continue;
+			}
+
+			if (!$value && !$saveEmptyFields) {
 				continue;
 			}
 

--- a/src/Entries/SettingsEntries.php
+++ b/src/Entries/SettingsEntries.php
@@ -57,6 +57,10 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 	 */
 	public const SETTINGS_ENTRIES_SETTINGS_USE_KEY = 'entries-settings-use';
 
+	/**
+	 * Entries settings save empty fields key.
+	 */
+	public const SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS = 'entries-save-empty-fields';
 
 	/**
 	 * Data data key.
@@ -156,6 +160,8 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 									[
 										'component' => 'checkbox',
 										'checkboxLabel' => \__('Store entries in database', 'eightshift-forms'),
+										// translators: %s is replaced with the form entries page URL.
+										'checkboxHelp' => $isUsed ? \sprintf(\__("You can find all form entries <a href='%s' rel='noopener noreferrer' target='_blank'>here</a>.", 'eightshift-forms'), UtilsGeneralHelper::getFormsEntriesPageUrl($formId)) : '',
 										'checkboxIsChecked' => $isUsed,
 										'checkboxValue' => self::SETTINGS_ENTRIES_SETTINGS_USE_KEY,
 										'checkboxSingleSubmit' => true,
@@ -163,19 +169,28 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 									]
 								]
 							],
-							[
-								'component' => 'divider',
-								'dividerExtraVSpacing' => true,
-							],
-							[
-								'component' => 'intro',
-								// translators: %s is the link to the entries page.
-								'introSubtitle' => \sprintf(\__("
-									<p>
-										You can find all form entries <a href='%s' rel='noopener noreferrer' target='_blank'>here</a>.
-									</p>
-								", 'eightshift-forms'), UtilsGeneralHelper::getFormsEntriesPageUrl($formId)),
-							],
+							...($isUsed ? [
+								[
+									'component' => 'divider',
+									'dividerExtraVSpacing' => true,
+								],
+								[
+									'component' => 'checkboxes',
+									'checkboxesFieldLabel' => '',
+									'checkboxesName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS),
+									'checkboxesContent' => [
+										[
+											'component' => 'checkbox',
+											'checkboxLabel' => \__('Save empty fields to database', 'eightshift-forms'),
+											'checkboxHelp' => \__('All empty field values will not be saved to database by default.', 'eightshift-forms'),
+											'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS, self::SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS, $formId),
+											'checkboxValue' => self::SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS,
+											'checkboxSingleSubmit' => true,
+											'checkboxAsToggle' => true,
+										]
+									]
+								],
+							] : []),
 						],
 					],
 				],

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -90,7 +90,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 	 *
 	 * @var string
 	 */
-	protected const VALIDATION_ERROR_SEND_FAlLBACK = 'validationErrorSendFallback';
+	protected const VALIDATION_ERROR_SEND_FALLBACK = 'validationErrorSendFallback';
 	protected const VALIDATION_ERROR_CODE = 'validationErrorCode';
 	protected const VALIDATION_ERROR_DATA = 'validationErrorData';
 	protected const VALIDATION_ERROR_MSG = 'validationErrorMsg';
@@ -120,7 +120,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 				throw new UnverifiedRequestException(
 					$this->getValidatorLabels()->getLabel('validationMissingMandatoryParams'),
 					[
-						self::VALIDATION_ERROR_SEND_FAlLBACK => true,
+						self::VALIDATION_ERROR_SEND_FALLBACK => true,
 						self::VALIDATION_ERROR_CODE => 'validationMissingMandatoryParams',
 					]
 				);
@@ -159,7 +159,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 								self::VALIDATION_ERROR_OUTPUT => [
 									$uploadFileId => $this->getValidatorLabels()->getLabel('validationFileUpload'),
 								],
-								self::VALIDATION_ERROR_SEND_FAlLBACK => true,
+								self::VALIDATION_ERROR_SEND_FALLBACK => true,
 								self::VALIDATION_ERROR_CODE => 'validationFileUploadProcessError',
 							]
 						);
@@ -207,7 +207,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 						throw new UnverifiedRequestException(
 							$this->getValidatorLabels()->getLabel('validationSecurity'),
 							[
-								self::VALIDATION_ERROR_SEND_FAlLBACK => true,
+								self::VALIDATION_ERROR_SEND_FALLBACK => true,
 								self::VALIDATION_ERROR_CODE => 'validationSecurity',
 							]
 						);
@@ -258,7 +258,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 			// Do Action.
 			return $this->submitAction($formDetails);
 		} catch (UnverifiedRequestException $e) {
-			if (isset($e->getData()[self::VALIDATION_ERROR_SEND_FAlLBACK]) && $e->getData()[self::VALIDATION_ERROR_SEND_FAlLBACK]) {
+			if (isset($e->getData()[self::VALIDATION_ERROR_SEND_FALLBACK]) && $e->getData()[self::VALIDATION_ERROR_SEND_FALLBACK]) {
 				// Send fallback email.
 				$this->getFormSubmitMailer()->sendFallbackProcessingEmail(
 					$formDetails,

--- a/src/Rest/Routes/Integrations/Mailer/FormSubmitCustomRoute.php
+++ b/src/Rest/Routes/Integrations/Mailer/FormSubmitCustomRoute.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 namespace EightshiftForms\Rest\Routes\Integrations\Mailer;
 
 use EightshiftForms\Captcha\CaptchaInterface;
+use EightshiftForms\Entries\EntriesHelper;
+use EightshiftForms\Entries\SettingsEntries;
 use EightshiftForms\Integrations\Mailer\SettingsMailer;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsGeneralHelper;
 use EightshiftForms\Validation\ValidatorInterface;
@@ -78,6 +80,12 @@ class FormSubmitCustomRoute extends AbstractFormSubmit
 		$params = $formDetails[UtilsConfig::FD_PARAMS];
 		$action = $formDetails[UtilsConfig::FD_ACTION];
 		$actionExternal = $formDetails[UtilsConfig::FD_ACTION_EXTERNAL];
+
+		// Save entries.
+		if (\apply_filters(SettingsEntries::FILTER_SETTINGS_IS_VALID_NAME, $formId)) {
+			$entryId = EntriesHelper::setEntryByFormDataRef($formDetails);
+			$formDetails[UtilsConfig::FD_ENTRY_ID] = $entryId ? (string) $entryId : '';
+		}
 
 		$debug = [
 			'formDetails' => $formDetails,


### PR DESCRIPTION
### Changed
- Entries now have the ability to save empty fields based on the settings.

### Fixed
- Custom mailer now supports saving entires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to save entries with empty fields.
	- Added support for saving entries via a custom mailer.

- **Bug Fixes**
	- Corrected a typo in the fallback error message for consistency.

- **Refactor**
	- Enhanced entry saving logic to handle empty fields based on new settings.
	- Added new settings for saving empty fields to the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->