### PR TITLE
Release 5.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [5.6.6]
+
+### Added
+
+- 2 new response tags for mailer `mailerTimestamp` and `mailerTimestampHuman`.
+- ability for subject to process response tags.
+
+### Changes
+
+- Moments API will not fetch only 100 items per request.
+
 ## [5.6.5]
 
 ### Fixed
@@ -872,6 +883,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[5.6.6]: https://github.com/infinum/eightshift-forms/compare/5.6.5...5.6.6
 [5.6.5]: https://github.com/infinum/eightshift-forms/compare/5.6.4...5.6.5
 [5.6.4]: https://github.com/infinum/eightshift-forms/compare/5.6.3...5.6.4
 [5.6.3]: https://github.com/infinum/eightshift-forms/compare/5.6.2...5.6.3

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 5.6.5
+ * Version: 5.6.6
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Hooks/FiltersSettingsBuilder.php
+++ b/src/Hooks/FiltersSettingsBuilder.php
@@ -236,6 +236,8 @@ class FiltersSettingsBuilder implements ServiceInterface
 					'mailerPostId' => '',
 					'mailerFormId' => '',
 					'mailerFormTitle' => '',
+					'mailerTimestamp' => '',
+					'mailerTimestampHuman' => '',
 				],
 				'labels' => [
 					'title' => \__('Mailer', 'eightshift-forms'),

--- a/src/Integrations/Mailer/Mailer.php
+++ b/src/Integrations/Mailer/Mailer.php
@@ -51,7 +51,7 @@ class Mailer implements MailerInterface
 		// Send email.
 		return \wp_mail(
 			$this->getTemplate('to', $fields, $formId, $to),
-			$this->getTemplate('subject', $fields, $formId, $subject),
+			$this->getTemplate('subject', $fields, $formId, $subject, $responseFields),
 			$this->getTemplate('message', $fields, $formId, $template, $responseFields),
 			$this->getHeader(
 				UtilsSettingsHelper::getSettingValue(SettingsMailer::SETTINGS_MAILER_SENDER_EMAIL_KEY, $formId),

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -698,6 +698,12 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 				case 'mailerFormTitle':
 					$output[$key] = \get_the_title((int) $data[UtilsHelper::getStateResponseOutputKey('formId')]);
 					break;
+				case 'mailerTimestamp':
+					$output[$key] = \current_datetime()->format('YmdHis');
+					break;
+				case 'mailerTimestampHuman':
+					$output[$key] = \current_datetime()->format('Y-m-d H:i:s');
+					break;
 				case 'mailerEntryUrl':
 					$entryId = $data[UtilsHelper::getStateResponseOutputKey('entry')] ?? '';
 					$formId = $data[UtilsHelper::getStateResponseOutputKey('formId')] ?? '';


### PR DESCRIPTION
### Added

- 2 new response tags for mailer `mailerTimestamp` and `mailerTimestampHuman`.
- ability for subject to process response tags.

### Changes

- Moments API will not fetch only 100 items per request.