### PR TITLE
Feature/other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - `phone` field now supports initial selected value both for country picker and number.
 - `field` now support additional `suffix` content that will be displayed after the field input.
 - `radio and checkbox` fields now support one `input` field that can be used as `other` option and this value will be sent with the main values.
+- new `enrichment` prefill option to save all fields defined as `smart` and prefilled all forms that have that field.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,27 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 ### Changed
 
 - Forms are now supporting multiple instances of the same form on the same page.
+- `enrichment` prefill on URL now has totally new logic and ways or prefilling the fields.
+- `JS` internal logic for setting up values on field.
 
 ### Added
 
 - new country order list filter to provide a custom `priority` order for the countries.
 - additional protection for checking if route is private or public for settings.
+- `country` field now supports multiple values, min/max count validation and ability to prefill the field value.
+- `phone` field now supports initial selected value both for country picker and number.
+- `field` now support additional `suffix` content that will be displayed after the field input.
+- `radio and checkbox` fields now support one `input` field that can be used as `other` option and this value will be sent with the main values.
+
+### Removed
+
+- ability for phone/country field to `sync` changes to the other field.
 
 ### Fixed
 
 - broken checkboxes and radios if there are multiple items with the same name.
+- missing email confirmation for `Corvus`, `Calculator` and `Paycek` integrations.
+- success redirect url will no longer send empty encrypted value.
 
 ## [5.6.6]
 

--- a/src/Blocks/SettingsBlocks.php
+++ b/src/Blocks/SettingsBlocks.php
@@ -57,7 +57,6 @@ class SettingsBlocks implements UtilsSettingGlobalInterface, UtilsSettingInterfa
 	public const SETTINGS_BLOCK_PHONE_OVERRIDE_GLOBAL_SETTINGS_KEY = 'block-phone-override-global-settings';
 	public const SETTINGS_BLOCK_PHONE_DATA_SET_KEY = 'block-phone-data-set';
 	public const SETTINGS_BLOCK_PHONE_DATA_SET_GLOBAL_KEY = self::SETTINGS_BLOCK_PHONE_DATA_SET_KEY . '-global';
-	public const SETTINGS_BLOCK_PHONE_DISABLE_SYNC_KEY = 'block-phone-disable-sync';
 	public const SETTINGS_BLOCK_PHONE_DISABLE_PICKER_KEY = 'block-phone-disable-picker';
 	public const SETTINGS_BLOCK_PHONE_USE_COUNTRY_DATA_KEY = 'block-phone-use-country-data';
 	public const SETTINGS_BLOCK_PHONE_USE_COUNTRY_DATA_GLOBAL_KEY = self::SETTINGS_BLOCK_PHONE_USE_COUNTRY_DATA_KEY . '-global';
@@ -187,26 +186,6 @@ class SettingsBlocks implements UtilsSettingGlobalInterface, UtilsSettingInterfa
 									),
 								],
 							] : []),
-							[
-								'component' => 'divider',
-								'dividerExtraVSpacing' => 'true',
-							],
-							[
-								'component' => 'checkboxes',
-								'checkboxesFieldLabel' => '',
-								'checkboxesName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_BLOCK_PHONE_DISABLE_SYNC_KEY),
-								'checkboxesContent' => [
-									[
-										'component' => 'checkbox',
-										'checkboxLabel' => \__('Disable phone/country sync on change', 'eightshift-forms'),
-										'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_BLOCK_PHONE_DISABLE_SYNC_KEY, self::SETTINGS_BLOCK_PHONE_DISABLE_SYNC_KEY, $formId),
-										'checkboxValue' => self::SETTINGS_BLOCK_PHONE_DISABLE_SYNC_KEY,
-										'checkboxSingleSubmit' => true,
-										'checkboxAsToggle' => true,
-										'checkboxAsToggleSize' => 'medium',
-									],
-								],
-							],
 						],
 					],
 				],

