### PR TITLE
More value types supported in Countries

### DIFF
--- a/src/Blocks/components/country/components/country-options.js
+++ b/src/Blocks/components/country/components/country-options.js
@@ -11,7 +11,8 @@ import {
 	props,
 	Section,
 	IconToggle,
-	STORE_NAME, Select,
+	STORE_NAME, 
+	Select,
 } from '@eightshift/frontend-libs/scripts';
 import { FieldOptions, FieldOptionsMore, FieldOptionsLayout, FieldOptionsVisibility } from '../../field/components/field-options';
 import { isOptionDisabled, NameField } from '../../utils';
@@ -88,7 +89,7 @@ export const CountryOptions = (attributes) => {
 					icon={icons.required}
 					label={__('Required', 'eightshift-forms')}
 					checked={countryIsRequired}
-					onChange={(value) => {setAttributes({ [getAttrKey('countryIsRequired', attributes, manifest)]: value })}}
+					onChange={(value) => setAttributes({ [getAttrKey('countryIsRequired', attributes, manifest)]: value })}
 					disabled={isOptionDisabled(getAttrKey('countryIsRequired', attributes, manifest), countryDisabledOptions)}
 					noBottomSpacing
 				/>

--- a/src/Blocks/components/country/components/country-options.js
+++ b/src/Blocks/components/country/components/country-options.js
@@ -11,7 +11,7 @@ import {
 	props,
 	Section,
 	IconToggle,
-	STORE_NAME,
+	STORE_NAME, Select,
 } from '@eightshift/frontend-libs/scripts';
 import { FieldOptions, FieldOptionsMore, FieldOptionsLayout, FieldOptionsVisibility } from '../../field/components/field-options';
 import { isOptionDisabled, NameField } from '../../utils';
@@ -34,6 +34,7 @@ export const CountryOptions = (attributes) => {
 	const countryUseSearch = checkAttr('countryUseSearch', attributes, manifest);
 	const countryPlaceholder = checkAttr('countryPlaceholder', attributes, manifest);
 	const countryUseLabelAsPlaceholder = checkAttr('countryUseLabelAsPlaceholder', attributes, manifest);
+	const countryValueType = checkAttr('countryValueType', attributes, manifest);
 
 	return (
 		<PanelBody title={__('Country', 'eightshift-forms')}>
@@ -87,7 +88,7 @@ export const CountryOptions = (attributes) => {
 					icon={icons.required}
 					label={__('Required', 'eightshift-forms')}
 					checked={countryIsRequired}
-					onChange={(value) => setAttributes({ [getAttrKey('countryIsRequired', attributes, manifest)]: value })}
+					onChange={(value) => {setAttributes({ [getAttrKey('countryIsRequired', attributes, manifest)]: value })}}
 					disabled={isOptionDisabled(getAttrKey('countryIsRequired', attributes, manifest), countryDisabledOptions)}
 					noBottomSpacing
 				/>
@@ -114,6 +115,21 @@ export const CountryOptions = (attributes) => {
 					checked={countryUseSearch}
 					onChange={(value) => setAttributes({ [getAttrKey('countryUseSearch', attributes, manifest)]: value })}
 					disabled={isOptionDisabled(getAttrKey('countryUseSearch', attributes, manifest), countryDisabledOptions)}
+				/>
+
+				<Select
+					icon={icons.migrationAlt}
+					value={countryValueType}
+					onChange={(value) => setAttributes({[getAttrKey('countryValueType', attributes, manifest)]: value})}
+					label={__('Value type', 'eightshift-forms')}
+					subtitle={__('Determine whether to send the value as a country code, number or (un)localized name to the integration.', 'eightshift-forms')}
+					options={[
+						{ value: 'countryCode', label: __('Country code', 'eightshift-forms')},
+						{ value: 'countryName', label: __('Localized country name (site locale)', 'eightshift-forms')},
+						{ value: 'countryUnlocalizedName', label: __('Country name in English', 'eightshift-forms')},
+						{ value: 'countryNumber', label: __('Country phone number prefix', 'eightshift-forms')},
+					]}
+					simpleValue
 					noBottomSpacing
 				/>
 			</Section>

--- a/src/Blocks/components/country/country.php
+++ b/src/Blocks/components/country/country.php
@@ -36,6 +36,7 @@ $countryFieldAttrs = Helpers::checkAttr('countryFieldAttrs', $attributes, $manif
 $countryPlaceholder = Helpers::checkAttr('countryPlaceholder', $attributes, $manifest);
 $countryUseLabelAsPlaceholder = Helpers::checkAttr('countryUseLabelAsPlaceholder', $attributes, $manifest);
 $countrySingleSubmit = Helpers::checkAttr('countrySingleSubmit', $attributes, $manifest);
+$countryValueType = Helpers::checkAttr('countryValueType', $attributes, $manifest);
 
 // Fix for getting attribute that is part of the child component.
 $countryHideLabel = false;
@@ -89,7 +90,21 @@ if (has_filter($filterName)) {
 	foreach ($settings['countries'][$datasetList]['items'] as $option) {
 		$label = $option[0] ?? '';
 		$code = $option[1] ?? '';
-		$value = $option[2] ?? '';
+		$value = $option[2] ?? ''; // country phone code
+		$unlocalizedLabel = $option[3] ?? '';
+
+		$optionValue = $label;
+		switch ($countryValueType) {
+			case 'countryCode':
+				$optionValue = $code;
+				break;
+			case 'countryNumber':
+				$optionValue = $value;
+				break;
+			case 'countryUnlocalizedName':
+				$optionValue = $unlocalizedLabel;
+				break;
+		}
 
 		$customProperties = [
 			UtilsHelper::getStateAttribute('selectCountryCode') => $code,
@@ -99,7 +114,7 @@ if (has_filter($filterName)) {
 
 		$options[] = '
 			<option
-				value="' . $label . '"
+				value="' . $optionValue . '"
 				' . UtilsHelper::getStateAttribute('selectCustomProperties') . '=\'' . htmlspecialchars(wp_json_encode($customProperties), ENT_QUOTES, 'UTF-8') . '\'
 				' . selected($code, $settings['country']['preselectedValue'], false) . '
 			>' . $label . '</option>';

--- a/src/Blocks/components/country/country.php
+++ b/src/Blocks/components/country/country.php
@@ -90,7 +90,7 @@ if (has_filter($filterName)) {
 	foreach ($settings['countries'][$datasetList]['items'] as $option) {
 		$label = $option[0] ?? '';
 		$code = $option[1] ?? '';
-		$value = $option[2] ?? ''; // country phone code
+		$value = $option[2] ?? ''; // Country phone code.
 		$unlocalizedLabel = $option[3] ?? '';
 
 		$optionValue = $label;

--- a/src/Blocks/components/country/manifest.json
+++ b/src/Blocks/components/country/manifest.json
@@ -61,6 +61,10 @@
 		"countrySingleSubmit": {
 			"type": "boolean",
 			"default": false
+		},
+		"countryValueType": {
+			"type": "string",
+			"default": "countryName"
 		}
 	}
 }

--- a/src/Countries/Countries.php
+++ b/src/Countries/Countries.php
@@ -38,6 +38,9 @@ class Countries implements CountriesInterface
 						return [
 							'label' => $item[0],
 							'value' => $item[1],
+							'unlocalized-label' => $item[3] ?? $item[0],
+							'code' => $item[1],
+							'phone' => $item[2],
 						];
 					},
 					$countries
@@ -124,267 +127,320 @@ class Countries implements CountriesInterface
 			[
 				\__('Afghanistan', 'eightshift-forms'),
 				'af',
-				'93'
+				'93',
+				'Afghanistan'
 			],
 			[
 				\__('Åland Islands', 'eightshift-forms'),
 				'ax',
-				'358'
+				'358',
+				'Åland Islands'
 			],
 			[
 				\__('Albania', 'eightshift-forms'),
 				'al',
-				'355'
+				'355',
+				'Albania'
 			],
 			[
 				\__('Algeria', 'eightshift-forms'),
 				'dz',
-				'213'
+				'213',
+				'Algeria'
 			],
 			[
 				\__('American Samoa', 'eightshift-forms'),
 				'as',
-				'1684'
+				'1684',
+				'American Samoa'
 			],
 			[
 				\__('Andorra', 'eightshift-forms'),
 				'ad',
-				'376'
+				'376',
+				'Andorra'
 			],
 			[
 				\__('Angola', 'eightshift-forms'),
 				'ao',
-				'244'
+				'244',
+				'Angola'
 			],
 			[
 				\__('Anguilla', 'eightshift-forms'),
 				'ai',
-				'1264'
+				'1264',
+				'Anguilla'
 			],
 			[
 				\__('Antarctica', 'eightshift-forms'),
 				'aq',
-				'672'
+				'672',
+				'Antarctica'
 			],
 			[
 				\__('Antigua and Barbuda', 'eightshift-forms'),
 				'ag',
-				'1268'
+				'1268',
+				'Antigua and Barbuda'
 			],
 			[
 				\__('Argentina', 'eightshift-forms'),
 				'ar',
-				'54'
+				'54',
+				'Argentina'
 			],
 			[
 				\__('Armenia', 'eightshift-forms'),
 				'am',
-				'374'
+				'374',
+				'Armenia'
 			],
 			[
 				\__('Aruba', 'eightshift-forms'),
 				'aw',
-				'297'
+				'297',
+				'Aruba'
 			],
 			[
 				\__('Australia', 'eightshift-forms'),
 				'au',
-				'61'
+				'61',
+				'Australia'
 			],
 			[
 				\__('Austria', 'eightshift-forms'),
 				'at',
-				'43'
+				'43',
+				'Austria'
 			],
 			[
 				\__('Azerbaijan', 'eightshift-forms'),
 				'az',
-				'994'
+				'994',
+				'Azerbaijan'
 			],
 			[
 				\__('Bahamas', 'eightshift-forms'),
 				'bs',
-				'1242'
+				'1242',
+				'Bahamas'
 			],
 			[
 				\__('Bahrain', 'eightshift-forms'),
 				'bh',
-				'973'
+				'973',
+				'Bahrain'
 			],
 			[
 				\__('Bangladesh', 'eightshift-forms'),
 				'bd',
-				'880'
+				'880',
+				'Bangladesh'
 			],
 			[
 				\__('Barbados', 'eightshift-forms'),
 				'bb',
-				'1246'
+				'1246',
+				'Barbados'
 			],
 			[
 				\__('Belarus', 'eightshift-forms'),
 				'by',
-				'375'
+				'375',
+				'Belarus'
 			],
 			[
 				\__('Belgium', 'eightshift-forms'),
 				'be',
-				'32'
+				'32',
+				'Belgium'
 			],
 			[
 				\__('Belize', 'eightshift-forms'),
 				'bz',
-				'501'
+				'501',
+				'Belize'
 			],
 			[
 				\__('Benin', 'eightshift-forms'),
 				'bj',
-				'229'
+				'229',
+				'Benin'
 			],
 			[
 				\__('Bermuda', 'eightshift-forms'),
 				'bm',
-				'1441'
+				'1441',
+				'Bermuda'
 			],
 			[
 				\__('Bhutan', 'eightshift-forms'),
 				'bt',
-				'975'
+				'975',
+				'Bhutan'
 			],
 			[
 				\__('Bolivia', 'eightshift-forms'),
 				'bo',
-				'591'
+				'591',
+				'Bolivia'
 			],
 			[
 				\__('Bonaire', 'eightshift-forms'),
 				'bq',
-				'5997'
+				'5997',
+				'Bonaire'
 			],
 			[
 				\__('Bosnia and Herzegovina', 'eightshift-forms'),
 				'ba',
-				'387'
+				'387',
+				'Bosnia and Herzegovina'
 			],
 			[
 				\__('Botswana', 'eightshift-forms'),
 				'bw',
-				'267'
+				'267',
+				'Botswana'
 			],
 			[
 				\__('Brazil', 'eightshift-forms'),
 				'br',
-				'55'
+				'55',
+				'Brazil'
 			],
 			[
 				\__('British Indian Ocean Territory', 'eightshift-forms'),
 				'io',
-				'246'
+				'246',
+				'British Indian Ocean Territory'
 			],
 			[
 				\__('Brunei Darussalam', 'eightshift-forms'),
 				'bn',
-				'673'
+				'673',
+				'Brunei Darussalam'
 			],
 			[
 				\__('Bulgaria', 'eightshift-forms'),
 				'bg',
-				'359'
+				'359',
+				'Bulgaria'
 			],
 			[
 				\__('Burkina Faso', 'eightshift-forms'),
 				'bf',
-				'226'
+				'226',
+				'Burkina Faso'
 			],
 			[
 				\__('Burundi', 'eightshift-forms'),
 				'bi',
-				'257'
+				'257',
+				'Burundi'
 			],
 			[
 				\__('Cambodia', 'eightshift-forms'),
 				'kh',
-				'855'
+				'855',
+				'Cambodia'
 			],
 			[
 				\__('Cameroon', 'eightshift-forms'),
 				'cm',
-				'237'
+				'237',
+				'Cameroon'
 			],
 			[
 				\__('Canada', 'eightshift-forms'),
 				'ca',
-				'1'
+				'1',
+				'Canada'
 			],
 			[
 				\__('Cabo Verde', 'eightshift-forms'),
 				'cv',
-				'238'
+				'238',
+				'Cabo Verde'
 			],
 			[
 				\__('Cayman Islands', 'eightshift-forms'),
 				'ky',
-				'1345'
+				'1345',
+				'Cayman Islands'
 			],
 			[
 				\__('Central African Republic', 'eightshift-forms'),
 				'cf',
-				'236'
+				'236',
+				'Central African Republic'
 			],
 			[
 				\__('Chad', 'eightshift-forms'),
 				'td',
-				'235'
+				'235',
+				'Chad'
 			],
 			[
 				\__('Chile', 'eightshift-forms'),
 				'cl',
-				'56'
+				'56',
+				'Chile'
 			],
 			[
 				\__('China', 'eightshift-forms'),
 				'cn',
-				'86'
+				'86',
+				'China'
 			],
 			[
 				\__('Christmas Island', 'eightshift-forms'),
 				'cx',
-				'61'
+				'61',
+				'Christmas Island'
 			],
 			[
 				\__('Cocos (Keeling) Island', 'eightshift-forms'),
 				'cc',
-				'61'
+				'61',
+				'Cocos (Keeling) Island'
 			],
 			[
 				\__('Colombia', 'eightshift-forms'),
 				'co',
-				'57'
+				'57',
+				'Colombia'
 			],
 			[
 				\__('Comoros', 'eightshift-forms'),
 				'km',
-				'269'
+				'269',
+				'Comoros'
 			],
 			[
 				\__('Congo', 'eightshift-forms'),
 				'cg',
-				'242'
+				'242',
+				'Congo'
 			],
 			[
 				\__('Congo (Democratic Republic)', 'eightshift-forms'),
 				'cd',
-				'243'
+				'243',
+				'Congo (Democratic Republic)'
 			],
 			[
 				\__('Cook Islands', 'eightshift-forms'),
 				'ck',
-				'682'
+				'682',
+				'Cook Islands'
 			],
 			[
 				\__('Costa Rica', 'eightshift-forms'),
 				'cr',
-				'506'
+				'506',
+				'Costa Rica'
 			],
 			[
 				\__("Côte d'Ivoire", 'eightshift-forms'),
@@ -394,317 +450,380 @@ class Countries implements CountriesInterface
 			[
 				\__('Croatia', 'eightshift-forms'),
 				'hr',
-				'385'
+				'385',
+				'Croatia'
 			],
 			[
 				\__('Curaçao', 'eightshift-forms'),
 				'cw',
-				'599'
+				'599',
+				'Curaçao'
 			],
 			[
 				\__('Cyprus', 'eightshift-forms'),
 				'cy',
-				'357'
+				'357',
+				'Cyprus'
 			],
 			[
 				\__('Czech Republic', 'eightshift-forms'),
 				'cz',
-				'420'
+				'420',
+				'Czech Republic'
 			],
 			[
 				\__('Denmark', 'eightshift-forms'),
 				'dk',
-				'45'
+				'45',
+				'Denmark'
 			],
 			[
 				\__('Djibouti', 'eightshift-forms'),
 				'dj',
-				'253'
+				'253',
+				'Djibouti'
 			],
 			[
 				\__('Dominica', 'eightshift-forms'),
 				'dm',
-				'1767'
+				'1767',
+				'Dominica'
 			],
 			[
 				\__('Dominican Republic', 'eightshift-forms'),
 				'do',
-				'1'
+				'1',
+				'Dominican Republic'
 			],
 			[
 				\__('Ecuador', 'eightshift-forms'),
 				'ec',
-				'593'
+				'593',
+				'Ecuador'
 			],
 			[
 				\__('Egypt', 'eightshift-forms'),
 				'eg',
-				'20'
+				'20',
+				'Egypt'
 			],
 			[
 				\__('El Salvador', 'eightshift-forms'),
 				'sv',
-				'503'
+				'503',
+				'El Salvador'
 			],
 			[
 				\__('Equatorial Guinea', 'eightshift-forms'),
 				'gq',
-				'240'
+				'240',
+				'Equatorial Guinea'
 			],
 			[
 				\__('Eritrea', 'eightshift-forms'),
 				'er',
-				'291'
+				'291',
+				'Eritrea'
 			],
 			[
 				\__('Estonia', 'eightshift-forms'),
 				'ee',
-				'372'
+				'372',
+				'Estonia'
 			],
 			[
 				\__('Eswatini', 'eightshift-forms'),
 				'sz',
-				'268'
+				'268',
+				'Eswatini'
 			],
 			[
 				\__('Ethiopia', 'eightshift-forms'),
 				'et',
-				'251'
+				'251',
+				'Ethiopia'
 			],
 			[
 				\__('Falkland Islands', 'eightshift-forms'),
 				'fk',
-				'500'
+				'500',
+				'Falkland Islands'
 			],
 			[
 				\__('Faroe Islands', 'eightshift-forms'),
 				'fo',
-				'298'
+				'298',
+				'Faroe Islands'
 			],
 			[
 				\__('Fiji', 'eightshift-forms'),
 				'fj',
-				'679'
+				'679',
+				'Fiji'
 			],
 			[
 				\__('Finland', 'eightshift-forms'),
 				'fi',
-				'358'
+				'358',
+				'Finland'
 			],
 			[
 				\__('France', 'eightshift-forms'),
 				'fr',
-				'33'
+				'33',
+				'France'
 			],
 			[
 				\__('French Guiana', 'eightshift-forms'),
 				'gf',
-				'594'
+				'594',
+				'French Guiana'
 			],
 			[
 				\__('French Polynesia', 'eightshift-forms'),
 				'pf',
-				'689'
+				'689',
+				'French Polynesia'
 			],
 			[
 				\__('French Southern Territories', 'eightshift-forms'),
 				'tf',
-				'262'
+				'262',
+				'French Southern Territories'
 			],
 			[
 				\__('Gabon', 'eightshift-forms'),
 				'ga',
-				'241'
+				'241',
+				'Gabon'
 			],
 			[
 				\__('Gambia', 'eightshift-forms'),
 				'gm',
-				'220'
+				'220',
+				'Gambia'
 			],
 			[
 				\__('Georgia', 'eightshift-forms'),
 				'ge',
-				'995'
+				'995',
+				'Georgia'
 			],
 			[
 				\__('Germany', 'eightshift-forms'),
 				'de',
-				'49'
+				'49',
+				'Germany'
 			],
 			[
 				\__('Ghana', 'eightshift-forms'),
 				'gh',
-				'233'
+				'233',
+				'Ghana'
 			],
 			[
 				\__('Gibraltar', 'eightshift-forms'),
 				'gi',
-				'350'
+				'350',
+				'Gibraltar'
 			],
 			[
 				\__('Greece', 'eightshift-forms'),
 				'gr',
-				'30'
+				'30',
+				'Greece'
 			],
 			[
 				\__('Greenland', 'eightshift-forms'),
 				'gl',
-				'299'
+				'299',
+				'Greenland'
 			],
 			[
 				\__('Grenada', 'eightshift-forms'),
 				'gd',
-				'1473'
+				'1473',
+				'Grenada'
 			],
 			[
 				\__('Guadeloupe', 'eightshift-forms'),
 				'gp',
-				'590'
+				'590',
+				'Guadeloupe'
 			],
 			[
 				\__('Guam', 'eightshift-forms'),
 				'gu',
-				'1'
+				'1',
+				'Guam'
 			],
 			[
 				\__('Guatemala', 'eightshift-forms'),
 				'gt',
-				'502'
+				'502',
+				'Guatemala'
 			],
 			[
 				\__('Guernsey', 'eightshift-forms'),
 				'gg',
-				'44'
+				'44',
+				'Guernsey'
 			],
 			[
 				\__('Guinea', 'eightshift-forms'),
 				'gn',
-				'224'
+				'224',
+				'Guinea'
 			],
 			[
 				\__('Guinea-Bissau', 'eightshift-forms'),
 				'gw',
-				'245'
+				'245',
+				'Guinea-Bissau'
 			],
 			[
 				\__('Guyana', 'eightshift-forms'),
 				'gy',
-				'592'
+				'592',
+				'Guyana'
 			],
 			[
 				\__('Haiti', 'eightshift-forms'),
 				'ht',
-				'509'
+				'509',
+				'Haiti'
 			],
 			[
 				\__('Holy See', 'eightshift-forms'),
 				'va',
-				'39'
+				'39',
+				'Holy See'
 			],
 			[
 				\__('Honduras', 'eightshift-forms'),
 				'hn',
-				'504'
+				'504',
+				'Honduras'
 			],
 			[
 				\__('Hong Kong', 'eightshift-forms'),
 				'hk',
-				'852'
+				'852',
+				'Hong Kong'
 			],
 			[
 				\__('Hungary', 'eightshift-forms'),
 				'hu',
-				'36'
+				'36',
+				'Hungary'
 			],
 			[
 				\__('Iceland', 'eightshift-forms'),
 				'is',
-				'354'
+				'354',
+				'Iceland'
 			],
 			[
 				\__('India', 'eightshift-forms'),
 				'in',
-				'91'
+				'91',
+				'India'
 			],
 			[
 				\__('Indonesia', 'eightshift-forms'),
 				'id',
-				'62'
+				'62',
+				'Indonesia'
 			],
 			[
 				\__('Iraq', 'eightshift-forms'),
 				'iq',
-				'964'
+				'964',
+				'Iraq'
 			],
 			[
 				\__('Ireland', 'eightshift-forms'),
 				'ie',
-				'353'
+				'353',
+				'Ireland'
 			],
 			[
 				\__('Isle of Man', 'eightshift-forms'),
 				'im',
-				'44'
+				'44',
+				'Isle of Man'
 			],
 			[
 				\__('Israel', 'eightshift-forms'),
 				'il',
-				'972'
+				'972',
+				'Israel'
 			],
 			[
 				\__('Italy', 'eightshift-forms'),
 				'it',
-				'39'
+				'39',
+				'Italy'
 			],
 			[
 				\__('Jamaica', 'eightshift-forms'),
 				'jm',
-				'1'
+				'1',
+				'Jamaica'
 			],
 			[
 				\__('Japan', 'eightshift-forms'),
 				'jp',
-				'81'
+				'81',
+				'Japan'
 			],
 			[
 				\__('Jersey', 'eightshift-forms'),
 				'je',
-				'44'
+				'44',
+				'Jersey'
 			],
 			[
 				\__('Jordan', 'eightshift-forms'),
 				'jo',
-				'962'
+				'962',
+				'Jordan'
 			],
 			[
 				\__('Kazakhstan', 'eightshift-forms'),
 				'kz',
-				'7'
+				'7',
+				'Kazakhstan'
 			],
 			[
 				\__('Kenya', 'eightshift-forms'),
 				'ke',
-				'254'
+				'254',
+				'Kenya'
 			],
 			[
 				\__('Kiribati', 'eightshift-forms'),
 				'ki',
-				'686'
+				'686',
+				'Kiribati'
 			],
 			[
 				\__('Korea, the Republic of', 'eightshift-forms'),
 				'kr',
-				'82'
+				'82',
+				'Korea, the Republic of'
 			],
 			[
 				\__('Kuwait', 'eightshift-forms'),
 				'kw',
-				'965'
+				'965',
+				'Kuwait'
 			],
 			[
 				\__('Kyrgyzstan', 'eightshift-forms'),
 				'kg',
-				'996'
+				'996',
+				'Kyrgyzstan'
 			],
 			[
 				\__("Lao People's Democratic Republic", 'eightshift-forms'),
@@ -714,632 +833,758 @@ class Countries implements CountriesInterface
 			[
 				\__('Latvia', 'eightshift-forms'),
 				'lv',
-				'371'
+				'371',
+				'Latvia'
 			],
 			[
 				\__('Lebanon', 'eightshift-forms'),
 				'lb',
-				'961'
+				'961',
+				'Lebanon'
 			],
 			[
 				\__('Lesotho', 'eightshift-forms'),
 				'ls',
-				'266'
+				'266',
+				'Lesotho'
 			],
 			[
 				\__('Liberia', 'eightshift-forms'),
 				'lr',
-				'231'
+				'231',
+				'Liberia'
 			],
 			[
 				\__('Libya', 'eightshift-forms'),
 				'ly',
-				'218'
+				'218',
+				'Libya'
 			],
 			[
 				\__('Liechtenstein', 'eightshift-forms'),
 				'li',
-				'423'
+				'423',
+				'Liechtenstein'
 			],
 			[
 				\__('Lithuania', 'eightshift-forms'),
 				'lt',
-				'370'
+				'370',
+				'Lithuania'
 			],
 			[
 				\__('Luxembourg', 'eightshift-forms'),
 				'lu',
-				'352'
+				'352',
+				'Luxembourg'
 			],
 			[
 				\__('Macao', 'eightshift-forms'),
 				'mo',
-				'853'
+				'853',
+				'Macao'
 			],
 			[
 				\__('Madagascar', 'eightshift-forms'),
 				'mg',
-				'261'
+				'261',
+				'Madagascar'
 			],
 			[
 				\__('Malawi', 'eightshift-forms'),
 				'mw',
-				'265'
+				'265',
+				'Malawi'
 			],
 			[
 				\__('Malaysia', 'eightshift-forms'),
 				'my',
-				'60'
+				'60',
+				'Malaysia'
 			],
 			[
 				\__('Maldives', 'eightshift-forms'),
 				'mv',
-				'960'
+				'960',
+				'Maldives'
 			],
 			[
 				\__('Mali', 'eightshift-forms'),
 				'ml',
-				'223'
+				'223',
+				'Mali'
 			],
 			[
 				\__('Malta', 'eightshift-forms'),
 				'mt',
-				'356'
+				'356',
+				'Malta'
 			],
 			[
 				\__('Marshall Islands', 'eightshift-forms'),
 				'mh',
-				'692'
+				'692',
+				'Marshall Islands'
 			],
 			[
 				\__('Martinique', 'eightshift-forms'),
 				'mq',
-				'596'
+				'596',
+				'Martinique'
 			],
 			[
 				\__('Mauritania', 'eightshift-forms'),
 				'mr',
-				'222'
+				'222',
+				'Mauritania'
 			],
 			[
 				\__('Mauritius', 'eightshift-forms'),
 				'mu',
-				'230'
+				'230',
+				'Mauritius'
 			],
 			[
 				\__('Mayotte', 'eightshift-forms'),
 				'yt',
-				'262'
+				'262',
+				'Mayotte'
 			],
 			[
 				\__('Mexico', 'eightshift-forms'),
 				'mx',
-				'52'
+				'52',
+				'Mexico'
 			],
 			[
 				\__('Micronesia (Federated States of)', 'eightshift-forms'),
 				'fm',
-				'691'
+				'691',
+				'Micronesia (Federated States of)'
 			],
 			[
 				\__('Moldova', 'eightshift-forms'),
 				'md',
-				'373'
+				'373',
+				'Moldova'
 			],
 			[
 				\__('Monaco', 'eightshift-forms'),
 				'mc',
-				'377'
+				'377',
+				'Monaco'
 			],
 			[
 				\__('Mongolia', 'eightshift-forms'),
 				'mn',
-				'976'
+				'976',
+				'Mongolia'
 			],
 			[
 				\__('Montenegro', 'eightshift-forms'),
 				'me',
-				'382'
+				'382',
+				'Montenegro'
 			],
 			[
 				\__('Montserrat', 'eightshift-forms'),
 				'ms',
-				'1664'
+				'1664',
+				'Montserrat'
 			],
 			[
 				\__('Morocco', 'eightshift-forms'),
 				'ma',
-				'212'
+				'212',
+				'Morocco'
 			],
 			[
 				\__('Mozambique', 'eightshift-forms'),
 				'mz',
-				'258'
+				'258',
+				'Mozambique'
 			],
 			[
 				\__('Myanmar', 'eightshift-forms'),
 				'mm',
-				'95'
+				'95',
+				'Myanmar'
 			],
 			[
 				\__('Namibia', 'eightshift-forms'),
 				'na',
-				'264'
+				'264',
+				'Namibia'
 			],
 			[
 				\__('Nauru', 'eightshift-forms'),
 				'nr',
-				'674'
+				'674',
+				'Nauru'
 			],
 			[
 				\__('Nepal', 'eightshift-forms'),
 				'np',
-				'977'
+				'977',
+				'Nepal'
 			],
 			[
 				\__('Netherlands', 'eightshift-forms'),
 				'nl',
-				'31'
+				'31',
+				'Netherlands'
 			],
 			[
 				\__('New Caledonia', 'eightshift-forms'),
 				'nc',
-				'687'
+				'687',
+				'New Caledonia'
 			],
 			[
 				\__('New Zealand', 'eightshift-forms'),
 				'nz',
-				'64'
+				'64',
+				'New Zealand'
 			],
 			[
 				\__('Nicaragua', 'eightshift-forms'),
 				'ni',
-				'505'
+				'505',
+				'Nicaragua'
 			],
 			[
 				\__('Niger', 'eightshift-forms'),
 				'ne',
-				'227'
+				'227',
+				'Niger'
 			],
 			[
 				\__('Nigeria', 'eightshift-forms'),
 				'ng',
-				'234'
+				'234',
+				'Nigeria'
 			],
 			[
 				\__('Niue', 'eightshift-forms'),
 				'nu',
-				'683'
+				'683',
+				'Niue'
 			],
 			[
 				\__('Norfolk Island', 'eightshift-forms'),
 				'nf',
-				'672'
+				'672',
+				'Norfolk Island'
 			],
 			[
 				\__('North Macedonia', 'eightshift-forms'),
 				'mk',
-				'389'
+				'389',
+				'North Macedonia'
 			],
 			[
 				\__('Northern Mariana Islands', 'eightshift-forms'),
 				'mp',
-				'1670'
+				'1670',
+				'Northern Mariana Islands'
 			],
 			[
 				\__('Norway', 'eightshift-forms'),
 				'no',
-				'47'
+				'47',
+				'Norway'
 			],
 			[
 				\__('Oman', 'eightshift-forms'),
 				'om',
-				'968'
+				'968',
+				'Oman'
 			],
 			[
 				\__('Pakistan', 'eightshift-forms'),
 				'pk',
-				'92'
+				'92',
+				'Pakistan'
 			],
 			[
 				\__('Palau', 'eightshift-forms'),
 				'pw',
-				'680'
+				'680',
+				'Palau'
 			],
 			[
 				\__('Palestine', 'eightshift-forms'),
 				'ps',
-				'970'
+				'970',
+				'Palestine'
 			],
 			[
 				\__('Panama', 'eightshift-forms'),
 				'pa',
-				'507'
+				'507',
+				'Panama'
 			],
 			[
 				\__('Papua New Guinea', 'eightshift-forms'),
 				'pg',
-				'675'
+				'675',
+				'Papua New Guinea'
 			],
 			[
 				\__('Paraguay', 'eightshift-forms'),
 				'py',
-				'595'
+				'595',
+				'Paraguay'
 			],
 			[
 				\__('Peru', 'eightshift-forms'),
 				'pe',
-				'51'
+				'51',
+				'Peru'
 			],
 			[
 				\__('Philippines', 'eightshift-forms'),
 				'ph',
-				'63'
+				'63',
+				'Philippines'
 			],
 			[
 				\__('Pitcairn', 'eightshift-forms'),
 				'pn',
-				'872'
+				'872',
+				'Pitcairn'
 			],
 			[
 				\__('Poland', 'eightshift-forms'),
 				'pl',
-				'48'
+				'48',
+				'Poland'
 			],
 			[
 				\__('Portugal', 'eightshift-forms'),
 				'pt',
-				'351'
+				'351',
+				'Portugal'
 			],
 			[
 				\__('Puerto Rico', 'eightshift-forms'),
 				'pr',
-				'1'
+				'1',
+				'Puerto Rico'
 			],
 			[
 				\__('Qatar', 'eightshift-forms'),
 				'qa',
-				'974'
+				'974',
+				'Qatar'
 			],
 			[
 				\__('Réunion', 'eightshift-forms'),
 				're',
-				'262'
+				'262',
+				'Réunion'
 			],
 			[
 				\__('Romania', 'eightshift-forms'),
 				'ro',
-				'40'
+				'40',
+				'Romania'
 			],
 			[
 				\__('Russian Federation', 'eightshift-forms'),
 				'ru',
-				'7'
+				'7',
+				'Russian Federation'
 			],
 			[
 				\__('Rwanda', 'eightshift-forms'),
 				'rw',
-				'250'
+				'250',
+				'Rwanda'
 			],
 			[
 				\__('Saba', 'eightshift-forms'),
 				'bg-sa',
-				'5994'
+				'5994',
+				'Saba'
 			],
 			[
 				\__('Saint Barthélemy', 'eightshift-forms'),
 				'bl',
-				'590'
+				'590',
+				'Saint Barthélemy'
 			],
 			[
 				\__('Saint Helena', 'eightshift-forms'),
 				'sh',
-				'290'
+				'290',
+				'Saint Helena'
 			],
 			[
 				\__('Saint Kitts and Nevis', 'eightshift-forms'),
 				'kn',
-				'1869'
+				'1869',
+				'Saint Kitts and Nevis'
 			],
 			[
 				\__('Saint Lucia', 'eightshift-forms'),
 				'lc',
-				'1758'
+				'1758',
+				'Saint Lucia'
 			],
 			[
 				\__('Saint Martin (French part)', 'eightshift-forms'),
 				'mf',
-				'590'
+				'590',
+				'Saint Martin (French part)'
 			],
 			[
 				\__('Saint Pierre and Miquelon', 'eightshift-forms'),
 				'pm',
-				'508'
+				'508',
+				'Saint Pierre and Miquelon'
 			],
 			[
 				\__('Saint Vincent and The Grenadines', 'eightshift-forms'),
 				'vc',
-				'1784'
+				'1784',
+				'Saint Vincent and The Grenadines'
 			],
 			[
 				\__('Samoa', 'eightshift-forms'),
 				'ws',
-				'685'
+				'685',
+				'Samoa'
 			],
 			[
 				\__('San Marino', 'eightshift-forms'),
 				'sm',
-				'378'
+				'378',
+				'San Marino'
 			],
 			[
 				\__('Sao Tome and Principe', 'eightshift-forms'),
 				'st',
-				'239'
+				'239',
+				'Sao Tome and Principe'
 			],
 			[
 				\__('Saudi Arabia', 'eightshift-forms'),
 				'sa',
-				'966'
+				'966',
+				'Saudi Arabia'
 			],
 			[
 				\__('Senegal', 'eightshift-forms'),
 				'sn',
-				'221'
+				'221',
+				'Senegal'
 			],
 			[
 				\__('Serbia', 'eightshift-forms'),
 				'rs',
-				'381'
+				'381',
+				'Serbia'
 			],
 			[
 				\__('Seychelles', 'eightshift-forms'),
 				'sc',
-				'248'
+				'248',
+				'Seychelles'
 			],
 			[
 				\__('Sierra Leone', 'eightshift-forms'),
 				'sl',
-				'232'
+				'232',
+				'Sierra Leone'
 			],
 			[
 				\__('Singapore', 'eightshift-forms'),
 				'sg',
-				'65'
+				'65',
+				'Singapore'
 			],
 			[
 				\__('Sint Maarten', 'eightshift-forms'),
 				'sx',
-				'1721'
+				'1721',
+				'Sint Maarten'
 			],
 			[
 				\__('Slovakia', 'eightshift-forms'),
 				'sk',
-				'421'
+				'421',
+				'Slovakia'
 			],
 			[
 				\__('Slovenia', 'eightshift-forms'),
 				'si',
-				'386'
+				'386',
+				'Slovenia'
 			],
 			[
 				\__('Solomon Islands', 'eightshift-forms'),
 				'sb',
-				'677'
+				'677',
+				'Solomon Islands'
 			],
 			[
 				\__('Somalia', 'eightshift-forms'),
 				'so',
-				'252'
+				'252',
+				'Somalia'
 			],
 			[
 				\__('South Africa', 'eightshift-forms'),
 				'za',
-				'27'
+				'27',
+				'South Africa'
 			],
 			[
 				\__('South Georgia and the South Sandwich Islands', 'eightshift-forms'),
 				'gs',
-				'500'
+				'500',
+				'South Georgia and the South Sandwich Islands'
 			],
 			[
 				\__('South Sudan', 'eightshift-forms'),
 				'ss',
-				'211'
+				'211',
+				'South Sudan'
 			],
 			[
 				\__('Spain', 'eightshift-forms'),
 				'es',
-				'34'
+				'34',
+				'Spain'
 			],
 			[
 				\__('Sri Lanka', 'eightshift-forms'),
 				'lk',
-				'94'
+				'94',
+				'Sri Lanka'
 			],
 			[
 				\__('Sudan', 'eightshift-forms'),
 				'sd',
-				'249'
+				'249',
+				'Sudan'
 			],
 			[
 				\__('Suriname', 'eightshift-forms'),
 				'sr',
-				'597'
+				'597',
+				'Suriname'
 			],
 			[
 				\__('Svalbard', 'eightshift-forms'),
 				'sj',
-				'47'
+				'47',
+				'Svalbard'
 			],
 			[
 				\__('Sweden', 'eightshift-forms'),
 				'se',
-				'46'
+				'46',
+				'Sweden'
 			],
 			[
 				\__('Switzerland', 'eightshift-forms'),
 				'ch',
-				'41'
+				'41',
+				'Switzerland'
 			],
 			[
 				\__('Taiwan, China', 'eightshift-forms'),
 				'tw',
-				'886'
+				'886',
+				'Taiwan, China'
 			],
 			[
 				\__('Tajikistan', 'eightshift-forms'),
 				'tj',
-				'992'
+				'992',
+				'Tajikistan'
 			],
 			[
 				\__('Tanzania', 'eightshift-forms'),
 				'tz',
-				'255'
+				'255',
+				'Tanzania'
 			],
 			[
 				\__('Thailand', 'eightshift-forms'),
 				'th',
-				'66'
+				'66',
+				'Thailand'
 			],
 			[
 				\__('Timor-Leste', 'eightshift-forms'),
 				'tl',
-				'670'
+				'670',
+				'Timor-Leste'
 			],
 			[
 				\__('Togo', 'eightshift-forms'),
 				'tg',
-				'228'
+				'228',
+				'Togo'
 			],
 			[
 				\__('Tokelau', 'eightshift-forms'),
 				'tk',
-				'690'
+				'690',
+				'Tokelau'
 			],
 			[
 				\__('Tonga', 'eightshift-forms'),
 				'to',
-				'676'
+				'676',
+				'Tonga'
 			],
 			[
 				\__('Trinidad and Tobago', 'eightshift-forms'),
 				'tt',
-				'1868'
+				'1868',
+				'Trinidad and Tobago'
 			],
 			[
 				\__('Tunisia', 'eightshift-forms'),
 				'tn',
-				'216'
+				'216',
+				'Tunisia'
 			],
 			[
 				\__('Turkey', 'eightshift-forms'),
 				'tr',
-				'90'
+				'90',
+				'Turkey'
 			],
 			[
 				\__('Turkmenistan', 'eightshift-forms'),
 				'tm',
-				'993'
+				'993',
+				'Turkmenistan'
 			],
 			[
 				\__('Turks and Caicos Islands', 'eightshift-forms'),
 				'tc',
-				'1649'
+				'1649',
+				'Turks and Caicos Islands'
 			],
 			[
 				\__('Tuvalu', 'eightshift-forms'),
 				'tv',
-				'688'
+				'688',
+				'Tuvalu'
 			],
 			[
 				\__('Uganda', 'eightshift-forms'),
 				'ug',
-				'256'
+				'256',
+				'Uganda'
 			],
 			[
 				\__('Ukraine', 'eightshift-forms'),
 				'ua',
-				'380'
+				'380',
+				'Ukraine'
 			],
 			[
 				\__('United Arab Emirates', 'eightshift-forms'),
 				'ae',
-				'971'
+				'971',
+				'United Arab Emirates'
 			],
 			[
 				\__('United Kingdom', 'eightshift-forms'),
 				'gb',
-				'44'
+				'44',
+				'United Kingdom'
 			],
 			[
 				\__('United States', 'eightshift-forms'),
 				'us',
-				'1'
+				'1',
+				'United States'
 			],
 			[
 				\__('United States Minor Outlying Islands', 'eightshift-forms'),
 				'um',
-				'699'
+				'699',
+				'United States Minor Outlying Islands'
 			],
 			[
 				\__('Uruguay', 'eightshift-forms'),
 				'uy',
-				'598'
+				'598',
+				'Uruguay'
 			],
 			[
 				\__('Uzbekistan', 'eightshift-forms'),
 				'uz',
-				'998'
+				'998',
+				'Uzbekistan'
 			],
 			[
 				\__('Vanuatu', 'eightshift-forms'),
 				'vu',
-				'678'
+				'678',
+				'Vanuatu'
 			],
 			[
 				\__('Venezuela', 'eightshift-forms'),
 				've',
-				'58'
+				'58',
+				'Venezuela'
 			],
 			[
 				\__('Vietnam', 'eightshift-forms'),
 				'vn',
-				'84'
+				'84',
+				'Vietnam'
 			],
 			[
 				\__('Virgin Islands (British)', 'eightshift-forms'),
 				'vg',
-				'1284'
+				'1284',
+				'Virgin Islands (British)'
 			],
 			[
 				\__('Virgin Islands (U.S.)', 'eightshift-forms'),
 				'vi',
-				'1340'
+				'1340',
+				'Virgin Islands (U.S.)'
 			],
 			[
 				\__('Wallis and Futuna', 'eightshift-forms'),
 				'wf',
-				'681'
+				'681',
+				'Wallis and Futuna'
 			],
 			[
 				\__('Western Sahara', 'eightshift-forms'),
 				'eh',
-				'212'
+				'212',
+				'Western Sahara'
 			],
 			[
 				\__('Yemen', 'eightshift-forms'),
 				'ye',
-				'967'
+				'967',
+				'Yemen'
 			],
 			[
 				\__('Zambia', 'eightshift-forms'),
 				'zm',
-				'260'
+				'260',
+				'Zambia'
 			],
 			[
 				\__('Zimbabwe', 'eightshift-forms'),
 				'zw',
-				'263'
+				'263',
+				'Zimbabwe'
 			]
 		];
 	}


### PR DESCRIPTION
# Description

I added a new "value type" attribute to the country field and use it to define the option values accordingly. I have adapted the Countries class to support this, but I am not sure whether I need to additionally change existing datasets and whether this covers custom datasets and the hidden value implementation we've discussed.

To do (on my end):
- [ ] Check "custom country list" functionality support
- [ ] Test out on staging instances with integrations
- [ ] Check hidden field support

Linked to 1777, iruzevic knows in which repo 😄 

# Screenshots / Videos

<img width="395" alt="Screenshot 2024-08-14 at 12 37 02" src="https://github.com/user-attachments/assets/52a0a2d3-110f-464d-bb80-9459dbb71bd4">


# Linked documentation PR

N/A