### PR TITLE
updating new mailer response tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -733,6 +733,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[5.1.8]: https://github.com/infinum/eightshift-forms/compare/5.1.8...5.1.9
 [5.1.8]: https://github.com/infinum/eightshift-forms/compare/5.1.7...5.1.8
 [5.1.7]: https://github.com/infinum/eightshift-forms/compare/5.1.6...5.1.7
 [5.1.6]: https://github.com/infinum/eightshift-forms/compare/5.1.5...5.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [5.1.9]
+
+### Added
+- Mailer now supports few new email response keys: `mailerPostTitle`, `mailerPostUrl`, `mailerPostId`, `mailerFormId` and `mailerFormTitle`.
+
 ## [5.1.8]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -733,7 +733,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
-[5.1.8]: https://github.com/infinum/eightshift-forms/compare/5.1.8...5.1.9
+[5.1.9]: https://github.com/infinum/eightshift-forms/compare/5.1.8...5.1.9
 [5.1.8]: https://github.com/infinum/eightshift-forms/compare/5.1.7...5.1.8
 [5.1.7]: https://github.com/infinum/eightshift-forms/compare/5.1.6...5.1.7
 [5.1.6]: https://github.com/infinum/eightshift-forms/compare/5.1.5...5.1.6

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 5.1.8
+ * Version: 5.1.9
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Hooks/FiltersSettingsBuilder.php
+++ b/src/Hooks/FiltersSettingsBuilder.php
@@ -238,6 +238,11 @@ class FiltersSettingsBuilder implements ServiceInterface
 					'mailerSuccessRedirectUrl' => '',
 					'mailerEntryId' => '',
 					'mailerEntryUrl' => '',
+					'mailerPostTitle' => '',
+					'mailerPostUrl' => '',
+					'mailerPostId' => '',
+					'mailerFormId' => '',
+					'mailerFormTitle' => '',
 				],
 				'labels' => [
 					'title' => \__('Mailer', 'eightshift-forms'),

--- a/src/Integrations/Mailer/SettingsMailer.php
+++ b/src/Integrations/Mailer/SettingsMailer.php
@@ -212,6 +212,10 @@ class SettingsMailer extends AbstractSettingsIntegrations implements UtilsSettin
 		$fieldNameTags = UtilsSettingsOutputHelper::getPartialFormFieldNames($fieldNames);
 		$formResponseTags = UtilsSettingsOutputHelper::getPartialFormResponseTags($formDetails[UtilsConfig::FD_TYPE]);
 
+		if ($formDetails[UtilsConfig::FD_TYPE] !== self::SETTINGS_TYPE_KEY) {
+			$formResponseTags .= UtilsSettingsOutputHelper::getPartialFormResponseTags(self::SETTINGS_TYPE_KEY);
+		}
+
 		$isUsed = UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_MAILER_SETTINGS_USE_KEY, self::SETTINGS_MAILER_SETTINGS_USE_KEY, $formId);
 		$isSenderUsed = UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_MAILER_SENDER_USE_KEY, self::SETTINGS_MAILER_SENDER_USE_KEY, $formId);
 		$emailField = UtilsSettingsHelper::getSettingValue(self::SETTINGS_MAILER_EMAIL_FIELD_KEY, $formId);

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -632,7 +632,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 	protected function getCombinedEmailResponseTags(array $formDetails, array $data): array
 	{
 		return \array_merge(
-			$this->getCommonEmailResponseTags($data),
+			$this->getCommonEmailResponseTags($data, $formDetails),
 			$this->getEmailResponseTags($formDetails)
 		);
 	}
@@ -641,10 +641,11 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 	 * Prepare all email response tags.
 	 *
 	 * @param array<string, mixed> $data Data passed from the `getIntegrationResponseSuccessOutputAdditionalData` function.
+	 * @param array<string, mixed> $formDetails Data passed from the `getFormDetailsApi` function.
 	 *
 	 * @return array<string, mixed>
 	 */
-	protected function getCommonEmailResponseTags(array $data): array
+	protected function getCommonEmailResponseTags(array $data, array $formDetails): array
 	{
 		$output = [];
 
@@ -657,6 +658,21 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 					break;
 				case 'mailerEntryId':
 					$output[$key] = $data[UtilsHelper::getStateResponseOutputKey('entry')] ?? '';
+					break;
+				case 'mailerPostUrl':
+					$output[$key] = \get_the_permalink((int) $formDetails['postId']);
+					break;
+				case 'mailerPostTitle':
+					$output[$key] = \get_the_title((int) $formDetails['postId']);
+					break;
+				case 'mailerPostId':
+					$output[$key] = $formDetails['postId'] ?? '';
+					break;
+				case 'mailerFormId':
+					$output[$key] = $formDetails[UtilsHelper::getStateResponseOutputKey('formId')];
+					break;
+				case 'mailerFormTitle':
+					$output[$key] = \get_the_title((int) $data[UtilsHelper::getStateResponseOutputKey('formId')]);
 					break;
 				case 'mailerEntryUrl':
 					$entryId = $data[UtilsHelper::getStateResponseOutputKey('entry')] ?? '';

--- a/src/Rest/Routes/Integrations/Mailer/FormSubmitMailerRoute.php
+++ b/src/Rest/Routes/Integrations/Mailer/FormSubmitMailerRoute.php
@@ -87,7 +87,8 @@ class FormSubmitMailerRoute extends AbstractFormSubmit
 				\array_merge(
 					$successAdditionalData['public'],
 					$successAdditionalData['private']
-				)
+				),
+				$formDetails
 			)
 		);
 


### PR DESCRIPTION

### Added
- Mailer now supports few new email response keys: `mailerPostTitle`, `mailerPostUrl`, `mailerPostId`, `mailerFormId` and `mailerFormTitle`.