--- a/src/Blocks/components/country/components/country-options.js
+++ b/src/Blocks/components/country/components/country-options.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { TextControl, PanelBody } from '@wordpress/components';
+import { TextControl, PanelBody, Button } from '@wordpress/components';
 import {
 	icons,
 	checkAttr,
@@ -13,6 +13,8 @@ import {
 	IconToggle,
 	STORE_NAME, 
 	Select,
+	Control,
+	NumberPicker,
 } from '@eightshift/frontend-libs/scripts';
 import { FieldOptions, FieldOptionsMore, FieldOptionsLayout, FieldOptionsVisibility } from '../../field/components/field-options';
 import { isOptionDisabled, NameField } from '../../utils';
@@ -20,6 +22,10 @@ import { ConditionalTagsOptions } from '../../conditional-tags/components/condit
 
 export const CountryOptions = (attributes) => {
 	const manifest = select(STORE_NAME).getComponent('country');
+
+	const {
+		options,
+	} = manifest;
 
 	const {
 		setAttributes,
@@ -36,6 +42,10 @@ export const CountryOptions = (attributes) => {
 	const countryPlaceholder = checkAttr('countryPlaceholder', attributes, manifest);
 	const countryUseLabelAsPlaceholder = checkAttr('countryUseLabelAsPlaceholder', attributes, manifest);
 	const countryValueType = checkAttr('countryValueType', attributes, manifest);
+	const countryIsMultiple = checkAttr('countryIsMultiple', attributes, manifest);
+	const countryMinCount = checkAttr('countryMinCount', attributes, manifest);
+	const countryMaxCount = checkAttr('countryMaxCount', attributes, manifest);
+	const countryValue = checkAttr('countryValue', attributes, manifest);
 
 	return (
 		<PanelBody title={__('Country', 'eightshift-forms')}>
@@ -93,9 +103,92 @@ export const CountryOptions = (attributes) => {
 					disabled={isOptionDisabled(getAttrKey('countryIsRequired', attributes, manifest), countryDisabledOptions)}
 					noBottomSpacing
 				/>
+
+
+				{countryIsMultiple &&
+					<Control
+						icon={icons.range}
+						label={__('Number of items', 'eightshift-forms')}
+						additionalLabelClasses='es-mb-0!'
+					>
+						<div className='es-h-spaced es-gap-5!'>
+							<div className='es-display-flex es-items-end es-gap-2'>
+								<NumberPicker
+									label={__('Min', 'eightshift-forms')}
+									value={countryMinCount}
+									onChange={(value) => setAttributes({ [getAttrKey('countryMinCount', attributes, manifest)]: value })}
+									min={options.countryMinCount.min}
+									step={options.countryMinCount.step}
+									disabled={isOptionDisabled(getAttrKey('countryMinCount', attributes, manifest), countryDisabledOptions)}
+									placeholder='–'
+									fixedWidth={4}
+									noBottomSpacing
+								/>
+
+								{countryMinCount > 0 && !isOptionDisabled(getAttrKey('countryMinCount', attributes, manifest), countryDisabledOptions) &&
+									<Button
+										label={__('Clear', 'eightshift-forms')}
+										icon={icons.clear}
+										onClick={() => setAttributes({ [getAttrKey('countryMinCount', attributes, manifest)]: undefined })}
+										className='es-button-square-32 es-button-icon-24'
+										showTooltip
+									/>
+								}
+							</div>
+
+							<div className='es-display-flex es-items-end es-gap-2'>
+								<NumberPicker
+									label={__('Max', 'eightshift-forms')}
+									value={countryMaxCount}
+									onChange={(value) => setAttributes({ [getAttrKey('countryMaxCount', attributes, manifest)]: value })}
+									min={options.countryMaxCount.min}
+									step={options.countryMaxCount.step}
+									disabled={isOptionDisabled(getAttrKey('countryMaxCount', attributes, manifest), countryDisabledOptions)}
+									placeholder='–'
+									fixedWidth={4}
+									noBottomSpacing
+								/>
+
+								{countryMaxCount > 0 && !isOptionDisabled(getAttrKey('countryMaxCount', attributes, manifest), countryDisabledOptions) &&
+									<Button
+										label={__('Clear', 'eightshift-forms')}
+										icon={icons.clear}
+										onClick={() => setAttributes({ [getAttrKey('countryMaxCount', attributes, manifest)]: undefined })}
+										className='es-button-square-32 es-button-icon-24'
+										showTooltip
+									/>
+								}
+							</div>
+						</div>
+					</Control>
+				}
 			</Section>
 
 			<Section icon={icons.tools} label={__('Advanced', 'eightshift-forms')}>
+				<TextControl
+					label={<IconLabel icon={icons.titleGeneric} label={__('Initial value', 'eightshift-forms')} />}
+					value={countryValue}
+					onChange={(value) => setAttributes({ [getAttrKey('countryValue', attributes, manifest)]: value })}
+					disabled={isOptionDisabled(getAttrKey('countryValue', attributes, manifest), countryDisabledOptions)}
+					help={__('Initial value of the field. This value depends on the value type.', 'eightshift-forms')}
+				/>
+
+				<Select
+					icon={icons.migrationAlt}
+					value={countryValueType}
+					onChange={(value) => setAttributes({[getAttrKey('countryValueType', attributes, manifest)]: value})}
+					label={__('Value type', 'eightshift-forms')}
+					subtitle={__('Determine whether to send the value as a country code, number or (un)localized name to the integration.', 'eightshift-forms')}
+					options={[
+						{ value: 'countryCode', label: __('Country code', 'eightshift-forms')},
+						{ value: 'countryName', label: __('Localized country name (site locale)', 'eightshift-forms')},
+						{ value: 'countryUnlocalizedName', label: __('Country name in English', 'eightshift-forms')},
+						{ value: 'countryNumber', label: __('Country phone number prefix', 'eightshift-forms')},
+					]}
+					simpleValue
+					noBottomSpacing
+				/>
+
 				<FieldOptionsVisibility
 					{...props('field', attributes, {
 						fieldDisabledOptions: countryDisabledOptions,
@@ -118,20 +211,14 @@ export const CountryOptions = (attributes) => {
 					disabled={isOptionDisabled(getAttrKey('countryUseSearch', attributes, manifest), countryDisabledOptions)}
 				/>
 
-				<Select
-					icon={icons.migrationAlt}
-					value={countryValueType}
-					onChange={(value) => setAttributes({[getAttrKey('countryValueType', attributes, manifest)]: value})}
-					label={__('Value type', 'eightshift-forms')}
-					subtitle={__('Determine whether to send the value as a country code, number or (un)localized name to the integration.', 'eightshift-forms')}
-					options={[
-						{ value: 'countryCode', label: __('Country code', 'eightshift-forms')},
-						{ value: 'countryName', label: __('Localized country name (site locale)', 'eightshift-forms')},
-						{ value: 'countryUnlocalizedName', label: __('Country name in English', 'eightshift-forms')},
-						{ value: 'countryNumber', label: __('Country phone number prefix', 'eightshift-forms')},
-					]}
-					simpleValue
-					noBottomSpacing
+				<IconToggle
+					icon={icons.files}
+					label={__('Allow multi selection', 'eightshift-forms')}
+					checked={countryIsMultiple}
+					onChange={(value) => {
+						setAttributes({ [getAttrKey('countryIsMultiple', attributes, manifest)]: value });
+					}}
+					disabled={isOptionDisabled(getAttrKey('countryIsMultiple', attributes, manifest), countryDisabledOptions)}
 				/>
 			</Section>
 

--- a/src/Blocks/components/country/country.php
+++ b/src/Blocks/components/country/country.php
@@ -38,6 +38,8 @@ $countryUseLabelAsPlaceholder = Helpers::checkAttr('countryUseLabelAsPlaceholder
 $countrySingleSubmit = Helpers::checkAttr('countrySingleSubmit', $attributes, $manifest);
 $countryValueType = Helpers::checkAttr('countryValueType', $attributes, $manifest);
 $countryTwSelectorsData = Helpers::checkAttr('countryTwSelectorsData', $attributes, $manifest);
+$countryIsMultiple = Helpers::checkAttr('countryIsMultiple', $attributes, $manifest);
+$countryValue = Helpers::checkAttr('countryValue', $attributes, $manifest);
 
 $countryId = $countryName . '-' . Helpers::getUnique();
 
@@ -54,6 +56,11 @@ $countryClass = Helpers::classnames([
 
 if ($countryUseSearch) {
 	$countryAttrs[UtilsHelper::getStateAttribute('selectAllowSearch')] = esc_attr($countryUseSearch);
+}
+
+if ($countryIsMultiple) {
+	$countryAttrs[UtilsHelper::getStateAttribute('selectIsMultiple')] = esc_attr($countryIsMultiple);
+	$countryAttrs['multiple'] = 'true';
 }
 
 if ($countryUseLabelAsPlaceholder) {
@@ -90,13 +97,14 @@ if (has_filter($filterName)) {
 		$datasetList = $settings['country']['dataset'];
 	}
 
+	$preselectedValue = $settings['country']['preselectedValue'] ?: $countryValue; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
+
 	foreach ($settings['countries'][$datasetList]['items'] as $option) {
 		$label = $option[0] ?? '';
 		$code = $option[1] ?? '';
 		$value = $option[2] ?? ''; // Country phone code.
 		$unlocalizedLabel = $option[3] ?? '';
 
-		$optionValue = $label;
 		switch ($countryValueType) {
 			case 'countryCode':
 				$optionValue = $code;
@@ -106,6 +114,9 @@ if (has_filter($filterName)) {
 				break;
 			case 'countryUnlocalizedName':
 				$optionValue = $unlocalizedLabel;
+				break;
+			default:
+				$optionValue = $label;
 				break;
 		}
 
@@ -119,7 +130,7 @@ if (has_filter($filterName)) {
 			<option
 				value="' . $optionValue . '"
 				' . UtilsHelper::getStateAttribute('selectCustomProperties') . '=\'' . htmlspecialchars(wp_json_encode($customProperties), ENT_QUOTES, 'UTF-8') . '\'
-				' . selected($code, $settings['country']['preselectedValue'], false) . '
+				' . selected($optionValue, $preselectedValue, false) . '
 			>' . $label . '</option>';
 	}
 }

--- a/src/Blocks/components/country/manifest.json
+++ b/src/Blocks/components/country/manifest.json
@@ -62,12 +62,35 @@
 			"type": "boolean",
 			"default": false
 		},
+		"countryValue": {
+			"type": "string"
+		},
 		"countryValueType": {
 			"type": "string",
 			"default": "countryName"
 		},
 		"countryTwSelectorsData": {
 			"type": "array"
+		},
+		"countryIsMultiple": {
+			"type": "boolean",
+			"default": false
+		},
+		"countryMinCount": {
+			"type": "integer"
+		},
+		"countryMaxCount": {
+			"type": "integer"
+		}
+	},
+	"options": {
+		"countryMinCount": {
+			"min":  0,
+			"step": 1
+		},
+		"countryMaxCount": {
+			"min":  1,
+			"step": 1
 		}
 	}
 }

--- a/src/Blocks/components/field/components/field-editor.js
+++ b/src/Blocks/components/field/components/field-editor.js
@@ -97,6 +97,7 @@ export const FieldEditor = (attributes) => {
 	const fieldHideLabel = checkAttr('fieldHideLabel', attributes, manifest);
 	const fieldBeforeContent = checkAttr('fieldBeforeContent', attributes, manifest);
 	const fieldAfterContent = checkAttr('fieldAfterContent', attributes, manifest);
+	const fieldSuffixContent = checkAttr('fieldSuffixContent', attributes, manifest);
 	const fieldType = checkAttr('fieldType', attributes, manifest);
 	const fieldHelp = checkAttr('fieldHelp', attributes, manifest);
 	const fieldStyle = checkAttr('fieldStyle', attributes, manifest);
@@ -144,6 +145,12 @@ export const FieldEditor = (attributes) => {
 			}
 			<div className={`${componentClass}__content-wrap`}>
 				{fieldContent}
+
+				{fieldSuffixContent &&
+					<div className={`${componentClass}__suffix-content`}>
+						{fieldSuffixContent}
+					</div>
+				}
 			</div>
 			{fieldAfterContent &&
 				<div className={`${componentClass}__after-content`}>

--- a/src/Blocks/components/field/components/field-options.js
+++ b/src/Blocks/components/field/components/field-options.js
@@ -187,6 +187,7 @@ export const FieldOptionsMore = (attributes) => {
 	const fieldHelp = checkAttr('fieldHelp', attributes, manifest);
 	const fieldBeforeContent = checkAttr('fieldBeforeContent', attributes, manifest);
 	const fieldAfterContent = checkAttr('fieldAfterContent', attributes, manifest);
+	const fieldSuffixContent = checkAttr('fieldSuffixContent', attributes, manifest);
 
 	return (
 		<Section
@@ -211,6 +212,13 @@ export const FieldOptionsMore = (attributes) => {
 					label={<IconLabel icon={icons.fieldAfterText} label={__('Above the help text', 'eightshift-forms')} />}
 					value={fieldAfterContent}
 					onChange={(value) => setAttributes({ [getAttrKey('fieldAfterContent', attributes, manifest)]: value })}
+					className='es-no-field-spacing'
+				/>
+
+				<TextControl
+					label={<IconLabel icon={icons.fieldAfterText} label={__('After field text', 'eightshift-forms')} />}
+					value={fieldSuffixContent}
+					onChange={(value) => setAttributes({ [getAttrKey('fieldSuffixContent', attributes, manifest)]: value })}
 					className='es-no-field-spacing'
 				/>
 			</>

--- a/src/Blocks/components/field/field.php
+++ b/src/Blocks/components/field/field.php
@@ -58,6 +58,7 @@ $fieldId = Helpers::checkAttr('fieldId', $attributes, $manifest);
 $fieldName = Helpers::checkAttr('fieldName', $attributes, $manifest);
 $fieldBeforeContent = Helpers::checkAttr('fieldBeforeContent', $attributes, $manifest);
 $fieldAfterContent = Helpers::checkAttr('fieldAfterContent', $attributes, $manifest);
+$fieldSuffixContent = Helpers::checkAttr('fieldSuffixContent', $attributes, $manifest);
 $fieldType = Helpers::checkAttr('fieldType', $attributes, $manifest);
 $fieldUseError = Helpers::checkAttr('fieldUseError', $attributes, $manifest);
 $fieldUseTooltip = Helpers::checkAttr('fieldUseTooltip', $attributes, $manifest);
@@ -140,6 +141,11 @@ $contentClass = Helpers::classnames([
 $beforeContentClass = Helpers::classnames([
 	FormsHelper::getTwPart($twClasses, 'field', 'before-content', "{$componentClass}__before-content"),
 	FormsHelper::getTwPart($twClasses, $selectorClass, 'field-before-content'),
+]);
+
+$suffixContentClass = Helpers::classnames([
+	FormsHelper::getTwPart($twClasses, 'field', 'suffix-content', "{$componentClass}__suffix-content"),
+	FormsHelper::getTwPart($twClasses, $selectorClass, 'field-suffix-content'),
 ]);
 
 $afterContentClass = Helpers::classnames([
@@ -246,6 +252,12 @@ $additionalContent = UtilsGeneralHelper::getBlockAdditionalContentViaFilter('fie
 			<?php } ?>
 			<div class="<?php echo esc_attr($contentWrapClass); ?>">
 				<?php echo $fieldContent; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped ?>
+
+				<?php if ($fieldSuffixContent) { ?>
+					<div class="<?php echo esc_attr($suffixContentClass); ?>">
+						<?php echo $fieldSuffixContent; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped ?>
+					</div>
+				<?php } ?>
 			</div>
 			<?php if ($fieldAfterContent) { ?>
 				<div class="<?php echo esc_attr($afterContentClass); ?>">

--- a/src/Blocks/components/field/manifest.json
+++ b/src/Blocks/components/field/manifest.json
@@ -29,6 +29,9 @@
 		"fieldAfterContent": {
 			"type": "string"
 		},
+		"fieldSuffixContent": {
+			"type": "string"
+		},
 		"fieldName": {
 			"type": "string"
 		},

--- a/src/Blocks/components/form/assets/enrichment.js
+++ b/src/Blocks/components/form/assets/enrichment.js
@@ -106,27 +106,10 @@ export class Enrichment {
 			return;
 		}
 
-		let value = '';
 		let valueData = this.state.getStateElementValue(name, formId);
 
-		if (typeof valueData === 'undefined') {
-			valueData = '';
-		}
-
-		switch (this.state.getStateElementTypeField(name, formId)) {
-			case 'phone':
-				value = {
-					prefix: this.state.getStateElementValueCountry(name, formId)?.number,
-					value: valueData,
-				};
-				break;
-			default:
-				value = valueData;
-				break;
-		}
-
 		const newStorage = {
-			[name]: value,
+			[name]: typeof valueData === 'undefined' ? '' : valueData,
 		};
 
 		this.setLocalStorage(
@@ -319,6 +302,10 @@ export class Enrichment {
 				return;
 			}
 
+			if (!value) {
+				return;
+			}
+
 			switch (this.state.getStateElementTypeField(name, formId)) {
 				case 'phone':
 					this.utils.setManualPhoneValue(formId, name, value);
@@ -335,10 +322,13 @@ export class Enrichment {
 					this.utils.setManualCheckboxValue(formId, name, value);
 					break;
 				case 'radio':
-					this.utils.setManualRadioValue(formId, name, value);
+					this.utils.setManualRadioValue(formId, name, value, true);
 					break;
 				case 'rating':
 					this.utils.setManualRatingValue(formId, name, value);
+					break;
+				case 'range':
+					this.utils.setManualRangeValue(formId, name, value);
 					break;
 				default:
 					this.utils.setManualInputValue(formId, name, value);
@@ -392,7 +382,7 @@ export class Enrichment {
 		// Find url params.
 		const searchParams = new URLSearchParams(window.location.search);
 
-		const param = searchParams.get(`form-${formId}`);
+		const param = searchParams.get(`form-${this.state.getStateFormFid(formId)}`);
 
 		if(!param) {
 			return;
@@ -410,7 +400,7 @@ export class Enrichment {
 			return;
 		}
 
-		this.prefillByData(formId,data);
+		this.prefillByData(formId, data);
 	};
 
 	/**

--- a/src/Blocks/components/form/assets/enrichment.js
+++ b/src/Blocks/components/form/assets/enrichment.js
@@ -460,7 +460,7 @@ export class Enrichment {
 					this.utils.setManualRangeValue(formId, name, value);
 					break;
 				default:
-					this.utils.setManualInputValue(formId, name, value, true, true);
+					this.utils.setManualInputValue(formId, name, value);
 					break;
 			}
 		});
@@ -574,11 +574,11 @@ export class Enrichment {
 			setLocalStorageEnrichment: () => {
 				this.setLocalStorageEnrichment();
 			},
-			setLocalStorageFormPrefill: () => {
-				this.setLocalStorageFormPrefill();
+			setLocalStorageFormPrefill: (formId) => {
+				this.setLocalStorageFormPrefill(formId);
 			},
-			setUrlParamsFormPrefill: () => {
-				this.setUrlParamsFormPrefill();
+			setUrlParamsFormPrefill: (formId) => {
+				this.setUrlParamsFormPrefill(formId);
 			},
 			setLocalStorageFormPrefillItem: (formId, name) => {
 				this.setLocalStorageFormPrefillItem(formId, name);
@@ -595,11 +595,14 @@ export class Enrichment {
 			getUrlAllowedParams: (allowedTags) => {
 				return this.getUrlAllowedParams(allowedTags);
 			},
-			getCookiesAllowedParams: (allowedTags) => {
-				return this.getCookiesAllowedParams(allowedTags);
+			prefillByUrlData: (formId, data) => {
+				this.prefillByUrlData(formId, data);
 			},
 			prefillByLocalstorageData: (formId, data) => {
 				this.prefillByLocalstorageData(formId, data);
+			},
+			getCookiesAllowedParams: (allowedTags) => {
+				return this.getCookiesAllowedParams(allowedTags);
 			},
 			removeEvents: (formId) => {
 				this.removeEvents(formId);

--- a/src/Blocks/components/form/assets/enrichment.js
+++ b/src/Blocks/components/form/assets/enrichment.js
@@ -74,7 +74,7 @@ export class Enrichment {
 
 		this.state.getStateFormElement(formId).addEventListener(
 			this.state.getStateEvent('formJsLoaded'),
-			this.onPrefillEvent
+			this.onLocalstoragePrefillEvent
 		);
 	}
 
@@ -289,20 +289,149 @@ export class Enrichment {
 	}
 
 	/**
-	 * Prefill form fields with data.
+	 * Prefill form fields with data - url params.
 	 *
 	 * @param {string} formId Form ID.
-	 * @param {object} data Data to prefill.
-	 * 
+	 * @param {array} data Field data.
+	 *
+	 * Note:
+	 * Field divider is / and value divider is ==.
+	 *
+	 * Fields:
+	 * - checkboxes (checkboxes==check1---test). If the value is not in the checkboxes group, it will be added to the input field if it exists.
+	 * - input (input==test).
+	 * - range (range==10).
+	 * - rating (rating==1).
+	 * - textarea (textarea==test test).
+	 * - radios (radios==radio-2). If the value is not in the radio group, it will be added to the input field if it exists.
+	 * - date (date==2021-01-01).
+	 * - datetime (datetime==2021-01-01 12:00).
+	 * - select (select==option-1---option-2).
+	 * - phone (phone==385---123456789). Prefix and value.
+	 * - country (country==hr---de). Country code.
+	 *
+	 * Example:
+	 * ?form-840=checkboxes==check1---check2/input==test/range==10
+	 *
 	 * @returns {void}
 	 */
-	prefillByData(formId, data) {
-		Object.entries(data).forEach(([name, value]) => {
-			if (name === 'timestamp') {
+	prefillByUrlData(formId, data) {
+		data.forEach((param) => {
+			const paramItem = param.split('==');
+
+			if(!paramItem.length) {
 				return;
 			}
 
-			if (!value) {
+			const name = paramItem[0];
+			const value = paramItem[1];
+
+			if (!name || !value) {
+				return;
+			}
+
+			switch (this.state.getStateElementTypeField(name, formId)) {
+				case 'phone':
+					const phoneValue = value.split('---');
+
+					if (!phoneValue.length) {
+						break;
+					}
+
+					const newPhoneValue = {
+						prefix: phoneValue[0] || '',
+						value: phoneValue[1] ,
+					};
+
+					this.utils.setManualPhoneValue(formId, name, newPhoneValue);
+					break;
+				case 'date':
+				case 'dateTime':
+					this.utils.setManualDateValue(formId, name, value);
+					break;
+				case 'country':
+				case 'select':
+					const selectValue = value.split('---');
+
+					if (!selectValue.length) {
+						break;
+					}
+
+					const newSelectValue = selectValue.map((item) => ({value: item}));
+
+					this.utils.setManualSelectValue(formId, name, newSelectValue);
+					break;
+				case 'checkbox':
+					const checkboxValue = value.split('---');
+
+					if (!checkboxValue.length) {
+						break;
+					}
+
+					const innerCheckbox = this.state.getStateElementItems(name, formId);
+					const inputCheckbox = this.state.getStateElementCustom(name, formId);
+
+					const newCheckboxValue = {};
+
+					checkboxValue.forEach((item) => {
+						if (item in innerCheckbox) {
+							newCheckboxValue[item] = item;
+						} else {
+							if (inputCheckbox) {
+								this.utils.setManualInputValue(
+									formId,
+									inputCheckbox.name,
+									item,
+								);
+							}
+						}
+					});
+
+					this.utils.setManualCheckboxValue(formId, name, newCheckboxValue);
+					break;
+				case 'radio':
+					const innerRadio = this.state.getStateElementItems(name, formId);
+					const inputRadio = this.state.getStateElementCustom(name, formId);
+
+					// If we have input part of the radio, and the value is not in the radio group add it to the input.
+					if (value !== '' && !innerRadio?.[value] && inputRadio) {
+						this.utils.setManualInputValue(
+							formId,
+							inputRadio.name,
+							value,
+							true,
+							true
+						);
+					}
+
+					this.utils.setManualRadioValue(formId, name, value, true, true);
+					break;
+				case 'rating':
+					this.utils.setManualRatingValue(formId, name, value);
+					break;
+				case 'range':
+					this.utils.setManualRangeValue(formId, name, value);
+					break;
+				default:
+					this.utils.setManualInputValue(formId, name, value);
+					break;
+			}
+		});
+
+		this.utils.dispatchFormEvent(formId, this.state.getStateEvent('enrichmentPrefill'), data);
+	}
+
+	/**
+	 * Prefill form fields with data - localstorage.
+	 *
+	 * @param {string} formId Form ID.
+	 * @param {object} data Field data.
+	 * 
+	 * @returns {void}
+	 */
+	prefillByLocalstorageData(formId, data) {
+		Object.entries(data).forEach(([name, value]) => {
+			if (name === 'timestamp') {
 				return;
 			}
 
@@ -322,7 +451,7 @@ export class Enrichment {
 					this.utils.setManualCheckboxValue(formId, name, value);
 					break;
 				case 'radio':
-					this.utils.setManualRadioValue(formId, name, value, true);
+					this.utils.setManualRadioValue(formId, name, value, true, true);
 					break;
 				case 'rating':
 					this.utils.setManualRatingValue(formId, name, value);
@@ -331,7 +460,7 @@ export class Enrichment {
 					this.utils.setManualRangeValue(formId, name, value);
 					break;
 				default:
-					this.utils.setManualInputValue(formId, name, value);
+					this.utils.setManualInputValue(formId, name, value, true, true);
 					break;
 			}
 		});
@@ -351,7 +480,7 @@ export class Enrichment {
 	removeEvents(formId) {
 		this.state.getStateFormElement(formId)?.removeEventListener(
 			this.state.getStateEvent('formJsLoaded'),
-			this.onPrefillEvent
+			this.onLocalstoragePrefillEvent
 		);
 
 		this.state.getStateFormElement(formId)?.removeEventListener(
@@ -382,25 +511,19 @@ export class Enrichment {
 		// Find url params.
 		const searchParams = new URLSearchParams(window.location.search);
 
-		const param = searchParams.get(`form-${this.state.getStateFormFid(formId)}`);
+		let params = searchParams.get(`form-${this.state.getStateFormFid(formId)}`);
 
-		if(!param) {
+		if(!params) {
 			return;
 		}
 
-		let data = {};
+		params = params.split('/');
 
-		try {
-			data = JSON.parse(param);
-		} catch {
+		if(!params.length) {
 			return;
 		}
 
-		if(!data) {
-			return;
-		}
-
-		this.prefillByData(formId, data);
+		this.prefillByUrlData(formId, params);
 	};
 
 	/**
@@ -410,7 +533,7 @@ export class Enrichment {
 	 *
 	 * @returns {void}
 	 */
-	onPrefillEvent = (event) => {
+	onLocalstoragePrefillEvent = (event) => {
 		const { formId } = event.detail;
 
 		let data = {};
@@ -425,7 +548,7 @@ export class Enrichment {
 			return;
 		}
 
-		this.prefillByData(formId, data);
+		this.prefillByLocalstorageData(formId, data);
 	};
 
 	////////////////////////////////////////////////////////////////
@@ -475,8 +598,8 @@ export class Enrichment {
 			getCookiesAllowedParams: (allowedTags) => {
 				return this.getCookiesAllowedParams(allowedTags);
 			},
-			prefillByData: (formId, data) => {
-				this.prefillByData(formId, data);
+			prefillByLocalstorageData: (formId, data) => {
+				this.prefillByLocalstorageData(formId, data);
 			},
 			removeEvents: (formId) => {
 				this.removeEvents(formId);
@@ -484,8 +607,8 @@ export class Enrichment {
 			onUrlParamsPrefillEvent: (event) => {
 				this.onUrlParamsPrefillEvent(event);
 			},
-			onPrefillEvent: (event) => {
-				this.onPrefillEvent(event);
+			onLocalstoragePrefillEvent: (event) => {
+				this.onLocalstoragePrefillEvent(event);
 			},
 		};
 	}

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -199,6 +199,8 @@ export class Form {
 	 * @returns {void}
 	 */
 	initOne(formId) {
+		console.log(formId);
+		
 		// Regular submit.
 		this.state.getStateFormElement(formId).addEventListener('submit', this.onFormSubmitEvent);
 
@@ -2104,6 +2106,9 @@ export class Form {
 			},
 			setupInputField: (formId, name) => {
 				this.setupInputField(formId, name);
+			},
+			setupRangeField: (formId, name) => {
+				this.setupRangeField(formId, name);
 			},
 			setupRatingField: (formId, name) => {
 				this.setupRatingField(formId, name);

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -1840,7 +1840,37 @@ export class Form {
 		const name = field.getAttribute(this.state.getStateAttribute('fieldName'));
 		const customType = this.state.getStateElementTypeCustom(name, formId);
 
-		this.utils.setOnUserChangeInput(event.target);
+		const {
+			value,
+			checked,
+		 } = event?.target;
+
+		switch (customType) {
+			case 'checkbox':
+				this.utils.setManualCheckboxValue(
+					formId,
+					name,
+					{
+						[value]: checked ? value : '',
+					}
+				);
+				break;
+			case 'radio':
+				this.utils.setManualRadioValue(formId, name, value);
+				break;
+			case 'phone':
+				this.utils.setManualPhoneValue(formId, name, {
+					prefix: '',
+					value,
+				});
+				break;
+			case 'range':
+				this.utils.setManualRangeValue(formId, name, value);
+				break;
+			default:
+				this.utils.setManualInputValue(formId, name, value);
+				break;
+		}
 
 		// Used only for admin single submit.
 		if (this.state.getStateConfigIsAdmin() && this.state.getStateElementIsSingleSubmit(name, formId)) {
@@ -1878,7 +1908,6 @@ export class Form {
 		const field = this.state.getFormFieldElementByChild(event.target);
 		const name = field.getAttribute(this.state.getStateAttribute('fieldName'));
 		const value = event.target.getAttribute(this.state.getStateAttribute('ratingValue'));
-		const input = this.state.getStateElementInput(name, formId);
 		const disabled = this.state.getStateElementIsDisabled(name, formId);
 
 		if (disabled) {
@@ -1886,8 +1915,6 @@ export class Form {
 		}
 
 		this.utils.setManualRatingValue(formId, name, value);
-
-		this.utils.setOnUserChangeInput(input);
 
 		// Used only for admin single submit.
 		if (this.state.getStateConfigIsAdmin() && this.state.getStateElementIsSingleSubmit(name, formId)) {

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -225,6 +225,11 @@ export class Form {
 			this.setupInputField(formId, input.name);
 		});
 
+		// Range.
+		[...this.state.getStateElementByTypeField('range', formId)].forEach((range) => {
+			this.setupRangeField(formId, range.name);
+		});
+
 		// Date.
 		[
 			...this.state.getStateElementByTypeField('date', formId),
@@ -659,7 +664,6 @@ export class Form {
 			const saveAsJson = this.state.getStateElementSaveAsJson(key, formId);
 			const items = this.state.getStateElementItems(key, formId);
 			const field = this.state.getStateElementField(key, formId);
-			const valueCountry = this.state.getStateElementValueCountry(key, formId);
 			const disabled = this.state.getStateElementIsDisabled(key, formId);
 
 			// Skip select search field.
@@ -736,18 +740,22 @@ export class Form {
 
 					this.FORM_DATA.append(name, JSON.stringify(data));
 					break;
+				case 'select':
+				case 'country':
+					if (disabled) {
+						break;
+					}
+
+					data.value = data.value.map((item) => item.value);
+
+					this.FORM_DATA.append(name, JSON.stringify(data));
+					break;
 				case 'phone':
 					if (disabled) {
 						break;
 					}
 
-					if (!this.state.getStateFormConfigPhoneDisablePicker(formId) && value) {
-						if (typeof valueCountry.number !== 'undefined') {
-							data.value = `${valueCountry.number}${value}`;
-						} else {
-							data.value = '';
-						}
-					}
+					data.value = data?.value?.combined ?? '';
 
 					this.FORM_DATA.append(name, JSON.stringify(data));
 					break;
@@ -933,7 +941,7 @@ export class Form {
 		this.buildFormDataItems([
 			{
 				name: this.state.getStateParam('formId'),
-				value: this.state.getStateFormFId(formId),
+				value: this.state.getStateFormFid(formId),
 			},
 			{
 				name: this.state.getStateParam('postId'),
@@ -1099,16 +1107,41 @@ export class Form {
 		input.addEventListener('blur', this.onBlurEvent);
 		input.addEventListener('keydown', this.onKeyDownEvent);
 
-
-		// If field range, set current value to DOM.
-		if (this.state.getStateElementTypeCustom(name, formId) === 'range') {
-			this.utils.setRangeCurrentValue(formId, name);
+		if (
+			(this.state.getStateConfigIsAdmin() && this.state.getStateElementIsSingleSubmit(name, formId)) ||
+			(this.state.getStateFormConfigUseSingleSubmit(formId) && (this.state.getStateElementTypeCustom(name, formId) === 'number'))
+		) {
+			input.addEventListener('input', debounce(this.onInputEvent, 300));
+		} else {
+			input.addEventListener('input', this.onInputEvent);
 		}
+	}
+
+	/**
+	 * Setup range field.
+	 *
+	 * @param {string} formId Form Id.
+	 * @param {string} name Field name.
+	 *
+	 * @returns {void}
+	 */
+	setupRangeField(formId, name) {
+		const input = this.state.getStateElementInput(name, formId);
+
+		this.state.setStateElementLoaded(name, true, formId);
+
+		this.utils.setFieldFilledState(formId, name);
+
+		input.addEventListener('keydown', this.onFocusEvent);
+		input.addEventListener('focus', this.onFocusEvent);
+		input.addEventListener('blur', this.onBlurEvent);
+		input.addEventListener('keydown', this.onKeyDownEvent);
+
+		this.utils.setRangeCurrentValue(formId, name);
 
 		if (
 			(this.state.getStateConfigIsAdmin() && this.state.getStateElementIsSingleSubmit(name, formId)) ||
-			(this.state.getStateFormConfigUseSingleSubmit(formId) && (this.state.getStateElementTypeCustom(name, formId) === 'range')) ||
-			(this.state.getStateFormConfigUseSingleSubmit(formId) && (this.state.getStateElementTypeCustom(name, formId) === 'number'))
+			this.state.getStateFormConfigUseSingleSubmit(formId)
 		) {
 			input.addEventListener('input', debounce(this.onInputEvent, 300));
 		} else {
@@ -1201,13 +1234,13 @@ export class Form {
 					utils.setFieldFilledState(formId, name);
 				},
 				onOpen: function () {
-					utils.setFieldActiveState(formId, name);
+					utils.setActiveState(formId, name);
 				},
 				onClose: function () {
 					utils.unsetActiveState(formId, name);
 				},
-				onChange: function () {
-					utils.setOnUserChangeDate(input);
+				onChange: function (selectedDates, dateStr) {
+					utils.setManualDateValue(formId, name, dateStr, false);
 				},
 			});
 		});
@@ -1429,7 +1462,7 @@ export class Form {
 				this.buildFormDataItems([
 					{
 						name: this.state.getStateParam('formId'),
-						value: this.state.getStateFormFId(formId),
+						value: this.state.getStateFormFid(formId),
 					},
 					{
 						name: this.state.getStateParam('postId'),
@@ -1559,6 +1592,17 @@ export class Form {
 			// Text.
 			[...this.state.getStateElementByTypeField('input', formId)].forEach((text) => {
 				const input = this.state.getStateElementInput(text.name, formId);
+
+				input?.removeEventListener('keydown', this.onFocusEvent);
+				input?.removeEventListener('focus', this.onFocusEvent);
+				input?.removeEventListener('blur', this.onBlurEvent);
+				input?.removeEventListener('input', this.onInputEvent);
+				input?.removeEventListener('keydown', this.onKeyDownEvent);
+			});
+
+			// Range.
+			[...this.state.getStateElementByTypeField('range', formId)].forEach((range) => {
+				const input = this.state.getStateElementInput(range.name, formId);
 
 				input?.removeEventListener('keydown', this.onFocusEvent);
 				input?.removeEventListener('focus', this.onFocusEvent);
@@ -1805,10 +1849,31 @@ export class Form {
 		const field = this.state.getFormFieldElementByChild(event.target);
 		const name = field.getAttribute(this.state.getStateAttribute('fieldName'));
 
-		this.utils.setOnUserChangeSelect(event.target);
+		this.state.setState([StateEnum.ELEMENTS, name, StateEnum.INPUT_SELECT], event.target, formId);
 
-		if (!this.state.getStateElementValue(name, formId) || !this.state.getStateElementValue(name, formId)?.length) {
-			this.utils.unsetFilledState(formId, name);
+		const options = event.detail.value !== '' ? [...event.target.options].map((option) => {
+				return {
+					value: option?.value,
+					meta: JSON.parse(option?.getAttribute(this.state.getStateAttribute('selectCustomProperties')) || '{}'),
+				};
+		}) : [];
+
+		switch (this.state.getStateElementTypeField(name, formId)) {
+			case 'phone':
+				const phoneValue = this.state.getStateElementValue(name, formId);
+
+				this.utils.setManualPhoneValue(formId, name, {
+					prefix: options?.[0]?.value || '',
+					meta: options?.[0]?.meta || {},
+					value: phoneValue?.value || '',
+				}, false);
+				break;
+			case 'country':
+				this.utils.setManualCountryValue(formId, name, options, false);
+				break;
+			case 'select':
+				this.utils.setManualSelectValue(formId, name, options, false);
+				break;
 		}
 
 		// Used only for admin single submit.
@@ -1838,37 +1903,41 @@ export class Form {
 		const formId = this.state.getFormIdByElement(event.target);
 		const field = this.state.getFormFieldElementByChild(event.target);
 		const name = field.getAttribute(this.state.getStateAttribute('fieldName'));
-		const customType = this.state.getStateElementTypeCustom(name, formId);
+		const type = this.state.getStateElementTypeField(name, formId);
 
 		const {
 			value,
 			checked,
 		 } = event?.target;
 
-		switch (customType) {
+		switch (type) {
 			case 'checkbox':
 				this.utils.setManualCheckboxValue(
 					formId,
 					name,
 					{
 						[value]: checked ? value : '',
-					}
+					},
+					false
 				);
 				break;
 			case 'radio':
-				this.utils.setManualRadioValue(formId, name, value);
+				this.utils.setManualRadioValue(formId, name, value, false);
 				break;
 			case 'phone':
+				const phoneValue = this.state.getStateElementValue(name, formId);
+
 				this.utils.setManualPhoneValue(formId, name, {
-					prefix: '',
-					value,
-				});
+					prefix: phoneValue?.prefix || '',
+					meta: phoneValue?.meta || {},
+					value: value || '',
+				}, false);
 				break;
 			case 'range':
-				this.utils.setManualRangeValue(formId, name, value);
+				this.utils.setManualRangeValue(formId, name, value, false);
 				break;
 			default:
-				this.utils.setManualInputValue(formId, name, value);
+				this.utils.setManualInputValue(formId, name, value, false);
 				break;
 		}
 
@@ -1886,10 +1955,10 @@ export class Form {
 		if (
 			!this.state.getStateConfigIsAdmin() &&
 			this.state.getStateFormConfigUseSingleSubmit(formId) && (
-				customType === 'range' ||
-				customType === 'number' ||
-				customType === 'checkbox' ||
-				customType === 'radio'
+				type === 'range' ||
+				type === 'number' ||
+				type === 'checkbox' ||
+				type === 'radio'
 			)
 		) {
 			debounce(this.formSubmit(formId), 100);
@@ -1914,7 +1983,7 @@ export class Form {
 			return;
 		}
 
-		this.utils.setManualRatingValue(formId, name, value);
+		this.utils.setManualRatingValue(formId, name, value, false);
 
 		// Used only for admin single submit.
 		if (this.state.getStateConfigIsAdmin() && this.state.getStateElementIsSingleSubmit(name, formId)) {
@@ -2074,6 +2143,9 @@ export class Form {
 			},
 			onSelectChangeEvent: (event) => {
 				this.onSelectChangeEvent(event);
+			},
+			onSelectRemoveEvent: (event) => {
+				this.onSelectRemoveEvent(event);
 			},
 			onInputEvent: (event) => {
 				this.onInputEvent(event);

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -199,8 +199,6 @@ export class Form {
 	 * @returns {void}
 	 */
 	initOne(formId) {
-		console.log(formId);
-		
 		// Regular submit.
 		this.state.getStateFormElement(formId).addEventListener('submit', this.onFormSubmitEvent);
 

--- a/src/Blocks/components/form/assets/geolocation.js
+++ b/src/Blocks/components/form/assets/geolocation.js
@@ -79,38 +79,49 @@ export class Geolocation {
 		].forEach((select) => {
 			const name = select.name;
 
-			const typeInternal = this.state.getStateElementTypeField(name, formId);
 			const custom = this.state.getStateElementCustom(name, formId);
 
-			const selectValue = this.utils.getSelectSelectedValueByCustomData(typeInternal, countryCookie, custom);
+			const selectValue = this.getSelectSelectedValueByCustomData(countryCookie, custom);
 
 			if (selectValue) {
-				this.utils.setManualSelectValue(formId, name, selectValue);
+				this.utils.setManualSelectValue(formId, name, [
+					{
+						value: selectValue?.value ?? '',
+						meta: selectValue?.customProperties ?? {},
+					}
+				]);
 			}
 		});
 
-		if (!this.state.getStateFormConfigPhoneDisablePicker(formId) && this.state.getStateFormConfigPhoneUseSync(formId)) {
-			[...this.state.getStateElementByTypeField('phone', formId)].forEach((phone) => {
-				const name = phone.name;
+		[...this.state.getStateElementByTypeField('phone', formId)].forEach((phone) => {
+			const name = phone.name;
 
-				const typeInternal = this.state.getStateElementTypeField(name, formId);
-				const custom = this.state.getStateElementCustom(name, formId);
+			const custom = this.state.getStateElementCustom(name, formId);
 
-				const selectValue = this.utils.getSelectSelectedValueByCustomData(typeInternal, countryCookie, custom);
+			const selectValue = this.getSelectSelectedValueByCustomData(countryCookie, custom);
 
-				if (selectValue) {
-					this.utils.setManualPhoneValue(
-						formId,
-						name,
-						{
-							prefix: selectValue,
-							value: this.state.getStateElementValue(name, formId),
-						}
-					);
-				}
-			});
-		}
+			if (selectValue) {
+				this.utils.setManualPhoneValue(formId, name, {
+					prefix: selectValue?.value ?? '',
+					value: '',
+					meta: selectValue?.customProperties ?? {},
+				});
+			}
+		});
 	};
+
+	/**
+	 * Get selected value by custom data of select for country and phone.
+	 *
+	 * @param {string} type Type for field.
+	 * @param {string} value Value to check.
+	 * @param {object} choices Choices object.
+	 *
+	 * @returns {string}
+	 */
+	getSelectSelectedValueByCustomData(value, choices) {
+		return choices?.config?.choices?.find((item) => item?.customProperties?.[this.state.getStateAttribute('selectCountryCode')] === value);
+	}
 
 	////////////////////////////////////////////////////////////////
 	// Private methods - not shared to the public window object.

--- a/src/Blocks/components/form/assets/payment-gateways.js
+++ b/src/Blocks/components/form/assets/payment-gateways.js
@@ -1,3 +1,5 @@
+import { setStateWindow, prefix } from './state-init';
+
 /**
  * PaymentGateways class.
  */

--- a/src/Blocks/components/form/assets/payment-gateways.js
+++ b/src/Blocks/components/form/assets/payment-gateways.js
@@ -13,6 +13,9 @@ export class PaymentGateways {
 		this.state = state;
 
 		this.response = response;
+
+		// Set all public methods.
+		this.publicMethods();
 	}
 
 	/**
@@ -82,5 +85,38 @@ export class PaymentGateways {
 		document.body.appendChild(form);
 		form.submit();
 		document.body.removeChild(form);
+	}
+
+
+	////////////////////////////////////////////////////////////////
+	// Private methods - not shared to the public window object.
+	////////////////////////////////////////////////////////////////
+
+	/**
+	 * Set all public methods.
+	 *
+	 * @returns {void}
+	 */
+	publicMethods() {
+		setStateWindow();
+
+		if (window[prefix].paymentGateways) {
+			return;
+		}
+
+		window[prefix].paymentGateways = {
+			init: () => {
+				this.init();
+			},
+			initFormActionSubmit: () => {
+				this.initFormActionSubmit();
+			},
+			initUrlRedirect: (url) => {
+				this.initUrlRedirect(url);
+			},
+			initFormSubmitBuilder: (url, params) => {
+				this.initFormSubmitBuilder(url, params);
+			},
+		};
 	}
 }

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -2,7 +2,6 @@
 
 import globalManifest from '../../../manifest.json';
 import utilsManifest from '../../../../../vendor-prefixed/infinum/eightshift-forms-utils/src/manifest.json';
-import { set } from 'ol/transform';
 
 ////////////////////////////////////////////////////////////////
 // Constants

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -30,10 +30,8 @@ export const StateEnum = {
 	FIELDSET: 'fieldset',
 	RANGE_CURRENT: 'rangeCurrent',
 	VALUE: 'value',
-	VALUE_COMBINED: 'valueCombined',
 	INITIAL: 'initial',
 	VALUES: 'values',
-	VALUE_COUNTRY: 'valueCountry',
 	INPUT: 'input',
 	INPUT_SELECT: 'inputSelect',
 	ITEMS: 'items',
@@ -80,7 +78,6 @@ export const StateEnum = {
 	CONFIG_SELECT_USE_SEARCH: 'useSearch',
 	CONFIG_SELECT_USE_MULTIPLE: 'useMultiple',
 	CONFIG_PHONE_DISABLE_PICKER: 'disablePhoneCountryPicker',
-	CONFIG_PHONE_USE_PHONE_SYNC: 'usePhoneSync',
 	CONFIG_USE_SINGLE_SUBMIT: 'useSingleSubmit',
 
 	SETTINGS: 'settings',
@@ -327,7 +324,6 @@ export function setStateFormInitial(formId) {
 
 	// Form settings
 	setState([StateEnum.FORM, StateEnum.CONFIG, StateEnum.CONFIG_PHONE_DISABLE_PICKER], Boolean(formElement?.getAttribute(getStateAttribute('phoneDisablePicker'))), formId);
-	setState([StateEnum.FORM, StateEnum.CONFIG, StateEnum.CONFIG_PHONE_USE_PHONE_SYNC], Boolean(formElement?.getAttribute(getStateAttribute('phoneSync'))), formId);
 	setState([StateEnum.FORM, StateEnum.CONFIG, StateEnum.CONFIG_USE_SINGLE_SUBMIT], Boolean(formElement?.getAttribute(getStateAttribute('singleSubmit'))), formId);
 
 	const globalMsg = formElement?.querySelector(getStateSelector('globalMsg', true));
@@ -396,61 +392,42 @@ export function setStateFormInitial(formId) {
 				break;
 			case 'select-one':
 			case 'select-multiple':
-				// Combined fields like phone can have field null.
-				const isMultiple = Boolean(item.getAttribute(getStateAttribute('selectIsMultiple')));
+				const selectedValues = [...item.options].filter((option) => option?.selected).map((option) => {
+					return {
+						value: option?.value,
+						meta: JSON.parse(option?.getAttribute(getStateAttribute('selectCustomProperties')))
+					};
+				}).filter((option) => option.value);
 
-				if (item.options.length && (fieldType === 'phone' || fieldType === 'country')) {
-					let customData = item?.options[item?.options?.selectedIndex]?.getAttribute(getStateAttribute('selectCustomProperties'));
-
-					if (typeof customData === 'string') {
-						customData = JSON.parse(customData);
-					}
-
-					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'code'], customData[getStateAttribute('selectCountryCode')], formId);
-					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'label'], customData[getStateAttribute('selectCountryLabel')], formId);
-					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'number'], customData[getStateAttribute('selectCountryNumber')], formId);
-				}
-
-				if (fieldType !== 'phone') {
-					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
-					setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], value, formId);
-
-					[...item.children].forEach((option) => {
-						const value = option?.value;
-
-						if (value) {
-							setState([StateEnum.ELEMENTS, name, StateEnum.ITEMS, name, StateEnum.NAME], value, formId);
-						}
-					});
-
-					if (isMultiple) {
-						const multipleValues = [...item.options].filter((option) => option?.selected).map((option) => option?.value);
-
-						setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], multipleValues, formId);
-						setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], multipleValues, formId);
-					}
-				}
+				setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], selectedValues, formId);
+				setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], selectedValues, formId);
 
 				setState([StateEnum.ELEMENTS, name, StateEnum.IS_DISABLED], disabled, formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.INPUT], item, formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.CONFIG, StateEnum.CONFIG_SELECT_USE_SEARCH], Boolean(item.getAttribute(getStateAttribute('selectAllowSearch'))), formId);
-				setState([StateEnum.ELEMENTS, name, StateEnum.CONFIG, StateEnum.CONFIG_SELECT_USE_MULTIPLE], isMultiple, formId);
+				setState([StateEnum.ELEMENTS, name, StateEnum.CONFIG, StateEnum.CONFIG_SELECT_USE_MULTIPLE], Boolean(item.getAttribute(getStateAttribute('selectIsMultiple'))), formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.TRACKING], field.getAttribute(getStateAttribute('tracking')), formId);
 				break;
 			case 'tel':
-				setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], value, formId);
-				setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
+				if (getState([StateEnum.FORM, StateEnum.CONFIG, StateEnum.CONFIG_PHONE_DISABLE_PICKER], formId)) {
+					setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], { value: value }, formId);
+					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], { value: value }, formId);
+				} else {
+					const newPhonePrefix = getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)?.[0]?.value ?? '';
+					const newPhoneValue = {
+						prefix: getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)?.[0]?.value ?? '',
+						value: value,
+						meta: getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)?.[0]?.meta ?? {},
+						combined: newPhonePrefix ? `${newPhonePrefix}${value}` : value,
+					};
+
+					setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], newPhoneValue, formId);
+					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], newPhoneValue, formId);
+				}
 				setState([StateEnum.ELEMENTS, name, StateEnum.INPUT], item, formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.IS_DISABLED], disabled, formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.INPUT_SELECT], field.querySelector('select'), formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.TRACKING], field.getAttribute(getStateAttribute('tracking')), formId);
-
-				if (!value) {
-					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], '', formId);
-				} else {
-					const countryValue = getState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY], formId)?.number ?? '';
-					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], `${countryValue}${value}`, formId);
-				}
 				break;
 			case 'date':
 			case 'datetime-local':
@@ -611,175 +588,30 @@ export function setSteps(formElement, formId) {
 }
 
 /**
- * Set state values when the field changes - Input.
+ * Set state values when the field changes.
  *
  * @param {object} item Item/field to check.
  * @param {string} formId Form ID.
  *
  * @returns {void}
  */
-export function setStateValuesInput(item, formId) {
-	const {
-		name,
-		value,
-	} = item;
-
-	// Datepicker and dropzone are set using native lib events.
+export function setStateValues(name, value, formId) {
 	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
-}
 
-/**
- * Set state values when the field changes - Radio.
- *
- * @param {object} item Item/field to check.
- * @param {string} formId Form ID.
- *
- * @returns {void}
- */
-export function setStateValuesRadio(item, formId) {
-	const {
-		name,
-		value,
-		checked,
-	} = item;
+	switch (getStateFieldType(name)) {
+		case 'phone':
+			const newValue = {
+				...value,
+				combined: value?.prefix ? `${value?.prefix}${value?.value}` : value?.value,
+			 };
 
-	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], checked ? value : '', formId);
-}
-
-/**
- * Set state values when the field changes - Checkbox.
- *
- * @param {object} item Item/field to check.
- * @param {string} formId Form ID.
- *
- * @returns {void}
- */
-export function setStateValuesCheckbox(item, formId) {
-	const {
-		name,
-		value,
-		checked,
-	} = item;
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE, value], checked ? value : '', formId);
-}
-
-/**
- * Set state values when the field changes - Phone input.
- *
- * @param {object} item Item/field to check.
- * @param {string} formId Form ID.
- *
- * @returns {void}
- */
-export function setStateValuesPhoneInput(item, formId) {
-	const {
-		name,
-		value,
-	} = item;
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], '', formId);
-
-	if (value) {
-		const countryValue = getState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY], formId)?.number ?? '';
-		setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], `${countryValue}${value}`, formId);
+			setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], newValue, formId);
+			break;
+		default:
+			setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
+			break;
 	}
 }
-
-/**
- * Set state values when the field changes - Select.
- *
- * @param {object} item Item/field to check.
- * @param {string} formId Form ID.
- *
- * @returns {void}
- */
-export function setStateValuesSelect(item, formId) {
-	const {
-		name,
-		value,
-	} = item;
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
-
-	if (getState([StateEnum.ELEMENTS, name, StateEnum.CONFIG, StateEnum.CONFIG_SELECT_USE_MULTIPLE], formId)) {
-		const multipleValues = [...item.options].filter((option) => option?.selected).map((option) => option?.value);
-		setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], multipleValues, formId);
-	}
-}
-
-/**
- * Set state values when the field changes - Country.
- *
- * @param {object} item Item/field to check.
- * @param {string} formId Form ID.
- *
- * @returns {void}
- */
-export function setStateValuesCountry(item, formId) {
-	const {
-		name,
-		value,
-	} = item;
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-
-	let customData = item?.options[item?.options?.selectedIndex]?.getAttribute(getStateAttribute('selectCustomProperties'));
-
-	if (typeof customData === 'string') {
-		customData = JSON.parse(customData);
-	}
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'code'], customData?.[getStateAttribute('selectCountryCode')], formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'label'], customData?.[getStateAttribute('selectCountryLabel')], formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'number'], customData?.[getStateAttribute('selectCountryNumber')], formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
-
-	if (getState([StateEnum.ELEMENTS, name, StateEnum.CONFIG, StateEnum.CONFIG_SELECT_USE_MULTIPLE], formId)) {
-		const multipleValues = [...item.options].filter((option) => option?.selected).map((option) => option?.value);
-		setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], multipleValues, formId);
-	}
-}
-
-/**
- * Set state values when the field changes - Phone select.
- *
- * @param {object} item Item/field to check.
- * @param {string} formId Form ID.
- *
- * @returns {void}
- */
-export function setStateValuesPhoneSelect(item, formId) {
-	const {
-		name,
-	} = item;
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-
-	let customData = item?.options[item?.options?.selectedIndex]?.getAttribute(getStateAttribute('selectCustomProperties'));
-
-	if (typeof customData === 'string') {
-		customData = JSON.parse(customData);
-	}
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'code'], customData?.[getStateAttribute('selectCountryCode')], formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'label'], customData?.[getStateAttribute('selectCountryLabel')], formId);
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY, 'number'], customData?.[getStateAttribute('selectCountryNumber')], formId);
-
-	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], '', formId);
-
-	if (getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)) {
-		const countryValue = getState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY], formId)?.number ?? '';
-		setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], `${countryValue}${getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)}`, formId);
-	}
-}
-
 
 /**
  * Set state conditional tags on one field.

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -27,6 +27,7 @@ export const StateEnum = {
 	ACTION_EXTERNAL: 'actionExternal',
 	SECURE_DATA: 'secureData',
 	FIELD: 'field',
+	FIELDSET: 'fieldset',
 	RANGE_CURRENT: 'rangeCurrent',
 	VALUE: 'value',
 	VALUE_COMBINED: 'valueCombined',
@@ -464,7 +465,7 @@ export function setStateFormInitial(formId) {
 				setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.INPUT], item, formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.IS_DISABLED], disabled, formId);
-				setState([StateEnum.ELEMENTS, name, StateEnum.RANGE_CURRENT], field.querySelector(getStateSelector('inputRangeCurrent', true)), formId);
+				setState([StateEnum.ELEMENTS, name, StateEnum.RANGE_CURRENT], field.querySelectorAll(getStateSelector('inputRangeCurrent', true)), formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.TRACKING], field.getAttribute(getStateAttribute('tracking')), formId);
 				break;
 			default:
@@ -490,6 +491,7 @@ export function setStateFormInitial(formId) {
 		setState([StateEnum.ELEMENTS, name, StateEnum.LOADED], false, formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.NAME], name, formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.FIELD], field, formId);
+		setState([StateEnum.ELEMENTS, name, StateEnum.FIELDSET], field?.closest('fieldset'), formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.ERROR], field?.querySelector(getStateSelector('error', true)), formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.IS_ADMIN_SINGLE_SUBMIT], item?.classList?.contains(getStateSelector('submitSingle', true).substring(1)), formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.TYPE_CUSTOM], field?.getAttribute(getStateAttribute('fieldTypeCustom')), formId);

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -2,6 +2,7 @@
 
 import globalManifest from '../../../manifest.json';
 import utilsManifest from '../../../../../vendor-prefixed/infinum/eightshift-forms-utils/src/manifest.json';
+import { set } from 'ol/transform';
 
 ////////////////////////////////////////////////////////////////
 // Constants
@@ -359,6 +360,7 @@ export function setStateFormInitial(formId) {
 
 		const field = formElement.querySelector(`${getStateSelector('field', true)}[${getStateAttribute('fieldName')}="${name}"]`);
 		const fieldType = field?.getAttribute(getStateAttribute('fieldType'));
+		const fieldset = field?.closest('fieldset');
 
 		// Make changes depending on the field type.
 		switch (type) {
@@ -451,6 +453,10 @@ export function setStateFormInitial(formId) {
 				setState([StateEnum.ELEMENTS, name, StateEnum.INPUT], item, formId);
 				setState([StateEnum.ELEMENTS, name, StateEnum.IS_DISABLED], disabled, formId);
 
+				if (fieldset) {
+					setState([StateEnum.ELEMENTS, fieldset.getAttribute(getStateAttribute('fieldName')), StateEnum.CUSTOM], item, formId);
+				}
+
 				if (fieldType === 'rating') {
 					setState([StateEnum.ELEMENTS, name, StateEnum.CUSTOM], field.querySelector(getStateSelector('rating', true)), formId);
 				}
@@ -468,7 +474,7 @@ export function setStateFormInitial(formId) {
 		setState([StateEnum.ELEMENTS, name, StateEnum.LOADED], false, formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.NAME], name, formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.FIELD], field, formId);
-		setState([StateEnum.ELEMENTS, name, StateEnum.FIELDSET], field?.closest('fieldset'), formId);
+		setState([StateEnum.ELEMENTS, name, StateEnum.FIELDSET], fieldset, formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.ERROR], field?.querySelector(getStateSelector('error', true)), formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.IS_ADMIN_SINGLE_SUBMIT], item?.classList?.contains(getStateSelector('submitSingle', true).substring(1)), formId);
 		setState([StateEnum.ELEMENTS, name, StateEnum.TYPE_CUSTOM], field?.getAttribute(getStateAttribute('fieldTypeCustom')), formId);

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -475,10 +475,10 @@ export function setStateFormInitial(formId) {
 					setState([StateEnum.ELEMENTS, name, StateEnum.CUSTOM], field.querySelector(getStateSelector('rating', true)), formId);
 				}
 
-				if (field.getAttribute(getStateAttribute('fieldPreventSubmit'))) {
+				if (field?.getAttribute(getStateAttribute('fieldPreventSubmit'))) {
 					setState([StateEnum.ELEMENTS, name, StateEnum.IS_DISABLED], Boolean(field.getAttribute(getStateAttribute('fieldPreventSubmit'))), formId);
 				}
-				setState([StateEnum.ELEMENTS, name, StateEnum.TRACKING], field.getAttribute(getStateAttribute('tracking')), formId);
+				setState([StateEnum.ELEMENTS, name, StateEnum.TRACKING], field?.getAttribute(getStateAttribute('tracking')), formId);
 				break;
 		}
 

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -105,6 +105,7 @@ export const StateEnum = {
 	ENRICHMENT_EXPIRATION: 'expiration',
 	ENRICHMENT_EXPIRATION_PREFILL: 'expirationPrefill',
 	ENRICHMENT_ALLOWED: 'allowed',
+	ENRICHMENT_ALLOWED_SMART: 'allowedSmart',
 
 	GEOLOCATION: 'geolocation',
 
@@ -275,6 +276,7 @@ export function setStateInitial() {
 		setState([StateEnum.ENRICHMENT_EXPIRATION], enrichment.expiration, StateEnum.ENRICHMENT);
 		setState([StateEnum.ENRICHMENT_EXPIRATION_PREFILL], enrichment.expirationPrefill, StateEnum.ENRICHMENT);
 		setState([StateEnum.ENRICHMENT_ALLOWED], Object.values(enrichment.allowed), StateEnum.ENRICHMENT);
+		setState([StateEnum.ENRICHMENT_ALLOWED_SMART], Object.values(enrichment.allowedSmart), StateEnum.ENRICHMENT);
 		setState([StateEnum.NAME], 'es-storage', StateEnum.ENRICHMENT);
 	}
 }

--- a/src/Blocks/components/form/assets/state.js
+++ b/src/Blocks/components/form/assets/state.js
@@ -270,8 +270,11 @@ export class State {
 	getStateElementByLoaded = (type, formId) => {
 		return this.getStateFilteredBykey(StateEnum.ELEMENTS, StateEnum.LOADED, type, formId);
 	};
+	getStateElementsObject = (formId) => {
+		return getState([StateEnum.ELEMENTS], formId);
+	};
 	getStateElements = (formId) => {
-		const items = getState([StateEnum.ELEMENTS], formId);
+		const items = this.getStateElementsObject(formId);
 
 		return items ? Object.entries(items) : [];
 	};

--- a/src/Blocks/components/form/assets/state.js
+++ b/src/Blocks/components/form/assets/state.js
@@ -459,8 +459,14 @@ export class State {
 	getStateEnrichmentAllowed = () => {
 		return getState([StateEnum.ENRICHMENT_ALLOWED], StateEnum.ENRICHMENT);
 	};
+	getStateEnrichmentAllowedSmart = () => {
+		return getState([StateEnum.ENRICHMENT_ALLOWED_SMART], StateEnum.ENRICHMENT);
+	};
 	getStateEnrichmentStorageName = () => {
 		return getState([StateEnum.NAME], StateEnum.ENRICHMENT);
+	};
+	getStateEnrichmentSmartStorageName = () => {
+		return `${getState([StateEnum.NAME], StateEnum.ENRICHMENT)}-smart`;
 	};
 	getStateEnrichmentFormPrefillStorageName = (formId) => {
 		return `${getState([StateEnum.NAME], StateEnum.ENRICHMENT)}-${this.getStateFormFid(formId)}`;

--- a/src/Blocks/components/form/assets/state.js
+++ b/src/Blocks/components/form/assets/state.js
@@ -316,6 +316,9 @@ export class State {
 	getStateElementField = (name, formId) => {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.FIELD], formId);
 	};
+	getStateElementFieldset = (name, formId) => {
+		return getState([StateEnum.ELEMENTS, name, StateEnum.FIELDSET], formId);
+	};
 	getStateElementIsDisabled = (name, formId) => {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.IS_DISABLED], formId);
 	};

--- a/src/Blocks/components/form/assets/state.js
+++ b/src/Blocks/components/form/assets/state.js
@@ -61,7 +61,7 @@ export class State {
 	getStateFormPostId = (formId) => {
 		return getState([StateEnum.FORM, StateEnum.POST_ID], formId);
 	};
-	getStateFormFId = (formId) => {
+	getStateFormFid = (formId) => {
 		return getState([StateEnum.FORM, StateEnum.FORM_FID], formId);
 	};
 	getStateFormIsAdminSingleSubmit = (formId) => {
@@ -142,9 +142,6 @@ export class State {
 
 	getStateFormConfigPhoneDisablePicker = (formId) => {
 		return getState([StateEnum.FORM, StateEnum.CONFIG, StateEnum.CONFIG_PHONE_DISABLE_PICKER], formId);
-	};
-	getStateFormConfigPhoneUseSync = (formId) => {
-		return getState([StateEnum.FORM, StateEnum.CONFIG, StateEnum.CONFIG_PHONE_USE_PHONE_SYNC], formId);
 	};
 	getStateFormConfigUseSingleSubmit = (formId) => {
 		return getState([StateEnum.FORM, StateEnum.CONFIG, StateEnum.CONFIG_USE_SINGLE_SUBMIT], formId);
@@ -326,7 +323,7 @@ export class State {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.LOADED], formId);
 	};
 	getStateElementTypeField = (name, formId) => {
-		return getState([StateEnum.ELEMENTS, name, StateEnum.TYPE_FIELD], formId);
+		return this.getStateFieldType(getState([StateEnum.ELEMENTS, name, StateEnum.TYPE_FIELD], formId));
 	};
 	getStateElementTypeCustom = (name, formId) => {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.TYPE_CUSTOM], formId);
@@ -339,9 +336,6 @@ export class State {
 	};
 	getStateElementSaveAsJson = (name, formId) => {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.SAVE_AS_JSON], formId);
-	};
-	getStateElementValueCountry = (name, formId) => {
-		return getState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY], formId);
 	};
 	getStateElementInitial = (name, formId) => {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], formId);
@@ -367,9 +361,6 @@ export class State {
 	getStateElementValue = (name, formId) => {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId);
 	};
-	getStateElementValueCombined = (name, formId) => {
-		return getState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], formId);
-	};
 	getStateElementError = (name, formId) => {
 		return getState([StateEnum.ELEMENTS, name, StateEnum.ERROR], formId);
 	};
@@ -385,12 +376,6 @@ export class State {
 
 	setStateElementValue = (name, value, formId) => {
 		setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
-	};
-	setStateElementValueCountry = (name, value, formId) => {
-		setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COUNTRY], value, formId);
-	};
-	setStateElementValueCombined = (name, value, formId) => {
-		setState([StateEnum.ELEMENTS, name, StateEnum.VALUE_COMBINED], value, formId);
 	};
 	setStateElementLoaded = (name, value, formId) => {
 		setState([StateEnum.ELEMENTS, name, StateEnum.LOADED], value, formId);
@@ -475,7 +460,7 @@ export class State {
 		return getState([StateEnum.NAME], StateEnum.ENRICHMENT);
 	};
 	getStateEnrichmentFormPrefillStorageName = (formId) => {
-		return `${getState([StateEnum.NAME], StateEnum.ENRICHMENT)}-${formId}`;
+		return `${getState([StateEnum.NAME], StateEnum.ENRICHMENT)}-${this.getStateFormFid(formId)}`;
 	};
 
 	////////////////////////////////////////////////////////////////
@@ -566,6 +551,9 @@ export class State {
 	};
 	getFormIdByElement = (element) => {
 		return this.getFormElementByChild(element)?.getAttribute(this.getStateAttribute('formId'));
+	};
+	getFormFidByElement = (element) => {
+		return this.getFormElementByChild(element)?.getAttribute(this.getStateAttribute('formFid'));
 	};
 	getFieldNameByElement = (element) => {
 		return this.getFormFieldElementByChild(element)?.getAttribute(this.getStateAttribute('fieldName'));

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -860,10 +860,20 @@ export class Utils {
 	 * @param {string} name Field name.
 	 * @param {object} value Field value.
 	 * @param {bool} set Set value.
+	 *
+	 * Expected value format:
+	 * {
+	 *  prefix: '1',
+	 *  value: '1234567890'
+	 * }
 	 * 
 	 * @returns {void}
 	 */
 	setManualPhoneValue(formId, name, value, set = true) {
+		if (typeof value !== 'object') {
+			return;
+		}
+
 		// For manual setting.
 		if (set) {
 			if (!this.state.getStateFormConfigPhoneDisablePicker(formId)) {
@@ -896,10 +906,18 @@ export class Utils {
 	 * @param {string} name Field name.
 	 * @param {string} value Field value.
 	 * @param {bool} set Set value.
+	 *
+	 * Expected value format:
+	 * '2021-01-01'
+	 * '2021-01-01 12:00'
 	 * 
 	 * @returns {void}
 	 */
 	setManualDateValue(formId, name, value, set = true) {
+		if (typeof value !== 'string') {
+			return;
+		}
+
 		// For manual setting.
 		if (set) {
 			const custom = this.state.getStateElementCustom(name, formId);
@@ -926,9 +944,19 @@ export class Utils {
 	 * @param {array} value Field value.
 	 * @param {bool} set Set value.
 	 * 
+	 * Expected value format:
+	 * [
+	 *  { value: '1' },
+	 *  { value: '2' },
+	 * ]
+	 * 
 	 * @returns {void}
 	 */
 	setManualSelectValue(formId, name, value, set = true) {
+		if (!Array.isArray(value)) {
+			return;
+		}
+
 		this.state.getStateElementCustom(name, formId).setChoiceByValue(value);
 
 			// For manual setting.
@@ -937,7 +965,7 @@ export class Utils {
 
 			if (custom) {
 				if (value.length) {
-					custom.setChoiceByValue(value.map((item) => item.value));
+					custom.setChoiceByValue(value?.map((item) => item.value));
 				} else {
 					custom.removeActiveItems();
 				}
@@ -958,7 +986,14 @@ export class Utils {
 	 * 
 	 * @param {string} formId Form Id.
 	 * @param {string} name Field name.
-	 * @param {object} value Field value.
+	 * @param {array} value Field value.
+	 * @param {bool} set Set value.
+	 * 
+	 * Expected value format:
+	 * [
+	 *  { value: 'hr' },
+	 *  { value: 'de' },
+	 * ]
 	 * 
 	 * @returns {void}
 	 */
@@ -971,12 +1006,22 @@ export class Utils {
 	 * 
 	 * @param {string} formId Form Id.
 	 * @param {string} name Field name.
-	 * @param {object} value Field value.
+	 * @param {array} value Field value.
 	 * @param {bool} set Set value.
+	 *
+	 * Expected value format:
+	 * {
+	 *  checkbox-1: checkbox-1,
+	 *  checkbox-2: checkbox-2,
+	 * }
 	 * 
 	 * @returns {void}
 	 */
 	setManualCheckboxValue(formId, name, value, set = true) {
+		if (typeof value !== 'object') {
+			return;
+		}
+
 		if (set) {
 			const inner = this.state.getStateElementItems(name, formId);
 
@@ -1006,21 +1051,29 @@ export class Utils {
 	 * @param {bool} set Set value.
 	 * @param {bool} ignoreCustomRadio Ignore custom radio.
 	 * 
+	 * Expected value format:
+	 * 'radio-1'
+	 * 
 	 * @returns {void}
 	 */
 	setManualRadioValue(formId, name, value, set = true, ignoreCustomRadio = false) {
+		if (typeof value !== 'string') {
+			return;
+		}
+
 		if (set) {
 			const inner = this.state.getStateElementItems(name, formId);
 
 			if (inner) {
 				if (value !== '' && inner?.[value]) {
-					console.log(inner[value]);
-					
 					inner[value].input.checked = true;
 				} else {
 					Object.values(inner).forEach((item) => {
 						item.input.checked = false;
 					});
+
+					// If sent value that doesn't exist in radio group, clear it.
+					value = '';
 				}
 			}
 		}
@@ -1055,10 +1108,17 @@ export class Utils {
 	 * @param {string} value Field value.
 	 * @param {bool} set Set value.
 	 * @param {bool} ignoreCustomRadio Ignore custom radio.
+	 *
+	 * Expected value format:
+	 * 'value'
 	 * 
 	 * @returns {void}
 	 */
 	setManualInputValue(formId, name, value, set = true, ignoreCustomRadio = false) {
+		if (typeof value !== 'string') {
+			return;
+		}
+
 		if (set) {
 			const input = this.state.getStateElementInput(name, formId);
 
@@ -1094,10 +1154,17 @@ export class Utils {
 	 * @param {string} name Field name.
 	 * @param {string} value Field value.
 	 * @param {bool} set Set value.
-	 * 
+	 *
+	 * Expected value format:
+	 * '5'
+	 *
 	 * @returns {void}
 	 */
 	setManualRatingValue(formId, name, value, set = true) {
+		if (typeof value !== 'string') {
+			return;
+		}
+
 		this.state.getStateElementCustom(name, formId)?.setAttribute(this.state.getStateAttribute('ratingValue'), value);
 		this.setManualInputValue(formId, name, value, set);
 	}
@@ -1109,10 +1176,17 @@ export class Utils {
 	 * @param {string} name Field name.
 	 * @param {string} value Field value.
 	 * @param {bool} set Set value.
-	 * 
+	 *
+	 * Expected value format:
+	 * '50'
+	 *
 	 * @returns {void}
 	 */
 	setManualRangeValue(formId, name, value, set = true) {
+		if (typeof value !== 'string') {
+			return;
+		}
+
 		this.setManualInputValue(formId, name, value, set);
 		this.setRangeCurrentValue(formId, name);
 	}

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -911,7 +911,7 @@ export class Utils {
 		setStateValues(name, value, formId);
 		this.setFieldFilledState(formId, name);
 
-		this.enrichment.setLocalStorageFormPrefillItem(formId, name);
+		this.enrichment.setLocalStorageFormPrefillField(formId, name);
 
 		this.conditionalTags.setField(formId, name);
 	}
@@ -950,7 +950,7 @@ export class Utils {
 
 		setStateValues(name, value, formId);
 
-		this.enrichment.setLocalStorageFormPrefillItem(formId, name);
+		this.enrichment.setLocalStorageFormPrefillField(formId, name);
 
 		this.conditionalTags.setField(formId, name);
 
@@ -999,7 +999,7 @@ export class Utils {
 
 		this.setFieldFilledState(formId, name);
 
-		this.enrichment.setLocalStorageFormPrefillItem(formId, name);
+		this.enrichment.setLocalStorageFormPrefillField(formId, name);
 
 		this.conditionalTags.setField(formId, name);
 	}
@@ -1064,7 +1064,7 @@ export class Utils {
 		setStateValues(name, { ...newValue, ...value }, formId);
 		this.setFieldFilledState(formId, name);
 
-		this.enrichment.setLocalStorageFormPrefillItem(formId, name);
+		this.enrichment.setLocalStorageFormPrefillField(formId, name);
 
 		this.conditionalTags.setField(formId, name);
 	}
@@ -1126,7 +1126,7 @@ export class Utils {
 			}
 		}
 
-		this.enrichment.setLocalStorageFormPrefillItem(formId, name);
+		this.enrichment.setLocalStorageFormPrefillField(formId, name);
 
 		this.conditionalTags.setField(formId, name);
 	}
@@ -1175,7 +1175,7 @@ export class Utils {
 			}
 		}
 
-		this.enrichment.setLocalStorageFormPrefillItem(formId, name);
+		this.enrichment.setLocalStorageFormPrefillField(formId, name);
 
 		this.conditionalTags.setField(formId, name);
 

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -898,6 +898,15 @@ export class Utils {
 				break;
 			case 'radio':
 				setStateValuesRadio(target, formId);
+
+				const inputField = field.querySelector(this.state.getStateSelector('field', true));
+
+				if (inputField) {
+					console.log(inputField.getAttribute(this.state.getStateAttribute('fieldName')));
+					
+					this.setManualInputValue(formId, inputField.getAttribute(this.state.getStateAttribute('fieldName')), '');
+				}
+
 				break;
 			case 'checkbox':
 				setStateValuesCheckbox(target, formId);
@@ -909,6 +918,12 @@ export class Utils {
 				break;
 			default:
 				setStateValuesInput(target, formId);
+
+				const fieldset = field.closest('fieldset');
+
+				if (fieldset?.getAttribute(this.state.getStateAttribute('fieldType')) === 'radio') {
+					this.setManualRadioValue(formId, fieldset?.getAttribute(this.state.getStateAttribute('fieldName')), '');
+				}
 
 				if (customType === 'range') {
 					this.setRangeCurrentValue(formId, name);
@@ -1172,6 +1187,14 @@ export class Utils {
 		this.enrichment.setLocalStorageFormPrefillItem(formId, name);
 
 		this.conditionalTags.setField(formId, name);
+
+		const fieldset = this.state.getStateElementField(name, formId)?.closest('fieldset');
+		if (fieldset?.getAttribute(this.state.getStateAttribute('fieldType')) === 'radio') {
+			console.log('aa');
+			
+			const parentName = fieldset?.getAttribute(this.state.getStateAttribute('fieldName'));
+			this.setManualRadioValue(formId, parentName, this.state.getStateElementInitial(parentName, formId));
+		}
 	}
 
 	/**

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -886,7 +886,7 @@ export class Utils {
 
 			const input = this.state.getStateElementInput(name, formId);
 
-			if (input) {
+			if (input && value?.value) {
 				input.value = value?.value;
 			}
 		}
@@ -956,8 +956,6 @@ export class Utils {
 		if (!Array.isArray(value)) {
 			return;
 		}
-
-		this.state.getStateElementCustom(name, formId).setChoiceByValue(value);
 
 			// For manual setting.
 		if (set) {
@@ -1480,9 +1478,6 @@ export class Utils {
 			formSubmitErrorFatal: (msg, type, error, formId) => {
 				this.formSubmitErrorFatal(msg, type, error, formId);
 			},
-			getSelectSelectedValueByCustomData: (type, value, choices) => {
-				return this.getSelectSelectedValueByCustomData(type, value, choices);
-			},
 			removeFormsWithMissingFormsBlock: () => {
 				this.removeFormsWithMissingFormsBlock();
 			},
@@ -1501,6 +1496,9 @@ export class Utils {
 			setManualSelectValue: (formId, name, value) => {
 				this.setManualSelectValue(formId, name, value);
 			},
+			setManualCountryValue: (formId, name, value) => {
+				this.setManualCountryValue(formId, name, value);
+			},
 			setManualCheckboxValue: (formId, name, value) => {
 				this.setManualCheckboxValue(formId, name, value);
 			},
@@ -1509,6 +1507,24 @@ export class Utils {
 			},
 			setManualInputValue: (formId, name, value) => {
 				this.setManualInputValue(formId, name, value);
+			},
+			setManualRatingValue: (formId, name, value) => {
+				this.setManualRatingValue(formId, name, value);
+			},
+			setManualRangeValue: (formId, name, value) => {
+				this.setManualRangeValue(formId, name, value);
+			},
+			setRangeCurrentValue: (formId, name) => {
+				this.setRangeCurrentValue(formId, name);
+			},
+			setResultsOutput: (formId, data) => {
+				this.setResultsOutput(formId, data);
+			},
+			resetResultsOutput: (formId) => {
+				this.resetResultsOutput(formId);
+			},
+			getComparator: () => {
+				return this.getComparator();
 			},
 		};
 	}

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -429,25 +429,38 @@ export class Utils {
 	 * @returns {void}
 	 */
 	setFieldFilledState(formId, name) {
+		this.unsetActiveState(formId, name);
+
 		const type = this.state.getStateElementTypeField(name, formId);
 		const value = this.state.getStateElementValue(name, formId);
 
-		let condition = false;
-
 		switch (type) {
 			case 'checkbox':
-				condition = Object.values(value).filter((item) => item !== '').length > 0;
+				this.setFieldFilledStateByName(
+					formId,
+					name,
+					Object.values(value).filter((item) => item !== '').length > 0
+				);
 				break;
 			case 'phone':
-				condition = value?.value;
+				this.setFieldFilledStateByName(formId, name, value?.value);
 				break;
 			default:
-				condition = value && value.length;
+				this.setFieldFilledStateByName(formId, name, value && value.length);
 				break;
 		}
+	}
 
-		this.unsetActiveState(formId, name);
-
+	/**
+	 * Prefill inputs active/filled.
+	 * 
+	 * @param {string} formId Form Id.
+	 * @param {string} name Field name.
+	 * @param {bool} condition Condition.
+	 * 
+	 * @returns {void}
+	 */
+	setFieldFilledStateByName(formId, name, condition) {
 		if (condition) {
 			this.setFilledState(formId, name);
 		} else {
@@ -874,6 +887,10 @@ export class Utils {
 			return;
 		}
 
+		if (!(name in this.state.getStateElementsObject(formId))) {
+			return;
+		}
+
 		// For manual setting.
 		if (set) {
 			if (!this.state.getStateFormConfigPhoneDisablePicker(formId)) {
@@ -918,6 +935,10 @@ export class Utils {
 			return;
 		}
 
+		if (!(name in this.state.getStateElementsObject(formId))) {
+			return;
+		}
+
 		// For manual setting.
 		if (set) {
 			const custom = this.state.getStateElementCustom(name, formId);
@@ -954,6 +975,10 @@ export class Utils {
 	 */
 	setManualSelectValue(formId, name, value, set = true) {
 		if (!Array.isArray(value)) {
+			return;
+		}
+
+		if (!(name in this.state.getStateElementsObject(formId))) {
 			return;
 		}
 
@@ -1020,6 +1045,10 @@ export class Utils {
 			return;
 		}
 
+		if (!(name in this.state.getStateElementsObject(formId))) {
+			return;
+		}
+
 		if (set) {
 			const inner = this.state.getStateElementItems(name, formId);
 
@@ -1056,6 +1085,10 @@ export class Utils {
 	 */
 	setManualRadioValue(formId, name, value, set = true, ignoreCustomRadio = false) {
 		if (typeof value !== 'string') {
+			return;
+		}
+
+		if (!(name in this.state.getStateElementsObject(formId))) {
 			return;
 		}
 
@@ -1117,6 +1150,10 @@ export class Utils {
 			return;
 		}
 
+		if (!(name in this.state.getStateElementsObject(formId))) {
+			return;
+		}
+
 		if (set) {
 			const input = this.state.getStateElementInput(name, formId);
 
@@ -1163,6 +1200,10 @@ export class Utils {
 			return;
 		}
 
+		if (!(name in this.state.getStateElementsObject(formId))) {
+			return;
+		}
+
 		this.state.getStateElementCustom(name, formId)?.setAttribute(this.state.getStateAttribute('ratingValue'), value);
 		this.setManualInputValue(formId, name, value, set);
 	}
@@ -1182,6 +1223,10 @@ export class Utils {
 	 */
 	setManualRangeValue(formId, name, value, set = true) {
 		if (typeof value !== 'string') {
+			return;
+		}
+
+		if (!(name in this.state.getStateElementsObject(formId))) {
 			return;
 		}
 
@@ -1441,6 +1486,9 @@ export class Utils {
 			},
 			setFieldFilledState: (formId, name) => {
 				this.setFieldFilledState(formId, name);
+			},
+			setFieldFilledStateByName: (formId, name, condition) => {
+				this.setFieldFilledStateByName(formId, name, condition);
 			},
 			setActiveState: (formId, name) => {
 				this.setActiveState(formId, name);

--- a/src/Blocks/components/form/form.php
+++ b/src/Blocks/components/form/form.php
@@ -35,7 +35,6 @@ $formActionExternal = Helpers::checkAttr('formActionExternal', $attributes, $man
 $formMethod = Helpers::checkAttr('formMethod', $attributes, $manifest);
 $formId = Helpers::checkAttr('formId', $attributes, $manifest);
 $formContent = Helpers::checkAttr('formContent', $attributes, $manifest);
-$formPhoneSync = Helpers::checkAttr('formPhoneSync', $attributes, $manifest);
 $formPhoneDisablePicker = Helpers::checkAttr('formPhoneDisablePicker', $attributes, $manifest);
 $formHasSteps = Helpers::checkAttr('formHasSteps', $attributes, $manifest);
 $formUseSingleSubmit = Helpers::checkAttr('formUseSingleSubmit', $attributes, $manifest);
@@ -74,10 +73,6 @@ if ($formDataTypeSelector) {
 
 if ($formSecureData) {
 	$formAttrs[UtilsHelper::getStateAttribute('formSecureData')] = $formSecureData; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped
-}
-
-if ($formPhoneSync) {
-	$formAttrs[UtilsHelper::getStateAttribute('phoneSync')] = esc_attr($formPhoneSync);
 }
 
 if ($formPhoneDisablePicker) {

--- a/src/Blocks/components/form/manifest.json
+++ b/src/Blocks/components/form/manifest.json
@@ -47,10 +47,6 @@
 		"formParentSettings": {
 			"type": "object"
 		},
-		"formPhoneSync": {
-			"type": "boolean",
-			"default": false
-		},
 		"formPhoneDisablePicker": {
 			"type": "boolean",
 			"default": false

--- a/src/Blocks/components/input/input.php
+++ b/src/Blocks/components/input/input.php
@@ -140,7 +140,7 @@ echo Helpers::render(
 			'fieldId' => $inputId,
 			'fieldName' => $inputName,
 			'fieldTwSelectorsData' => $inputTwSelectorsData,
-			'fieldTypeInternal' => FormsHelper::getStateFieldType('input'),
+			'fieldTypeInternal' => FormsHelper::getStateFieldType($inputType === 'range' ? 'range' : 'input'),
 			'fieldIsRequired' => $inputIsRequired,
 			'fieldDisabled' => !empty($inputIsDisabled),
 			'fieldUseError' => $inputType !== 'hidden',

--- a/src/Blocks/components/phone/components/phone-options.js
+++ b/src/Blocks/components/phone/components/phone-options.js
@@ -33,6 +33,7 @@ export const PhoneOptions = (attributes) => {
 	const phoneDisabledOptions = checkAttr('phoneDisabledOptions', attributes, manifest);
 	const phoneUseSearch = checkAttr('phoneUseSearch', attributes, manifest);
 	const phoneUseLabelAsPlaceholder = checkAttr('phoneUseLabelAsPlaceholder', attributes, manifest);
+	const phoneSelectValue = checkAttr('phoneSelectValue', attributes, manifest);
 
 	let phoneValidationPatternOptions = [];
 
@@ -93,6 +94,14 @@ export const PhoneOptions = (attributes) => {
 					value={phoneValue}
 					onChange={(value) => setAttributes({ [getAttrKey('phoneValue', attributes, manifest)]: value })}
 					disabled={isOptionDisabled(getAttrKey('phoneValue', attributes, manifest), phoneDisabledOptions)}
+				/>
+
+				<TextControl
+					label={<IconLabel icon={icons.titleGeneric} label={__('Select initial value', 'eightshift-forms')} />}
+					value={phoneSelectValue}
+					onChange={(value) => setAttributes({ [getAttrKey('phoneSelectValue', attributes, manifest)]: value })}
+					disabled={isOptionDisabled(getAttrKey('phoneSelectValue', attributes, manifest), phoneDisabledOptions)}
+					help={__('Initial value of the field. This value depends on the value type.', 'eightshift-forms')}
 				/>
 
 				<FieldOptionsVisibility

--- a/src/Blocks/components/phone/manifest.json
+++ b/src/Blocks/components/phone/manifest.json
@@ -27,6 +27,9 @@
 		"phonePlaceholder": {
 			"type": "string"
 		},
+		"phoneSelectValue": {
+			"type": "string"
+		},
 		"phoneUseLabelAsPlaceholder": {
 			"type": "boolean",
 			"default": false

--- a/src/Blocks/components/phone/phone.php
+++ b/src/Blocks/components/phone/phone.php
@@ -37,6 +37,7 @@ $phoneTypeCustom = Helpers::checkAttr('phoneTypeCustom', $attributes, $manifest)
 $phoneFieldAttrs = Helpers::checkAttr('phoneFieldAttrs', $attributes, $manifest);
 $phoneUseLabelAsPlaceholder = Helpers::checkAttr('phoneUseLabelAsPlaceholder', $attributes, $manifest);
 $phoneTwSelectorsData = Helpers::checkAttr('phoneTwSelectorsData', $attributes, $manifest);
+$phoneSelectValue = Helpers::checkAttr('phoneSelectValue', $attributes, $manifest);
 
 $phoneId = $phoneName . '-' . Helpers::getUnique();
 
@@ -91,6 +92,8 @@ if (has_filter($filterName)) {
 		$datasetList = $settings['phone']['dataset'];
 	}
 
+	$preselectedValue = $settings['phone']['preselectedValue'] ?: $phoneSelectValue; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
+
 	foreach ($settings['countries'][$datasetList]['items'] as $option) {
 		$label = $option[0] ?? '';
 		$code = $option[1] ?? '';
@@ -106,7 +109,7 @@ if (has_filter($filterName)) {
 			<option
 				value="' . $value . '"
 				' . UtilsHelper::getStateAttribute('selectCustomProperties') . '=\'' . htmlspecialchars(wp_json_encode($customProperties), ENT_QUOTES, 'UTF-8') . '\'
-				' . selected($code, $settings['phone']['preselectedValue'], false) . '
+				' . selected($code, $preselectedValue, false) . '
 			>+' . $value . '</option>';
 	}
 }

--- a/src/Blocks/components/select/components/select-options.js
+++ b/src/Blocks/components/select/components/select-options.js
@@ -139,7 +139,7 @@ export const SelectOptions = (attributes) => {
 
 								{selectMinCount > 0 && !isOptionDisabled(getAttrKey('selectMinCount', attributes, manifest), selectDisabledOptions) &&
 									<Button
-										label={__('Disable', 'eightshift-forms')}
+										label={__('Clear', 'eightshift-forms')}
 										icon={icons.clear}
 										onClick={() => setAttributes({ [getAttrKey('selectMinCount', attributes, manifest)]: undefined })}
 										className='es-button-square-32 es-button-icon-24'
@@ -163,7 +163,7 @@ export const SelectOptions = (attributes) => {
 
 								{selectMaxCount > 0 && !isOptionDisabled(getAttrKey('selectMaxCount', attributes, manifest), selectDisabledOptions) &&
 									<Button
-										label={__('Disable', 'eightshift-forms')}
+										label={__('Clear', 'eightshift-forms')}
 										icon={icons.clear}
 										onClick={() => setAttributes({ [getAttrKey('selectMaxCount', attributes, manifest)]: undefined })}
 										className='es-button-square-32 es-button-icon-24'

--- a/src/Blocks/components/utils/partials/debug-field-details.php
+++ b/src/Blocks/components/utils/partials/debug-field-details.php
@@ -22,7 +22,6 @@ if (!UtilsDeveloperHelper::isDeveloperModeActive()) {
 $fieldManifest = Helpers::getComponent('field');
 
 $componentClass = Helpers::classnames([
-	UtilsHelper::getStateSelector('field'),
 	Helpers::selector(true, $fieldManifest['componentClass'], 'debug'),
 ]);
 

--- a/src/Blocks/components/utils/partials/debug-field-details.php
+++ b/src/Blocks/components/utils/partials/debug-field-details.php
@@ -8,7 +8,6 @@
 
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsDeveloperHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsGeneralHelper;
-use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsHelper;
 use EightshiftFormsVendor\EightshiftLibs\Helpers\Helpers;
 
 if (UtilsGeneralHelper::isEightshiftFormsAdminPages()) {

--- a/src/Blocks/custom/checkboxes/manifest.json
+++ b/src/Blocks/custom/checkboxes/manifest.json
@@ -24,7 +24,8 @@
 				"type": "string"
 			},
 			"default": [
-				"eightshift-forms/checkbox"
+				"eightshift-forms/checkbox",
+				"eightshift-forms/input"
 			]
 		}
 	},

--- a/src/Blocks/custom/radios/manifest.json
+++ b/src/Blocks/custom/radios/manifest.json
@@ -24,7 +24,8 @@
 				"type": "string"
 			},
 			"default": [
-				"eightshift-forms/radio"
+				"eightshift-forms/radio",
+				"eightshift-forms/input"
 			]
 		}
 	},

--- a/src/Blocks/manifest.json
+++ b/src/Blocks/manifest.json
@@ -446,9 +446,10 @@
 			"file": "file",
 			"country": "country",
 			"date": "date",
-			"dateTime": "datetime",
+			"dateTime": "dateTime",
 			"select": "select",
 			"rating": "rating",
+			"range": "range",
 			"submit": "submit"
 		}
 	},

--- a/src/Enqueue/Blocks/EnqueueBlocks.php
+++ b/src/Enqueue/Blocks/EnqueueBlocks.php
@@ -318,6 +318,7 @@ class EnqueueBlocks extends AbstractEnqueueBlocks
 					'isUsed' => true,
 					'isUsedPrefill' => UtilsSettingsHelper::isOptionCheckboxChecked(SettingsEnrichment::SETTINGS_ENRICHMENT_PREFILL_USE_KEY, SettingsEnrichment::SETTINGS_ENRICHMENT_PREFILL_USE_KEY),
 					'isUsedPrefillUrl' => UtilsSettingsHelper::isOptionCheckboxChecked(SettingsEnrichment::SETTINGS_ENRICHMENT_PREFILL_URL_USE_KEY, SettingsEnrichment::SETTINGS_ENRICHMENT_PREFILL_URL_USE_KEY),
+					'allowedSmart' => \array_values(\array_filter(\explode(\PHP_EOL, UtilsSettingsHelper::getOptionValueAsJson(SettingsEnrichment::SETTINGS_ENRICHMENT_ALLOWED_SMART_TAGS_KEY, 1)))),
 				],
 				FiltersOuputMock::getEnrichmentManualMapFilterValue($this->enrichment->getEnrichmentConfig())['config'] ?? [],
 			);

--- a/src/Enrichment/SettingsEnrichment.php
+++ b/src/Enrichment/SettingsEnrichment.php
@@ -57,6 +57,11 @@ class SettingsEnrichment implements UtilsSettingGlobalInterface, ServiceInterfac
 	public const SETTINGS_ENRICHMENT_ALLOWED_TAGS_KEY = 'enrichment-allowed-tags';
 
 	/**
+	 * Allowed smart tags key.
+	 */
+	public const SETTINGS_ENRICHMENT_ALLOWED_SMART_TAGS_KEY = 'enrichment-allowed-smart-tags';
+
+	/**
 	 * Allowed tags map key.
 	 */
 	public const SETTINGS_ENRICHMENT_ALLOWED_TAGS_MAP_KEY = 'enrichment-allowed-tags-map';
@@ -166,7 +171,7 @@ class SettingsEnrichment implements UtilsSettingGlobalInterface, ServiceInterfac
 								'textareaSaveAsJson' => true,
 								// translators: %s will be replaced with local validation patterns.
 								'textareaFieldHelp' => \sprintf(\__('
-									Enter one URL parameter per line.
+									Enter one parameter per line.
 									<br/><br />
 									Parameters are stored in browser storage for optional additional processing later.<br />
 									Some commonly used parameters are included by default.%s', 'eightshift-forms'), $enrichment['settings']),
@@ -271,7 +276,27 @@ class SettingsEnrichment implements UtilsSettingGlobalInterface, ServiceInterfac
 							],
 						],
 					],
-				]
+					[
+						'component' => 'tab',
+						'tabLabel' => \__('Prefill smart', 'eightshift-forms'),
+						'tabContent' => [
+							[
+								'component' => 'textarea',
+								'textareaName' => UtilsSettingsHelper::getOptionName(self::SETTINGS_ENRICHMENT_ALLOWED_SMART_TAGS_KEY),
+								'textareaFieldLabel' => \__('Add custom enrichment smart parameters', 'eightshift-forms'),
+								'textareaIsMonospace' => true,
+								'textareaSaveAsJson' => true,
+								// translators: %s will be replaced with local validation patterns.
+								'textareaFieldHelp' => \sprintf(\__('
+									Enter one parameter per line.
+									<br/><br />
+									Parameters are stored in browser storage for optional additional processing later.<br />
+									These parameters will be automatically set on every form you have.', 'eightshift-forms'), $enrichment['settings']),
+								'textareaValue' => UtilsSettingsHelper::getOptionValueAsJson(self::SETTINGS_ENRICHMENT_ALLOWED_SMART_TAGS_KEY, 1),
+							],
+						],
+					],
+				],
 			],
 		];
 	}

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -80,16 +80,6 @@ class Form extends AbstractFormBuilder implements ServiceInterface
 
 		// Use single submit.
 		$attributes["{$prefix}UseSingleSubmit"] = UtilsSettingsHelper::isSettingCheckboxChecked(SettingsGeneral::SETTINGS_USE_SINGLE_SUBMIT_KEY, SettingsGeneral::SETTINGS_USE_SINGLE_SUBMIT_KEY, $formId);
-
-		// Phone sync with country block.
-		$attributes["{$prefix}PhoneSync"] = '';
-		$filterName = UtilsHooksHelper::getFilterName(['block', 'form', 'phoneSync']);
-		if (\has_filter($filterName)) {
-			$attributes["{$prefix}PhoneSync"] = \apply_filters($filterName, $type, $formId);
-		} else {
-			$attributes["{$prefix}PhoneSync"] = !UtilsSettingsHelper::isSettingCheckboxChecked(SettingsBlocks::SETTINGS_BLOCK_PHONE_DISABLE_SYNC_KEY, SettingsBlocks::SETTINGS_BLOCK_PHONE_DISABLE_SYNC_KEY, $formId);
-		}
-
 		$attributes["{$prefix}PhoneDisablePicker"] = UtilsSettingsHelper::isOptionCheckboxChecked(SettingsBlocks::SETTINGS_BLOCK_PHONE_DISABLE_PICKER_KEY, SettingsBlocks::SETTINGS_BLOCK_PHONE_DISABLE_PICKER_KEY);
 
 		// Output secure data.

--- a/src/Hooks/Filters.php
+++ b/src/Hooks/Filters.php
@@ -82,7 +82,6 @@ final class Filters
 					'trackingEventName',
 					'trackingAdditionalData',
 					'dataTypeSelector',
-					'phoneSync',
 					'globalMsgHeadings',
 					'additionalContent',
 					'additionalHiddenFields',

--- a/src/Hooks/FiltersOuputMock.php
+++ b/src/Hooks/FiltersOuputMock.php
@@ -32,7 +32,7 @@ final class FiltersOuputMock
 	{
 		$settings = '';
 		$filterUsed = false;
-		$settingsFields = [];
+		$settingsFields = $config['allowed'] ?? [];
 
 		$filterName = UtilsHooksHelper::getFilterName(['enrichment', 'manualMap']);
 
@@ -52,6 +52,8 @@ final class FiltersOuputMock
 						$settingsFields[] = $value;
 					}
 				}
+
+				$settingsFields = \array_unique($settingsFields);
 
 				$settings .= \__('Additional parameters were provided through code', 'eightshift-forms');
 				$settings .= '<ul>';

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -511,8 +511,13 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 		if ($successRedirectUrl) {
 			$redirectDataOutput = [];
 
+			dump($formDetails[UtilsConfig::FD_PARAMS]);
+
 			// Replace {field_name} with the actual value.
-			foreach ($formDetails[UtilsConfig::FD_PARAMS_RAW] as $name => $value) {
+			foreach ($formDetails[UtilsConfig::FD_PARAMS] as $param) {
+				$name = $param['name'] ?? '';
+				$value = $param['value'] ?? '';
+
 				if ($name === UtilsHelper::getStateParam('skippedParams')) {
 					continue;
 				}
@@ -534,7 +539,7 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 				$redirectDataOutput[UtilsHelper::getStateSuccessRedirectUrlKey('entry')] = $output['private'][UtilsHelper::getStateResponseOutputKey('entry')];
 			}
 
-			// Redirect secrue data.
+			// Redirect secure data.
 			if ($formDetails[UtilsConfig::FD_SECURE_DATA]) {
 				$secureData = \json_decode(UtilsEncryption::decryptor($formDetails[UtilsConfig::FD_SECURE_DATA]) ?: '', true);
 
@@ -559,9 +564,9 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 
 			// Redirect full url.
 			$output['public'][UtilsHelper::getStateResponseOutputKey('successRedirectUrl')] = \add_query_arg(
-				[
+				$redirectDataOutput ? [
 					UtilsHelper::getStateSuccessRedirectUrlKey('data') => UtilsEncryption::encryptor(\wp_json_encode($redirectDataOutput)),
-				],
+				] : [],
 				$successRedirectUrl
 			);
 		}

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -519,8 +519,6 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 		if ($successRedirectUrl) {
 			$redirectDataOutput = [];
 
-			dump($formDetails[UtilsConfig::FD_PARAMS]);
-
 			// Replace {field_name} with the actual value.
 			foreach ($formDetails[UtilsConfig::FD_PARAMS] as $param) {
 				$name = $param['name'] ?? '';

--- a/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
+++ b/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
@@ -89,11 +89,7 @@ class FormSubmitCalculatorRoute extends AbstractFormSubmit
 			$formDetails[UtilsConfig::FD_PARAMS] = \apply_filters($filterName, $formDetails[UtilsConfig::FD_PARAMS], $formId) ?? [];
 		}
 
-		dump($formDetails[UtilsConfig::FD_PARAMS]);
-
 		$successAdditionalData = $this->getIntegrationResponseSuccessOutputAdditionalData($formDetails);
-
-		dump($successAdditionalData);
 
 		// Set validation submit once.
 		$this->validator->setValidationSubmitOnce($formId);

--- a/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
+++ b/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
@@ -89,7 +89,11 @@ class FormSubmitCalculatorRoute extends AbstractFormSubmit
 			$formDetails[UtilsConfig::FD_PARAMS] = \apply_filters($filterName, $formDetails[UtilsConfig::FD_PARAMS], $formId) ?? [];
 		}
 
+		dump($formDetails[UtilsConfig::FD_PARAMS]);
+
 		$successAdditionalData = $this->getIntegrationResponseSuccessOutputAdditionalData($formDetails);
+
+		dump($successAdditionalData);
 
 		// Set validation submit once.
 		$this->validator->setValidationSubmitOnce($formId);

--- a/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
+++ b/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
@@ -94,6 +94,21 @@ class FormSubmitCalculatorRoute extends AbstractFormSubmit
 		// Set validation submit once.
 		$this->validator->setValidationSubmitOnce($formId);
 
+		// Located before the sendEmail mentod so we can utilize common email response tags.
+		$successAdditionalData = $this->getIntegrationResponseSuccessOutputAdditionalData($formDetails);
+
+		// Send email.
+		$this->getFormSubmitMailer()->sendEmails(
+			$formDetails,
+			$this->getCommonEmailResponseTags(
+				\array_merge(
+					$successAdditionalData['public'],
+					$successAdditionalData['private']
+				),
+				$formDetails
+			)
+		);
+
 		return \rest_ensure_response(
 			UtilsApiHelper::getApiSuccessPublicOutput(
 				$this->labels->getLabel('calculatorSuccess', $formId),

--- a/src/Rest/Routes/Integrations/Corvus/FormSubmitCorvusRoute.php
+++ b/src/Rest/Routes/Integrations/Corvus/FormSubmitCorvusRoute.php
@@ -124,6 +124,21 @@ class FormSubmitCorvusRoute extends AbstractFormSubmit
 		// Set validation submit once.
 		$this->validator->setValidationSubmitOnce($formId);
 
+		// Located before the sendEmail mentod so we can utilize common email response tags.
+		$successAdditionalData = $this->getIntegrationResponseSuccessOutputAdditionalData($formDetails);
+
+		// Send email.
+		$this->getFormSubmitMailer()->sendEmails(
+			$formDetails,
+			$this->getCommonEmailResponseTags(
+				\array_merge(
+					$successAdditionalData['public'],
+					$successAdditionalData['private']
+				),
+				$formDetails
+			)
+		);
+
 		// Finish.
 		return \rest_ensure_response(
 			UtilsApiHelper::getApiSuccessPublicOutput(

--- a/src/Rest/Routes/Integrations/Mailer/FormSubmitMailerRoute.php
+++ b/src/Rest/Routes/Integrations/Mailer/FormSubmitMailerRoute.php
@@ -77,7 +77,7 @@ class FormSubmitMailerRoute extends AbstractFormSubmit
 	{
 		$formId = $formDetails[UtilsConfig::FD_FORM_ID];
 
-		// Located before the sendEmail mentod so we can utilize common email response tags.
+		// Located before the sendEmail method so we can utilize common email response tags.
 		$successAdditionalData = $this->getIntegrationResponseSuccessOutputAdditionalData($formDetails);
 
 		// Send email.

--- a/src/Rest/Routes/Integrations/Paycek/FormSubmitPaycekRoute.php
+++ b/src/Rest/Routes/Integrations/Paycek/FormSubmitPaycekRoute.php
@@ -114,6 +114,21 @@ class FormSubmitPaycekRoute extends AbstractFormSubmit
 		// Set validation submit once.
 		$this->validator->setValidationSubmitOnce($formId);
 
+		// Located before the sendEmail mentod so we can utilize common email response tags.
+		$successAdditionalData = $this->getIntegrationResponseSuccessOutputAdditionalData($formDetails);
+
+		// Send email.
+		$this->getFormSubmitMailer()->sendEmails(
+			$formDetails,
+			$this->getCommonEmailResponseTags(
+				\array_merge(
+					$successAdditionalData['public'],
+					$successAdditionalData['private']
+				),
+				$formDetails
+			)
+		);
+
 		// Finish.
 		return \rest_ensure_response(
 			UtilsApiHelper::getApiSuccessPublicOutput(

--- a/testFilters/testFilters.php
+++ b/testFilters/testFilters.php
@@ -33,7 +33,6 @@ class Testfilters implements ServiceInterface
 			'es_forms_block_form_tracking_event_name' => ['getBlockFormTrackingEventName', 2],
 			'es_forms_block_form_tracking_additional_data' => ['getBlockFormTrackingAdditionalData', 2],
 			'es_forms_block_form_data_type_selector' => ['getFormDataTypeSelector', 2],
-			'es_forms_block_form_phone_sync' => ['getFormPhoneSync', 2],
 			'es_forms_block_form_global_msg_headings' => ['getGlobalMsgHeadings'],
 
 			'es_forms_block_form_selector_additional_content' => ['getBlockFormSelectorAdditionalContent'],
@@ -324,25 +323,6 @@ class Testfilters implements ServiceInterface
 		}
 
 		return 'my-new-selector';
-	}
-
-	/**
-	 * Set phone sync settings.
-	 *
-	 * This filter will override global settings for phone sync.
-	 *
-	 * @param string $formType Type of form used like greenhouse, hubspot, etc.
-	 * @param string $formId Form ID.
-	 *
-	 * @return bool
-	 */
-	public function getFormPhoneSync(string $formType, string $formId): bool
-	{
-		if ($formType === 'hubspot') {
-			return true;
-		}
-
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
### Changed

- Forms are now supporting multiple instances of the same form on the same page.
- `enrichment` prefill on URL now has totally new logic and ways or prefilling the fields.
- `JS` internal logic for setting up values on field.

### Added

- new country order list filter to provide a custom `priority` order for the countries.
- additional protection for checking if route is private or public for settings.
- `country` field now supports multiple values, min/max count validation and ability to prefill the field value.
- `phone` field now supports initial selected value both for country picker and number.
- `field` now support additional `suffix` content that will be displayed after the field input.
- `radio and checkbox` fields now support one `input` field that can be used as `other` option and this value will be sent with the main values.
- new `enrichment` prefill option to save all fields defined as `smart` and prefilled all forms that have that field.

### Removed

- ability for phone/country field to `sync` changes to the other field.

### Fixed

- broken checkboxes and radios if there are multiple items with the same name.
- missing email confirmation for `Corvus`, `Calculator` and `Paycek` integrations.
- success redirect url will no longer send empty encrypted value.
