### PR TITLE
Release 3.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [3.1.10]
+
+### Fixed
+- Airtable integration now supports multiple select fields.
+- Moments form validation of input fields limiting the number of characters to 1000.
+- Calculator will no longer break reCaptcha validation.
+- Single submit with global msg disabled will no longer output the empty success message.
+- Single submit now supports input type number.
+
+### Added
+- Security feature now supports calculator rate limiting separate setting.
+
 ## [3.1.9]
 
 ### Removed
@@ -356,6 +368,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[3.1.10]: https://github.com/infinum/eightshift-forms/compare/3.1.9...3.1.10
 [3.1.9]: https://github.com/infinum/eightshift-forms/compare/3.1.8...3.1.9
 [3.1.8]: https://github.com/infinum/eightshift-forms/compare/3.1.7...3.1.8
 [3.1.7]: https://github.com/infinum/eightshift-forms/compare/3.1.6...3.1.7

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b157fba0437e94fed471bb88139d810",
+    "content-hash": "777aa442dbc4a5568861928f7ef7fbbd",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -1111,16 +1111,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.11",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "81a161d0b135df89951abd52296adf97deb0723d"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/81a161d0b135df89951abd52296adf97deb0723d",
-                "reference": "81a161d0b135df89951abd52296adf97deb0723d",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
@@ -1190,7 +1190,7 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2024-03-21T18:34:15+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -1731,16 +1731,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.5.2",
+            "version": "v6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840"
+                "reference": "e611a83292d02055a25f83291a98fadd0c21e092"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
-                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/e611a83292d02055a25f83291a98fadd0c21e092",
+                "reference": "e611a83292d02055a25f83291a98fadd0c21e092",
                 "shasum": ""
             },
             "require-dev": {
@@ -1772,9 +1772,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.3"
             },
