### PR TITLE
Release 3.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [3.1.12]
+
+### Fixed
+- Geolocation will now work even if forms is configured but global setting is disabled.
+- HubSpot Client fixes for additional params broken after security fixes on the Chrome browser.
+
+### Added
+- Two new filters for encryption and decryption of the data.
+
 ## [3.1.11]
 
 ### Changed
@@ -376,6 +385,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[3.1.12]: https://github.com/infinum/eightshift-forms/compare/3.1.11...3.1.12
 [3.1.11]: https://github.com/infinum/eightshift-forms/compare/3.1.10...3.1.11
 [3.1.10]: https://github.com/infinum/eightshift-forms/compare/3.1.9...3.1.10
 [3.1.9]: https://github.com/infinum/eightshift-forms/compare/3.1.8...3.1.9

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 3.1.11
+ * Version: 3.1.12
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -99,6 +99,21 @@ export class Form {
 	 * @param {object} formsElement Forms element.
 	 */
 	initGolocationForm(formsElement) {
+		// If you have geolocation configured on the form but global setting is turned off. Return first form.
+		if (!this.state.getStateGeolocationIsUsed()) {
+			const formId = formsElement?.querySelector(this.state.getStateSelector('form', true))?.getAttribute(this.state.getStateAttribute('formId')) || '0';
+
+			this.initOnlyFormsInner(formId);
+
+			// Remove geolocation data attribute from forms element.
+			formsElement.removeAttribute(this.state.getStateAttribute('formGeolocation'));
+
+			// Remove loading class from forms element.
+			formsElement?.classList?.remove(this.state.getStateSelector('isGeoLoading'));
+
+			return;
+		}
+
 		const forms = formsElement?.querySelectorAll(this.state.getStateSelector('form', true));
 
 		const formData = new FormData();

--- a/src/Integrations/Hubspot/HubspotClient.php
+++ b/src/Integrations/Hubspot/HubspotClient.php
@@ -217,14 +217,27 @@ class HubspotClient implements HubspotClientInterface
 		$paramsPrepared = $this->prepareParams($params, $formId);
 		$paramsFiles = $this->prepareFiles($files, $formId);
 
-		$body = [
-			'context' => [
-				'ipAddress' => $this->security->getIpAddress(),
-				'hutk' => $params[UtilsHelper::getStateParam('hubspotCookie')]['value'] ?? '',
-				'pageUri' => UtilsGeneralHelper::cleanPageUrl($params[UtilsHelper::getStateParam('hubspotPageUrl')]['value'] ?? ''),
-				'pageName' => $params[UtilsHelper::getStateParam('hubspotPageName')]['value'] ?? '',
-			],
-		];
+		$body = [];
+
+		$pageUrl = UtilsGeneralHelper::cleanPageUrl($params[UtilsHelper::getStateParam('hubspotPageUrl')]['value'] ?? '');
+		if ($pageUrl) {
+			$body['context']['pageUri'] = $pageUrl;
+		}
+
+		$pageName = $params[UtilsHelper::getStateParam('hubspotPageName')]['value'] ?? '';
+		if ($pageName) {
+			$body['context']['pageName'] = $pageName;
+		}
+
+		$hutk = $params[UtilsHelper::getStateParam('hubspotCookie')]['value'] ?? '';
+		if ($hutk) {
+			$body['context']['hutk'] = $hutk;
+		}
+
+		$ip = $this->security->getIpAddress();
+		if ($ip) {
+			$body['context']['ipAddress'] = $ip;
+		}
 
 		$filterName = UtilsHooksHelper::getFilterName(['integrations', SettingsHubspot::SETTINGS_TYPE_KEY, 'prePostId']);
 		if (\has_filter($filterName)) {

--- a/src/Rest/Routes/SubmitGeolocationRoute.php
+++ b/src/Rest/Routes/SubmitGeolocationRoute.php
@@ -71,11 +71,11 @@ class SubmitGeolocationRoute extends AbstractUtilsBaseRoute
 			'request' => $request,
 		];
 
-		// Bailout if troubleshooting "skip captcha" is on.
+		// Bailout if geolocation setting is off.
 		if (!\apply_filters(SettingsGeolocation::FILTER_SETTINGS_GLOBAL_IS_VALID_NAME, false)) {
 			return \rest_ensure_response(
 				UtilsApiHelper::getApiSuccessPublicOutput(
-					\esc_html__('Form captcha skipped due to troubleshooting config set in settings.', 'eightshift-forms'),
+					\esc_html__('Form geolocation skipped. Feature inactive.', 'eightshift-forms'),
 					[],
 					$debug
 				)


### PR DESCRIPTION
### Fixed
- Geolocation will now work even if forms is configured but global setting is disabled.
- HubSpot Client fixes for additional params broken after security fixes on the Chrome browser.

### Added
- Two new filters for encryption and decryption of the data.