### PR TITLE
Lower limit to maximum value in MomentsClient

### DIFF
--- a/src/Integrations/Moments/MomentsClient.php
+++ b/src/Integrations/Moments/MomentsClient.php
@@ -370,7 +370,7 @@ class MomentsClient extends AbstractMoments implements ClientInterface
 	 */
 	private function getMomentsLists()
 	{
-		$url = "{$this->getBaseUrl()}/forms/1/forms?limit=1000";
+		$url = "{$this->getBaseUrl()}/forms/1/forms?limit=100";
 
 		$response = \wp_remote_get(
 			$url,


### PR DESCRIPTION
# Description

Moments API lowered the maximum accepted value for the limit parameter to a 100, refusing requests with a higher number set for the limit.

This caused Forms to crash while loading Moments forms, returning an empty form selector. We did not notice it earlier because of a transient being present.

# Screenshots / Videos

N/A

# Linked documentation PR

N/A