-            "time": "2024-04-14T17:30:14+00:00"
+            "time": "2024-05-08T02:12:31+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -2195,16 +2195,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.67",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
+                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e524358f930e41a2b4cca1320e3b04fc26b39e0b",
+                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b",
                 "shasum": ""
             },
             "require": {
@@ -2249,7 +2249,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-16T07:22:02+00:00"
+            "time": "2024-05-15T08:00:59+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 3.1.9
+ * Version: 3.1.10
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,4 +17,4 @@ parameters:
 		# Block templates
 		- '#^Variable \$attributes might not be defined\.#'
 		- '#^Variable \$innerBlockContent might not be defined\.#'
-	checkGenericClassInNonGenericObjectType: false
+		- identifier: missingType.generics

--- a/src/Blocks/components/form/assets/captcha.js
+++ b/src/Blocks/components/form/assets/captcha.js
@@ -51,7 +51,7 @@ export class Captcha {
 		}
 
 		if (this.state.getStateCaptchaIsEnterprise()) {
-			grecaptcha?.enterprise.ready(async () => {
+			grecaptcha?.enterprise?.ready(async () => {
 				try {
 					const token = await grecaptcha?.enterprise?.execute(siteKey, {action: actionName});
 
@@ -128,7 +128,7 @@ export class Captcha {
 			return;
 		}
 
-		document.querySelector('body').setAttribute(this.state.getStateAttribute('hideCaptchaBadge'), this.state.getStateCaptchaHideBadge());
+		document?.body?.setAttribute(this.state.getStateAttribute('hideCaptchaBadge'), this.state.getStateCaptchaHideBadge());
 	}
 
 	////////////////////////////////////////////////////////////////

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -1011,7 +1011,8 @@ export class Form {
 
 		if (
 			(this.state.getStateConfigIsAdmin() && this.state.getStateElementIsSingleSubmit(name, formId)) ||
-			(this.state.getStateFormConfigUseSingleSubmit(formId) && (this.state.getStateElementTypeCustom(name, formId) === 'range'))
+			(this.state.getStateFormConfigUseSingleSubmit(formId) && (this.state.getStateElementTypeCustom(name, formId) === 'range')) ||
+			(this.state.getStateFormConfigUseSingleSubmit(formId) && (this.state.getStateElementTypeCustom(name, formId) === 'number'))
 		) {
 			input.addEventListener('input', debounce(this.onInputEvent, 300));
 		} else {
@@ -1705,6 +1706,7 @@ export class Form {
 			!this.state.getStateConfigIsAdmin() &&
 			this.state.getStateFormConfigUseSingleSubmit(formId) && (
 				this.state.getStateElementTypeCustom(name, formId) === 'range' ||
+				this.state.getStateElementTypeCustom(name, formId) === 'number' ||
 				this.state.getStateElementTypeCustom(name, formId) === 'checkbox' ||
 				this.state.getStateElementTypeCustom(name, formId) === 'radio'
 			)

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -272,14 +272,14 @@ export class Utils {
 			return;
 		}
 
-		messageContainer?.classList?.add(this.state.getStateSelector('isActive'));
-		messageContainer.dataset.status = status;
-
 		// Scroll to msg if the condition is matched.
 		if (status === 'success') {
 			if (this.state.getStateFormGlobalMsgHideOnSuccess(formId)) {
 				return;
 			}
+
+			messageContainer?.classList?.add(this.state.getStateSelector('isActive'));
+			messageContainer.dataset.status = status;
 
 			if (!this.state.getStateSettingsDisableScrollToGlobalMsgOnSuccess(formId)) {
 				this.scrollToGlobalMsg(formId);
@@ -293,6 +293,9 @@ export class Utils {
 				messageContainer.innerHTML = `<div><span>${msg}</span></div>`;
 			}
 		} else {
+			messageContainer?.classList?.add(this.state.getStateSelector('isActive'));
+			messageContainer.dataset.status = status;
+
 			const headingError = this.state.getStateFormGlobalMsgHeadingError(formId);
 
 			if (headingError) {

--- a/src/Integrations/Airtable/AirtableClient.php
+++ b/src/Integrations/Airtable/AirtableClient.php
@@ -449,7 +449,7 @@ class AirtableClient implements AirtableClientInterface
 					break;
 				case 'dynamicSelect':
 					if (!\is_array($value)) {
-						$value = [$value];
+						$value = \explode(UtilsConfig::DELIMITER, $value);
 					}
 					break;
 				default:

--- a/src/Integrations/Hubspot/HubspotClient.php
+++ b/src/Integrations/Hubspot/HubspotClient.php
@@ -220,9 +220,9 @@ class HubspotClient implements HubspotClientInterface
 		$body = [
 			'context' => [
 				'ipAddress' => $this->security->getIpAddress(),
-				'hutk' => $params[UtilsHelper::getStateParam('hubspotCookie')]['value'],
-				'pageUri' => UtilsGeneralHelper::cleanPageUrl($params[UtilsHelper::getStateParam('hubspotPageUrl')]['value']),
-				'pageName' => $params[UtilsHelper::getStateParam('hubspotPageName')]['value'],
+				'hutk' => $params[UtilsHelper::getStateParam('hubspotCookie')]['value'] ?? '',
+				'pageUri' => UtilsGeneralHelper::cleanPageUrl($params[UtilsHelper::getStateParam('hubspotPageUrl')]['value'] ?? ''),
+				'pageName' => $params[UtilsHelper::getStateParam('hubspotPageName')]['value'] ?? '',
 			],
 		];
 

--- a/src/Integrations/Moments/MomentsClient.php
+++ b/src/Integrations/Moments/MomentsClient.php
@@ -429,11 +429,13 @@ class MomentsClient extends AbstractMoments implements ClientInterface
 			switch ($type) {
 				case 'select':
 					$explode = \explode(UtilsConfig::DELIMITER, $value);
-
 					$value = \count($explode) > 1 ? $explode : $value;
 					break;
 				case 'checkbox':
 					$value = \explode(UtilsConfig::DELIMITER, $value);
+					break;
+				case 'input':
+					$value = \substr($value, 0, 1000);
 					break;
 				case 'phone':
 					$value = \filter_var($value, \FILTER_SANITIZE_NUMBER_INT);

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -16,6 +16,7 @@ use EightshiftForms\Captcha\SettingsCaptcha;
 use EightshiftForms\Captcha\CaptchaInterface; // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use EightshiftForms\Entries\EntriesHelper;
 use EightshiftForms\Entries\SettingsEntries;
+use EightshiftForms\Integrations\Calculator\SettingsCalculator;
 use EightshiftForms\Labels\LabelsInterface; // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsApiHelper;
 use EightshiftForms\Rest\Routes\Integrations\Mailer\FormSubmitMailerInterface; // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
@@ -204,7 +205,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 
 					// Validate allowed number of requests.
 					// We don't want to limit any custom requests like files, settings, steps, etc.
-					if (!$this->getSecurity()->isRequestValid()) {
+					if (!$this->getSecurity()->isRequestValid($formDetails[UtilsConfig::FD_TYPE])) {
 						throw new UnverifiedRequestException(
 							$this->getValidatorLabels()->getLabel('validationSecurity'),
 							[
@@ -230,7 +231,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 					}
 
 					// Validate captcha.
-					if (\apply_filters(SettingsCaptcha::FILTER_SETTINGS_GLOBAL_IS_VALID_NAME, false)) {
+					if (\apply_filters(SettingsCaptcha::FILTER_SETTINGS_GLOBAL_IS_VALID_NAME, false) && $formDetails[UtilsConfig::FD_TYPE] !== SettingsCalculator::SETTINGS_TYPE_KEY) {
 						$captchaParams = $formDetails[UtilsConfig::FD_CAPTCHA] ?? [];
 
 						if (!$captchaParams) {
@@ -299,11 +300,11 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 					[
 						'exception' => $e,
 						'request' => $request,
-						'formDetails' => $formDetails,
 						self::VALIDATION_ERROR_CODE => \esc_html($e->getData()[self::VALIDATION_ERROR_CODE] ?? ''),
 						self::VALIDATION_ERROR_MSG => \esc_html($e->getMessage()),
 						self::VALIDATION_ERROR_OUTPUT => $e->getData()[self::VALIDATION_ERROR_OUTPUT] ?? '',
 						self::VALIDATION_ERROR_DATA => $e->getData()[self::VALIDATION_ERROR_DATA] ?? '',
+						'formDetails' => $formDetails,
 					]
 				)
 			);

--- a/src/Security/SecurityInterface.php
+++ b/src/Security/SecurityInterface.php
@@ -18,9 +18,11 @@ interface SecurityInterface
 	/**
 	 * Detect if the request is valid using rate limiting.
 	 *
+	 * @param string $formType Form type.
+	 *
 	 * @return boolean
 	 */
-	public function isRequestValid(): bool;
+	public function isRequestValid(string $formType): bool;
 
 	/**
 	 * Get users Ip address.

--- a/src/Security/SettingsSecurity.php
+++ b/src/Security/SettingsSecurity.php
@@ -52,6 +52,11 @@ class SettingsSecurity implements UtilsSettingGlobalInterface, ServiceInterface
 	public const SETTINGS_SECURITY_RATE_LIMIT_KEY = 'security-rate-limit';
 
 	/**
+	 * Rate limit calculator key.
+	 */
+	public const SETTINGS_SECURITY_RATE_LIMIT_CALCULATOR_KEY = 'security-rate-limit-calculator';
+
+	/**
 	 * Rate limit window key.
 	 */
 	public const SETTINGS_SECURITY_RATE_LIMIT_WINDOW_KEY = 'security-rate-limit-window';
@@ -118,8 +123,8 @@ class SettingsSecurity implements UtilsSettingGlobalInterface, ServiceInterface
 							[
 								'component' => 'input',
 								'inputName' => UtilsSettingsHelper::getOptionName(self::SETTINGS_SECURITY_RATE_LIMIT_KEY),
-								'inputFieldLabel' => \__('Number of requests', 'eightshift-forms'),
-								'inputFieldHelp' => \__('Define the maximum number of requests a user can make in the given time period.', 'eightshift-forms'),
+								'inputFieldLabel' => \__('Number of requests general', 'eightshift-forms'),
+								'inputFieldHelp' => \__('Define the maximum number of requests a user can make in the given time period for all forms.', 'eightshift-forms'),
 								'inputType' => 'number',
 								'inputMin' => 1,
 								'inputMax' => 300,
@@ -128,6 +133,20 @@ class SettingsSecurity implements UtilsSettingGlobalInterface, ServiceInterface
 								'inputFieldAfterContent' => \__('per min', 'eightshift-forms'),
 								'inputFieldInlineBeforeAfterContent' => true,
 								'inputValue' => UtilsSettingsHelper::getOptionValue(self::SETTINGS_SECURITY_RATE_LIMIT_KEY),
+							],
+							[
+								'component' => 'input',
+								'inputName' => UtilsSettingsHelper::getOptionName(self::SETTINGS_SECURITY_RATE_LIMIT_CALCULATOR_KEY),
+								'inputFieldLabel' => \__('Number of requests for calculator', 'eightshift-forms'),
+								'inputFieldHelp' => \__('Define the maximum number of requests a user can make in the given time period for calculator forms with single submit.', 'eightshift-forms'),
+								'inputType' => 'number',
+								'inputMin' => 1,
+								'inputMax' => 300,
+								'inputStep' => 1,
+								'inputPlaceholder' => Security::RATE_LIMIT,
+								'inputFieldAfterContent' => \__('per min', 'eightshift-forms'),
+								'inputFieldInlineBeforeAfterContent' => true,
+								'inputValue' => UtilsSettingsHelper::getOptionValue(self::SETTINGS_SECURITY_RATE_LIMIT_CALCULATOR_KEY),
 							],
 							[
 								'component' => 'input',


### PR DESCRIPTION
### Fixed
- Airtable integration now supports multiple select fields.
- Moments form validation of input fields limiting the number of characters to 1000.
- Calculator will no longer break reCaptcha validation.
- Single submit with global msg disabled will no longer output the empty success message.
- Single submit now supports input type number.

### Added
- Security feature now supports calculator rate limiting separate setting.