### PR TITLE
adding increment ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -928,6 +928,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[5.8.0]: https://github.com/infinum/eightshift-forms/compare/5.7.1...5.8.0
 [5.7.1]: https://github.com/infinum/eightshift-forms/compare/5.7.0...5.7.1
 [5.7.0]: https://github.com/infinum/eightshift-forms/compare/5.6.6...5.7.0
 [5.6.6]: https://github.com/infinum/eightshift-forms/compare/5.6.5...5.6.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ### Added
 
-- `increment ID` option for entries so you can us them to track success submissions or use it a order number.
+- `increment ID` option for entries so you can use them to track successful submissions or use it as an order number.
 - `incrementId` key is now available in the email response tags.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [5.8.0]
+
+### Added
+
+- `increment ID` option for entries so you can us them to track success submissions or use it a order number.
+- `incrementId` key is now available in the email response tags.
+
+### Changed
+
+- `entries` listing now has new listing page with better UX and table layout.
+
 ## [5.7.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ### Changed
 
-- `entries` listing now has new listing page with better UX and table layout.
+- `entries` listing now has the new listing page with better UX and table layout.
 
 ## [5.7.1]
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	"require": {
 		"php": ">=8.3",
 		"erusev/parsedown": "^1.7.4",
-		"infinum/eightshift-forms-utils": "^3.0.16"
+		"infinum/eightshift-forms-utils": "^3.0.18"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a94413b69de972942cd908264c7eed55",
+    "content-hash": "04dc9d89e994d026dbd74a899d6497b1",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -58,16 +58,16 @@
         },
         {
             "name": "infinum/eightshift-forms-utils",
-            "version": "3.0.16",
+            "version": "3.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infinum/eightshift-forms-utils.git",
-                "reference": "de03021b7b7817297be241c4957411ec81f234b4"
+                "reference": "28a6ab29433a14b51d3752bcfd52179f41051d36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infinum/eightshift-forms-utils/zipball/de03021b7b7817297be241c4957411ec81f234b4",
-                "reference": "de03021b7b7817297be241c4957411ec81f234b4",
+                "url": "https://api.github.com/repos/infinum/eightshift-forms-utils/zipball/28a6ab29433a14b51d3752bcfd52179f41051d36",
+                "reference": "28a6ab29433a14b51d3752bcfd52179f41051d36",
                 "shasum": ""
             },
             "require": {
@@ -120,7 +120,7 @@
                 "issues": "https://github.com/infinum/eightshift-forms/issues",
                 "source": "https://github.com/infinum/eightshift-forms"
             },
-            "time": "2025-01-13T11:18:49+00:00"
+            "time": "2025-01-14T14:33:01+00:00"
         },
         {
             "name": "infinum/eightshift-libs",

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 5.7.1
+ * Version: 5.8.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/AdminMenus/FormAdminMenu.php
+++ b/src/AdminMenus/FormAdminMenu.php
@@ -737,17 +737,27 @@ class FormAdminMenu extends AbstractAdminMenu
 				break;
 			case UtilsConfig::SLUG_ADMIN_LISTING_ENTRIES:
 				$i = 0;
-				$count = \count($items);
+
+				$tableHead = [];
+				$tableContent = [];
+
 				foreach (\array_reverse($items) as $item) {
 					$id = $item['id'] ?? ''; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-					$entryValue = $item['entryValue'] ?? [];
+					$entryValues = $item['entryValue'] ?? [];
 					$createdAt = $item['createdAt'] ?? '';
 
-					$content = "<ul class='is-list is-list--break-words' id='entry-{$id}'>";
-					foreach ($entryValue as $entryKey => $entryValue) {
+					// Prefixes are here to ensure that the columns are sorted correctly.
+					$tableHead['___bulk'] = \__('Bulk', 'eightshift-forms');
+					$tableContent[$id]['___bulk'] = Helpers::ensureString($this->getLeftContent($item));
+					$tableHead['__id'] = \__('ID', 'eightshift-forms');
+					$tableContent[$id]['__id'] = $id;
+					$tableHead['_createdAt'] = \__('Created', 'eightshift-forms');
+					$tableContent[$id]['_createdAt'] = $createdAt;
+
+					foreach ($entryValues as $entryKey => $entryValue) {
 						if (\gettype($entryValue) === 'array') {
 							if (\array_key_first($entryValue) === 0) {
-								$entryValue = \implode(UtilsConfig::DELIMITER, $entryValue);
+								$entryValue = \implode('<br/>', $entryValue);
 							} else {
 								$entryValue = \array_map(
 									function ($value, $key) {
@@ -756,37 +766,38 @@ class FormAdminMenu extends AbstractAdminMenu
 									$entryValue,
 									\array_keys($entryValue)
 								);
-								$entryValue = \implode(UtilsConfig::DELIMITER, $entryValue);
+								$entryValue = \implode('<br/>', $entryValue);
 							}
+						}
+
+						if (\gettype($entryValue) === 'string' && \str_contains($entryValue, UtilsConfig::DELIMITER)) {
+							$entryValue = \explode(UtilsConfig::DELIMITER, $entryValue);
+							$entryValue = \implode('<br/>', $entryValue);
 						}
 
 						if (\filter_var($entryValue, \FILTER_VALIDATE_URL)) {
 							$entryValue = "<a href='{$entryValue}' target='_blank' rel='noopener noreferrer'>{$entryValue}</a>";
 						}
 
-						$content .= "<li><strong>{$entryKey}:</strong><span>- {$entryValue}</span></li>";
+						if (!isset($tableHead[$entryKey])) {
+							$tableHead[$entryKey] = \ucfirst($entryKey);
+						}
+						$tableContent[$id][$entryKey] = $entryValue;
 					}
-					$content .= '</ul>';
 
-					$output[] = Helpers::render('card-inline', [
-						// Translators: %s is the entry ID.
-						'cardInlineTitle' => \sprintf(\__('Entry %s', 'eightshift-forms'), $id),
-						'cardInlineSubTitle' => $createdAt,
-						'cardInlineIcon' => UtilsHelper::getUtilsIcons('post'),
-						'cardInlineLeftContent' => Helpers::ensureString($this->getLeftContent($item)),
-						'cardInlineContent' => $content,
-						'cardInlineUseDivider' => true,
-						'cardInlineLastItem' => $i === $count - 1,
-						'additionalAttributes' => [
-							UtilsHelper::getStateAttribute('bulkId') => $id,
-						],
-						'additionalClass' => Helpers::classnames([
-							UtilsHelper::getStateSelectorAdmin('listingItem'),
-						]),
-					]);
+					\ksort($tableHead);
 
 					$i++;
 				}
+
+				$output[] = Helpers::render('table', [
+					'tableContent' => $tableContent,
+					'tableHead' => $tableHead,
+					'additionalClass' => Helpers::classnames([
+						UtilsHelper::getStateSelectorAdmin('listingItem'),
+					]),
+					'selectorClass' => Helpers::getComponent('admin-listing')['componentClass'],
+				]);
 				break;
 			case UtilsConfig::SLUG_ADMIN_LISTING_TRASH:
 				foreach ($items as $item) {

--- a/src/Blocks/components/admin-listing/admin-listing-admin.scss
+++ b/src/Blocks/components/admin-listing/admin-listing-admin.scss
@@ -21,6 +21,10 @@
 			margin: 0;
 		}
 	}
+
+	&__es-table {
+		margin: -0.75rem -1.5rem 0;
+	}
 }
 
 .es-admin-listing__form {

--- a/src/Blocks/components/admin-settings/admin-settings-admin.scss
+++ b/src/Blocks/components/admin-settings/admin-settings-admin.scss
@@ -8,7 +8,6 @@
 	.es-form[data-settings-type='documentation'],
 	.es-form[data-settings-type='migration'],
 	.es-form[data-settings-type='transfer'],
-	.es-form[data-settings-type='entries'],
 	.es-form[data-form-type='settingsGlobal'][data-settings-type='geolocation'],
 	.es-form[data-form-type='settingsGlobal'][data-settings-type='cloudflare'],
 	.es-form[data-form-type='settingsGlobal'][data-settings-type='wp'],

--- a/src/Blocks/components/form/assets-admin/bulk.js
+++ b/src/Blocks/components/form/assets-admin/bulk.js
@@ -78,7 +78,6 @@ export class Bulk {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/cache.js
+++ b/src/Blocks/components/form/assets-admin/cache.js
@@ -35,7 +35,6 @@ export class Cache {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/debug-encrypt.js
+++ b/src/Blocks/components/form/assets-admin/debug-encrypt.js
@@ -37,7 +37,6 @@ export class DebugEncrypt {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/export.js
+++ b/src/Blocks/components/form/assets-admin/export.js
@@ -44,7 +44,6 @@ export class Export {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/increment.js
+++ b/src/Blocks/components/form/assets-admin/increment.js
@@ -38,7 +38,6 @@ export class Increment {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/increment.js
+++ b/src/Blocks/components/form/assets-admin/increment.js
@@ -10,9 +10,7 @@ export class Increment {
 	}
 
 	init() {
-		[...document.querySelectorAll(this.selector)].forEach((element) => {
-			element.addEventListener('click', this.onClick, true);
-		});
+		document.querySelectorAll(this.selector).forEach((element) => element.addEventListener('click', this.onClick, true));
 	}
 
 	// Handle form submit and all logic.

--- a/src/Blocks/components/form/assets-admin/increment.js
+++ b/src/Blocks/components/form/assets-admin/increment.js
@@ -1,0 +1,70 @@
+export class Increment {
+	constructor(options = {}) {
+		/** @type {import('../assets/utils').Utils} */
+		this.utils = options.utils;
+		/** @type {import('../assets/state').State} */
+		this.state = this.utils.getState();
+
+		this.selector = options.selector;
+		this.confirmMsg = options.confirmMsg;
+	}
+
+	init() {
+		[...document.querySelectorAll(this.selector)].forEach((element) => {
+			element.addEventListener('click', this.onClick, true);
+		});
+	}
+
+	// Handle form submit and all logic.
+	onClick = (event) => {
+		event.preventDefault();
+
+		if(!confirm(this.confirmMsg)) {
+			return;
+		}
+
+		const formId = this.state.getFormIdByElement(event.target);
+		const field = this.state.getFormFieldElementByChild(event.target);
+
+		const formData = new FormData();
+
+		formData.append('formId', field.getAttribute(this.state.getStateAttribute('formId')));
+		this.utils.showLoader(formId);
+
+		// Populate body data.
+		const body = {
+			method: 'POST',
+			mode: 'same-origin',
+			headers: {
+				Accept: 'application/json',
+				'X-WP-Nonce': this.state.getStateConfigNonce(),
+			},
+			body: formData,
+			credentials: 'same-origin',
+			redirect: 'follow',
+			referrer: 'no-referrer',
+		};
+
+		fetch(this.state.getRestUrl('increment'), body)
+			.then((response) => {
+				this.utils.formSubmitErrorContentType(response, 'increment', formId);
+
+				return response.text();
+			})
+			.then((responseData) => {
+				const response = this.utils.formSubmitIsJsonString(responseData, 'increment', formId);
+
+				const {
+					message,
+					status,
+				} = response;
+
+				this.utils.hideLoader(formId);
+				this.utils.setGlobalMsg(formId, message, status);
+
+				setTimeout(() => {
+					location.reload();
+				}, 1000);
+			});
+	};
+}

--- a/src/Blocks/components/form/assets-admin/index.js
+++ b/src/Blocks/components/form/assets-admin/index.js
@@ -32,6 +32,22 @@ domReady(() => {
 	// Cache
 	////////////////////////////////////////////////////////////////
 
+	const selectorIncrement = state.getStateSelectorAdmin('incrementReset', true);
+
+	if (document.querySelector(selectorIncrement)) {
+		import('./increment').then(({ Increment }) => {
+			new Increment({
+				utils: utils,
+				selector: selectorIncrement,
+				confirmMsg: esFormsLocalization.confirmMsg,
+			}).init();
+		});
+	}
+
+	////////////////////////////////////////////////////////////////
+	// Cache
+	////////////////////////////////////////////////////////////////
+
 	const selectorCache = state.getStateSelectorAdmin('cacheDelete', true);
 
 	if (document.querySelectorAll(selectorCache).length) {
@@ -73,7 +89,7 @@ domReady(() => {
 				itemSelector: state.getStateSelectorAdmin('transferItem', true),
 				uploadSelector: state.getStateSelectorAdmin('transferUpload', true),
 				overrideExistingSelector: state.getStateSelectorAdmin('transferExisting', true),
-				uploadConfirmMsg: esFormsLocalization.uploadConfirmMsg,
+				confirmMsg: esFormsLocalization.confirmMsg,
 			}).init();
 		});
 	}

--- a/src/Blocks/components/form/assets-admin/locations.js
+++ b/src/Blocks/components/form/assets-admin/locations.js
@@ -38,7 +38,6 @@ export class Locations {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/manual-import-api.js
+++ b/src/Blocks/components/form/assets-admin/manual-import-api.js
@@ -125,7 +125,6 @@ export class ManualImportApi {
 						'X-WP-Nonce': this.state.getStateConfigNonce(),
 					},
 					body: formData,
-					credentials: 'same-origin',
 					redirect: 'follow',
 					referrer: 'no-referrer',
 				};

--- a/src/Blocks/components/form/assets-admin/migration.js
+++ b/src/Blocks/components/form/assets-admin/migration.js
@@ -38,7 +38,6 @@ export class Migration {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/test-api.js
+++ b/src/Blocks/components/form/assets-admin/test-api.js
@@ -37,7 +37,6 @@ export class TestApi {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets-admin/transfer.js
+++ b/src/Blocks/components/form/assets-admin/transfer.js
@@ -9,7 +9,7 @@ export class Transfer {
 		this.itemSelector = options.itemSelector;
 		this.uploadSelector = options.uploadSelector;
 		this.overrideExistingSelector = options.overrideExistingSelector;
-		this.uploadConfirmMsg = options.uploadConfirmMsg;
+		this.confirmMsg = options.confirmMsg;
 	}
 
 	init () {
@@ -44,7 +44,9 @@ export class Transfer {
 			formData.append('upload', this.utils.getFileNameFromFileObject(file));
 			formData.append('override', document.querySelector(`${this.overrideExistingSelector} input`).checked);
 
-			confirm(this.uploadConfirmMsg);
+			if(!confirm(this.confirmMsg)) {
+				return;
+			}
 		} else {
 			formData.append('items', field.getAttribute(this.state.getStateAttribute('migrationExportItems')));
 		}

--- a/src/Blocks/components/form/assets-admin/transfer.js
+++ b/src/Blocks/components/form/assets-admin/transfer.js
@@ -60,7 +60,6 @@ export class Transfer {
 				'X-WP-Nonce': this.state.getStateConfigNonce(),
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets/captcha.js
+++ b/src/Blocks/components/form/assets/captcha.js
@@ -97,7 +97,6 @@ export class Captcha {
 				Accept: 'application/json',
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -129,7 +129,6 @@ export class Form {
 				Accept: 'application/json',
 			},
 			body: formData,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};
@@ -292,7 +291,6 @@ export class Form {
 				Accept: 'multipart/form-data',
 			},
 			body: this.FORM_DATA,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};
@@ -359,7 +357,6 @@ export class Form {
 				Accept: 'multipart/form-data',
 			},
 			body: this.FORM_DATA,
-			credentials: 'same-origin',
 			redirect: 'follow',
 			referrer: 'no-referrer',
 		};

--- a/src/Blocks/components/table/manifest.json
+++ b/src/Blocks/components/table/manifest.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"componentName": "table",
+	"title": "table",
+	"componentClass": "es-table",
+	"attributes": {
+		"tableHead": {
+			"type": "array"
+		},
+		"tableContent": {
+			"type": "array"
+		}
+	}
+}

--- a/src/Blocks/components/table/table-admin.scss
+++ b/src/Blocks/components/table/table-admin.scss
@@ -1,0 +1,28 @@
+.es-table {
+	position: relative;
+	overflow: auto;
+
+	table {
+		width: 100%;
+		border-spacing: 0;
+	}
+
+	thead {
+		background-color: var(--global-colors-esf-gray-100);
+	}
+
+	th {
+		column-span: none;
+		padding: 0.5rem;
+		text-align: left;
+		border-right: 1px solid var(--global-colors-esf-gray-200);
+		border-bottom: 1px solid var(--global-colors-esf-gray-200);
+	}
+
+	td {
+		padding: 0.5rem;
+		text-align: left;
+		border-right: 1px solid var(--global-colors-esf-gray-200);
+		border-bottom: 1px solid var(--global-colors-esf-gray-200);
+	}
+}

--- a/src/Blocks/components/table/table.php
+++ b/src/Blocks/components/table/table.php
@@ -42,16 +42,14 @@ if (!$tableContent) {
 				</tr>
 			</thead>
 		<?php } ?>
-		<?php if ($tableContent) { ?>
-			<tbody>
-				<?php foreach ($tableContent as $row) { ?>
-					<tr>
-						<?php foreach ($tableHead as $headKey => $headValue) { ?>
-							<td><?php echo $row[$headKey] ?? ''; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped ?></td>
-						<?php } ?>
-					</tr>
-				<?php } ?>
-			</tbody>
-		<?php } ?>
+		<tbody>
+			<?php foreach ($tableContent as $row) { ?>
+				<tr>
+					<?php foreach ($tableHead as $headKey => $headValue) { ?>
+						<td><?php echo $row[$headKey] ?? ''; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped ?></td>
+					<?php } ?>
+				</tr>
+			<?php } ?>
+		</tbody>
 	</table>
 </div>

--- a/src/Blocks/components/table/table.php
+++ b/src/Blocks/components/table/table.php
@@ -25,6 +25,10 @@ $tableWrapClass = Helpers::classnames([
 
 $tableClass = Helpers::selector($componentClass, $componentClass, 'table');
 
+if (!$tableContent) {
+	return;
+}
+
 ?>
 
 <div class="<?php echo esc_attr($tableWrapClass); ?>">

--- a/src/Blocks/components/table/table.php
+++ b/src/Blocks/components/table/table.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Template for the Table Component.
+ *
+ * @package EightshiftForms
+ */
+
+use EightshiftFormsVendor\EightshiftLibs\Helpers\Helpers;
+
+$manifest = Helpers::getManifestByDir(__DIR__);
+
+$componentClass = $manifest['componentClass'] ?? '';
+$additionalClass = $attributes['additionalClass'] ?? '';
+$selectorClass = $attributes['selectorClass'] ?? $componentClass;
+
+$tableContent = Helpers::checkAttr('tableContent', $attributes, $manifest);
+$tableHead = Helpers::checkAttr('tableHead', $attributes, $manifest);
+
+$tableWrapClass = Helpers::classnames([
+	Helpers::selector($componentClass, $componentClass),
+	Helpers::selector($selectorClass, $selectorClass, $componentClass),
+	Helpers::selector($additionalClass, $additionalClass),
+]);
+
+$tableClass = Helpers::classnames([
+	Helpers::selector($componentClass, $componentClass, 'table'),
+]);
+
+?>
+
+<div class="<?php echo esc_attr($tableWrapClass); ?>">
+	<table>
+		<?php if ($tableHead) { ?>
+			<thead>
+				<tr>
+					<?php foreach ($tableHead as $head) { ?>
+						<th><?php echo $head; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped ?></th>
+					<?php } ?>
+				</tr>
+			</thead>
+		<?php } ?>
+		<?php if ($tableContent) { ?>
+			<tbody>
+				<?php foreach ($tableContent as $row) { ?>
+					<tr>
+						<?php foreach ($tableHead as $headKey => $headValue) { ?>
+							<td><?php echo $row[$headKey] ?? ''; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped ?></td>
+						<?php } ?>
+					</tr>
+				<?php } ?>
+			</tbody>
+		<?php } ?>
+	</table>
+</div>

--- a/src/Blocks/components/table/table.php
+++ b/src/Blocks/components/table/table.php
@@ -23,9 +23,7 @@ $tableWrapClass = Helpers::classnames([
 	Helpers::selector($additionalClass, $additionalClass),
 ]);
 
-$tableClass = Helpers::classnames([
-	Helpers::selector($componentClass, $componentClass, 'table'),
-]);
+$tableClass = Helpers::selector($componentClass, $componentClass, 'table');
 
 ?>
 

--- a/src/Enqueue/Admin/EnqueueAdmin.php
+++ b/src/Enqueue/Admin/EnqueueAdmin.php
@@ -81,7 +81,7 @@ class EnqueueAdmin extends AbstractEnqueueAdmin
 			$this->getEnqueueSharedInlineCommonItems(false),
 			[
 				'nonce' => \wp_create_nonce('wp_rest'),
-				'uploadConfirmMsg' => \__('Are you sure you want to contine?', 'eighshift-forms'),
+				'confirmMsg' => \__('Are you sure you want to contine?', 'eighshift-forms'),
 				'importErrorMsg' => \__('There is an error with your data, please try again.', 'eighshift-forms'),
 				'isAdmin' => true,
 				'redirectionTimeout' => 100,

--- a/src/Enqueue/Admin/EnqueueAdmin.php
+++ b/src/Enqueue/Admin/EnqueueAdmin.php
@@ -81,7 +81,7 @@ class EnqueueAdmin extends AbstractEnqueueAdmin
 			$this->getEnqueueSharedInlineCommonItems(false),
 			[
 				'nonce' => \wp_create_nonce('wp_rest'),
-				'confirmMsg' => \__('Are you sure you want to contine?', 'eighshift-forms'),
+				'confirmMsg' => \__('Are you sure you want to continue?', 'eighshift-forms'),
 				'importErrorMsg' => \__('There is an error with your data, please try again.', 'eighshift-forms'),
 				'isAdmin' => true,
 				'redirectionTimeout' => 100,

--- a/src/Enqueue/SharedEnqueue.php
+++ b/src/Enqueue/SharedEnqueue.php
@@ -17,6 +17,7 @@ use EightshiftForms\Rest\Routes\Editor\IntegrationEditorSyncRoute;
 use EightshiftForms\Rest\Routes\Editor\Options\GeolocationCountriesRoute;
 use EightshiftForms\Rest\Routes\Settings\BulkRoute;
 use EightshiftForms\Rest\Routes\Settings\CacheDeleteRoute;
+use EightshiftForms\Rest\Routes\Settings\IncrementRoute;
 use EightshiftForms\Rest\Routes\Settings\DebugEncryptRoute;
 use EightshiftForms\Rest\Routes\Settings\ExportRoute;
 use EightshiftForms\Rest\Routes\Settings\LocationsRoute;
@@ -75,6 +76,7 @@ trait SharedEnqueue
 			$outputPrivate = [
 				// Admin.
 				'settings' => SettingsSubmitRoute::ROUTE_SLUG,
+				'increment' => IncrementRoute::ROUTE_SLUG,
 				'cacheClear' => CacheDeleteRoute::ROUTE_SLUG,
 				'migration' => MigrationRoute::ROUTE_SLUG,
 				'transfer' => TransferRoute::ROUTE_SLUG,

--- a/src/Entries/EntriesHelper.php
+++ b/src/Entries/EntriesHelper.php
@@ -15,7 +15,6 @@ use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsGeneralHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsHooksHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsSettingsHelper;
-use Hamcrest\Util;
 
 /**
  * EntriesHelper class.

--- a/src/Entries/EntriesHelper.php
+++ b/src/Entries/EntriesHelper.php
@@ -15,6 +15,7 @@ use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsGeneralHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsHooksHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsSettingsHelper;
+use Hamcrest\Util;
 
 /**
  * EntriesHelper class.
@@ -312,6 +313,55 @@ class EntriesHelper
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get increment.
+	 *
+	 * @param string $formId Form Id.
+	 *
+	 * @return string
+	 */
+	public static function getIncrement(string $formId): string
+	{
+		$value = UtilsSettingsHelper::getSettingValue(SettingsEntries::INCREMENT_META_KEY, $formId);
+		if (!$value) {
+			$value = 0;
+		}
+
+		$length = UtilsSettingsHelper::getSettingValue(SettingsEntries::SETTINGS_ENTRIES_INCREMENT_LENGTH_KEY, $formId);
+		if ($length) {
+			$value = \str_pad($value, (int) $length, '0', STR_PAD_LEFT);
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Set increment.
+	 *
+	 * @param string $formId Form Id.
+	 *
+	 * @return string
+	 */
+	public static function setIncrement(string $formId): string
+	{
+		$start = UtilsSettingsHelper::getSettingValue(SettingsEntries::SETTINGS_ENTRIES_INCREMENT_START_KEY, $formId);
+		$value = UtilsSettingsHelper::getSettingValue(SettingsEntries::INCREMENT_META_KEY, $formId);
+
+		if (!$value) {
+			$value = $start;
+		}
+
+		if ((int) $start > (int) $value) {
+			$value = $start;
+		}
+
+		$value = (int) $value + 1;
+
+		update_post_meta($formId, UtilsSettingsHelper::getSettingName(SettingsEntries::INCREMENT_META_KEY), $value);
+
+		return (string) $value;
 	}
 
 	/**

--- a/src/Entries/EntriesHelper.php
+++ b/src/Entries/EntriesHelper.php
@@ -330,10 +330,10 @@ class EntriesHelper
 
 		$length = UtilsSettingsHelper::getSettingValue(SettingsEntries::SETTINGS_ENTRIES_INCREMENT_LENGTH_KEY, $formId);
 		if ($length) {
-			$value = \str_pad($value, (int) $length, '0', STR_PAD_LEFT);
+			$value = \str_pad($value, (int) $length, '0', \STR_PAD_LEFT);
 		}
 
-		return $value;
+		return (string) $value;
 	}
 
 	/**
@@ -358,9 +358,29 @@ class EntriesHelper
 
 		$value = (int) $value + 1;
 
-		update_post_meta($formId, UtilsSettingsHelper::getSettingName(SettingsEntries::INCREMENT_META_KEY), $value);
+		\update_post_meta((int) $formId, UtilsSettingsHelper::getSettingName(SettingsEntries::INCREMENT_META_KEY), $value);
 
 		return (string) $value;
+	}
+
+	/**
+	 * Reset increment.
+	 *
+	 * @param string $formId Form Id.
+	 *
+	 * @return bool
+	 */
+	public static function resetIncrement(string $formId): bool
+	{
+		$value = UtilsSettingsHelper::getSettingValue(SettingsEntries::SETTINGS_ENTRIES_INCREMENT_START_KEY, $formId);
+
+		if (!$value) {
+			$value = 0;
+		}
+
+		$update = \update_post_meta((int) $formId, UtilsSettingsHelper::getSettingName(SettingsEntries::INCREMENT_META_KEY), $value);
+
+		return (bool) $update;
 	}
 
 	/**

--- a/src/Entries/SettingsEntries.php
+++ b/src/Entries/SettingsEntries.php
@@ -12,6 +12,7 @@ namespace EightshiftForms\Entries;
 
 use EightshiftFormsVendor\EightshiftFormsUtils\Config\UtilsConfig;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsGeneralHelper;
+use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsSettingsOutputHelper;
 use EightshiftFormsVendor\EightshiftFormsUtils\Settings\UtilsSettingInterface;
 use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsSettingsHelper;
@@ -44,6 +45,13 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 	public const FILTER_SETTINGS_GLOBAL_IS_VALID_NAME = 'es_forms_settings_global_is_valid_entries';
 
 	/**
+	 * Increment meta key.
+	 *
+	 * @var string
+	 */
+	public const INCREMENT_META_KEY = 'es_forms_increment';
+
+	/**
 	 * Settings key.
 	 */
 	public const SETTINGS_TYPE_KEY = 'entries';
@@ -59,9 +67,19 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 	public const SETTINGS_ENTRIES_SETTINGS_USE_KEY = 'entries-settings-use';
 
 	/**
-	 * Entries settings save empty fields key.
+	 * Save empty fields key.
 	 */
 	public const SETTINGS_ENTRIES_SAVE_EMPTY_FIELDS = 'entries-save-empty-fields';
+
+	/**
+	 * Increment start key.
+	 */
+	public const SETTINGS_ENTRIES_INCREMENT_START_KEY = 'entries-increment-start';
+
+	/**
+	 * Increment length key.
+	 */
+	public const SETTINGS_ENTRIES_INCREMENT_LENGTH_KEY = 'entries-increment-length';
 
 	/**
 	 * Entries settings send entry in form submit key.
@@ -69,6 +87,7 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 	public const SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_KEY = 'entries-save-additional-values';
 	public const SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_REDIRECT_URL_KEY = 'redirect-url';
 	public const SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_VARIATIONS_KEY = 'variations';
+	public const SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_INCREMENT_ID_KEY = 'increment-id';
 
 	/**
 	 * Data data key.
@@ -152,47 +171,52 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 
 		return [
 			UtilsSettingsOutputHelper::getIntro(self::SETTINGS_TYPE_KEY),
-			[
+			($isUsed ? [
 				'component' => 'layout',
 				'layoutType' => 'layout-v-stack-clean',
 				'layoutContent' => [
 					[
 						'component' => 'card-inline',
-						'cardInlineTitle' => \__('Store entries in database', 'eightshift-forms'),
+						'cardInlineTitle' => \__('View all entries in database', 'eightshift-forms'),
 						'cardInlineRightContent' => [
-							$isUsed ? [
+							[
 								'component' => 'submit',
 								'submitVariant' => 'ghost',
 								'submitButtonAsLink' => true,
 								'submitButtonAsLinkUrl' => UtilsGeneralHelper::getListingPageUrl(UtilsConfig::SLUG_ADMIN_LISTING_ENTRIES, $formId),
 								'submitValue' => \__('View', 'eightshift-forms'),
-							] : [],
+							],
+						],
+					],
+				],
+			] : []),
+			[
+				'component' => 'tabs',
+				'tabsContent' => [
+					[
+						'component' => 'tab',
+						'tabLabel' => \__('Entries', 'eightshift-forms'),
+						'tabContent' => [
 							[
 								'component' => 'checkboxes',
 								'checkboxesName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_SETTINGS_USE_KEY),
 								'checkboxesContent' => [
 									[
 										'component' => 'checkbox',
+										'checkboxLabel' => \__('Store entries in database', 'eightshift-forms'),
 										'checkboxIsChecked' => $isUsed,
 										'checkboxValue' => self::SETTINGS_ENTRIES_SETTINGS_USE_KEY,
 										'checkboxSingleSubmit' => true,
 										'checkboxAsToggle' => true,
 									],
 								],
+								'checkboxesFieldHelp' => $isUsed ? sprintf(\__('View all stored entries on <a href="%s">this</a> link.', 'eightshift-forms'), UtilsGeneralHelper::getListingPageUrl(UtilsConfig::SLUG_ADMIN_LISTING_ENTRIES, $formId)) : '',
 							],
-						],
-					],
-				],
-			],
-			...($isUsed ? [
-				[
-					'component' => 'tabs',
-					'tabsFull' => true,
-					'tabsContent' => [
-						[
-							'component' => 'tab',
-							'tabLabel' => \__('Options', 'eightshift-forms'),
-							'tabContent' => [
+							...($isUsed ? [
+								[
+									'component' => 'divider',
+									'dividerExtraVSpacing' => true,
+								],
 								[
 									'component' => 'checkboxes',
 									'checkboxesFieldLabel' => '',
@@ -235,14 +259,83 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 											'checkboxValue' => self::SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_VARIATIONS_KEY,
 											'checkboxSingleSubmit' => true,
 											'checkboxAsToggle' => true,
-										]
-									]
+										],
+										[
+											'component' => 'checkbox',
+											'checkboxLabel' => \__('Increment ID', 'eightshift-forms'),
+											'checkboxHelp' => \__('Increment ID set by the form successful submission.', 'eightshift-forms'),
+											'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_INCREMENT_ID_KEY, self::SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_KEY, $formId),
+											'checkboxValue' => self::SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_INCREMENT_ID_KEY,
+											'checkboxSingleSubmit' => true,
+											'checkboxAsToggle' => true,
+										],
+									],
+								],
+							] : []),
+						],
+					],
+					[
+						'component' => 'tab',
+						'tabLabel' => \__('Increment', 'eightshift-forms'),
+						'tabContent' => [
+							[
+								'component' => 'layout',
+								'layoutType' => 'layout-v-stack',
+								'layoutContent' => [
+									[
+										'component' => 'intro',
+										'introTitle' => \__('Export', 'eightshift-forms'),
+									],
+									[
+										'component' => 'card-inline',
+										'cardInlineTitle' => \__('Increment Id settings'),
+										'cardInlineSubTitle' => sprintf(\__('Current increment Id is: %s', 'eightshift-forms'), EntriesHelper::getIncrement($formId)),
+										'cardInlineRightContent' => [
+											[
+												'component' => 'submit',
+												'submitValue' => \__('Reset', 'eightshift-forms'),
+												'submitVariant' => 'ghost',
+												'submitAttrs' => [
+													// UtilsHelper::getStateAttribute('migrationType') => self::TYPE_EXPORT_GLOBAL_SETTINGS,
+												],
+												'additionalClass' => UtilsHelper::getStateSelectorAdmin('incrementReset'),
+											],
+										],
+									],
 								],
 							],
+							[
+								'component' => 'divider',
+								'dividerExtraVSpacing' => true,
+							],
+							[
+								'component' => 'input',
+								'inputName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_INCREMENT_START_KEY),
+								'inputId' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_INCREMENT_START_KEY),
+								'inputFieldLabel' => \__('Increment start number', 'eightshift-forms'),
+								'inputFieldHelp' => \__('Set the starting increment number of each successful form submission.', 'eightshift-forms'),
+								'inputType' => 'number',
+								'inputMin' => 1,
+								'inputStep' => 1,
+								'inputIsNumber' => true,
+								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_ENTRIES_INCREMENT_START_KEY, $formId),
+							],
+							[
+								'component' => 'input',
+								'inputName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_INCREMENT_LENGTH_KEY),
+								'inputId' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_INCREMENT_LENGTH_KEY),
+								'inputFieldLabel' => \__('Increment length number', 'eightshift-forms'),
+								'inputFieldHelp' => \__('Define minimal increment length you want to use. If the number is less than starting number, increment will have leading zeros.', 'eightshift-forms'),
+								'inputType' => 'number',
+								'inputMin' => 1,
+								'inputStep' => 1,
+								'inputIsNumber' => true,
+								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_ENTRIES_INCREMENT_LENGTH_KEY, $formId),
+							]
 						],
 					],
 				],
-			] : []),
+			],
 		];
 	}
 

--- a/src/Entries/SettingsEntries.php
+++ b/src/Entries/SettingsEntries.php
@@ -210,7 +210,8 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 										'checkboxAsToggle' => true,
 									],
 								],
-								'checkboxesFieldHelp' => $isUsed ? sprintf(\__('View all stored entries on <a href="%s">this</a> link.', 'eightshift-forms'), UtilsGeneralHelper::getListingPageUrl(UtilsConfig::SLUG_ADMIN_LISTING_ENTRIES, $formId)) : '',
+								// translators: %s is the link to the listing page.
+								'checkboxesFieldHelp' => $isUsed ? \sprintf(\__('View all stored entries on <a href="%s">this</a> link.', 'eightshift-forms'), UtilsGeneralHelper::getListingPageUrl(UtilsConfig::SLUG_ADMIN_LISTING_ENTRIES, $formId)) : '',
 							],
 							...($isUsed ? [
 								[
@@ -279,36 +280,6 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 						'tabLabel' => \__('Increment', 'eightshift-forms'),
 						'tabContent' => [
 							[
-								'component' => 'layout',
-								'layoutType' => 'layout-v-stack',
-								'layoutContent' => [
-									[
-										'component' => 'intro',
-										'introTitle' => \__('Export', 'eightshift-forms'),
-									],
-									[
-										'component' => 'card-inline',
-										'cardInlineTitle' => \__('Increment Id settings'),
-										'cardInlineSubTitle' => sprintf(\__('Current increment Id is: %s', 'eightshift-forms'), EntriesHelper::getIncrement($formId)),
-										'cardInlineRightContent' => [
-											[
-												'component' => 'submit',
-												'submitValue' => \__('Reset', 'eightshift-forms'),
-												'submitVariant' => 'ghost',
-												'submitAttrs' => [
-													// UtilsHelper::getStateAttribute('migrationType') => self::TYPE_EXPORT_GLOBAL_SETTINGS,
-												],
-												'additionalClass' => UtilsHelper::getStateSelectorAdmin('incrementReset'),
-											],
-										],
-									],
-								],
-							],
-							[
-								'component' => 'divider',
-								'dividerExtraVSpacing' => true,
-							],
-							[
 								'component' => 'input',
 								'inputName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_INCREMENT_START_KEY),
 								'inputId' => UtilsSettingsHelper::getSettingName(self::SETTINGS_ENTRIES_INCREMENT_START_KEY),
@@ -331,7 +302,33 @@ class SettingsEntries implements UtilsSettingGlobalInterface, UtilsSettingInterf
 								'inputStep' => 1,
 								'inputIsNumber' => true,
 								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_ENTRIES_INCREMENT_LENGTH_KEY, $formId),
-							]
+							],
+							[
+								'component' => 'divider',
+								'dividerExtraVSpacing' => true,
+							],
+							[
+								'component' => 'layout',
+								'layoutType' => 'layout-v-stack',
+								'layoutContent' => [
+									[
+										'component' => 'card-inline',
+										// translators: %s is the current increment number.
+										'cardInlineTitle' => \sprintf(\__('Current increment: %s', 'eightshift-forms'), EntriesHelper::getIncrement($formId)),
+										'cardInlineRightContent' => [
+											[
+												'component' => 'submit',
+												'submitValue' => \__('Reset', 'eightshift-forms'),
+												'submitVariant' => 'ghost',
+												'submitAttrs' => [
+													UtilsHelper::getStateAttribute('formId') => $formId,
+												],
+												'additionalClass' => UtilsHelper::getStateSelectorAdmin('incrementReset'),
+											],
+										],
+									],
+								],
+							],
 						],
 					],
 				],

--- a/src/General/SettingsGeneral.php
+++ b/src/General/SettingsGeneral.php
@@ -355,7 +355,7 @@ class SettingsGeneral implements UtilsSettingGlobalInterface, UtilsSettingInterf
 								'inputFieldHelp' => \__('Target a form (or a set of forms) and apply changes through filters, in code.', 'eightshift-forms'),
 								'inputType' => 'text',
 								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_FORM_CUSTOM_NAME_KEY, $formId),
-							]
+							],
 						],
 					],
 					[

--- a/src/Helpers/FormsHelper.php
+++ b/src/Helpers/FormsHelper.php
@@ -258,6 +258,4 @@ final class FormsHelper
 	{
 		return \str_pad((string) \wp_rand(1, 9999999999), 10, '0', \STR_PAD_LEFT);
 	}
-
-	
 }

--- a/src/Helpers/FormsHelper.php
+++ b/src/Helpers/FormsHelper.php
@@ -258,4 +258,6 @@ final class FormsHelper
 	{
 		return \str_pad((string) \wp_rand(1, 9999999999), 10, '0', \STR_PAD_LEFT);
 	}
+
+	
 }

--- a/src/Hooks/Filters.php
+++ b/src/Hooks/Filters.php
@@ -31,6 +31,7 @@ use EightshiftForms\Transfer\SettingsTransfer;
 use EightshiftForms\Troubleshooting\SettingsDebug;
 use EightshiftForms\Troubleshooting\SettingsFallback;
 use EightshiftForms\Captcha\SettingsCaptcha;
+use EightshiftForms\Entries\SettingsEntries;
 use EightshiftForms\Integrations\Calculator\SettingsCalculator;
 use EightshiftForms\Integrations\Corvus\SettingsCorvus;
 use EightshiftForms\Integrations\Paycek\SettingsPaycek;
@@ -437,6 +438,8 @@ final class Filters
 			SettingsDebug::SETTINGS_DEBUG_DEBUGGING_KEY,
 
 			SettingsSettings::SETTINGS_GENERAL_DISABLE_DEFAULT_ENQUEUE_KEY,
+
+			SettingsEntries::INCREMENT_META_KEY,
 		];
 	}
 }

--- a/src/Hooks/FiltersSettingsBuilder.php
+++ b/src/Hooks/FiltersSettingsBuilder.php
@@ -238,6 +238,7 @@ class FiltersSettingsBuilder implements ServiceInterface
 					'mailerFormTitle' => '',
 					'mailerTimestamp' => '',
 					'mailerTimestampHuman' => '',
+					'mailerIncrementId' => '',
 				],
 				'labels' => [
 					'title' => \__('Mailer', 'eightshift-forms'),

--- a/src/Rest/Routes/AbstractFormSubmit.php
+++ b/src/Rest/Routes/AbstractFormSubmit.php
@@ -487,6 +487,9 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 			'public' => [],
 		];
 
+		// Set increment and add it to the output.
+		$output['private'][UtilsHelper::getStateResponseOutputKey('incrementId')] = EntriesHelper::setIncrement($formId);
+
 		// Set entries.
 		$useEntries = \apply_filters(SettingsEntries::FILTER_SETTINGS_IS_VALID_NAME, $formId);
 		if ($useEntries) {
@@ -595,6 +598,13 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 					isset($output['public'][UtilsHelper::getStateResponseOutputKey('variation')])
 				) {
 					$entryNewData[UtilsHelper::getStateResponseOutputKey('variation')] = $output['public'][UtilsHelper::getStateResponseOutputKey('variation')];
+				}
+
+				if (
+					UtilsSettingsHelper::isSettingCheckboxChecked(SettingsEntries::SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_INCREMENT_ID_KEY, SettingsEntries::SETTINGS_ENTRIES_SAVE_ADDITONAL_VALUES_KEY, $formId) &&
+					isset($output['private'][UtilsHelper::getStateResponseOutputKey('incrementId')])
+				) {
+					$entryNewData[UtilsHelper::getStateResponseOutputKey('incrementId')] = $output['private'][UtilsHelper::getStateResponseOutputKey('incrementId')];
 				}
 
 				EntriesHelper::updateEntry($entryNewData, $output['private'][UtilsHelper::getStateResponseOutputKey('entry')]);
@@ -714,6 +724,9 @@ abstract class AbstractFormSubmit extends AbstractUtilsBaseRoute
 					break;
 				case 'mailerTimestampHuman':
 					$output[$key] = \current_datetime()->format('Y-m-d H:i:s');
+					break;
+				case 'mailerIncrementId':
+					$output[$key] = $data[UtilsHelper::getStateResponseOutputKey('incrementId')] ?? '';
 					break;
 				case 'mailerEntryUrl':
 					$entryId = $data[UtilsHelper::getStateResponseOutputKey('entry')] ?? '';

--- a/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
+++ b/src/Rest/Routes/Integrations/Calculator/FormSubmitCalculatorRoute.php
@@ -89,8 +89,6 @@ class FormSubmitCalculatorRoute extends AbstractFormSubmit
 			$formDetails[UtilsConfig::FD_PARAMS] = \apply_filters($filterName, $formDetails[UtilsConfig::FD_PARAMS], $formId) ?? [];
 		}
 
-		$successAdditionalData = $this->getIntegrationResponseSuccessOutputAdditionalData($formDetails);
-
 		// Set validation submit once.
 		$this->validator->setValidationSubmitOnce($formId);
 

--- a/src/Rest/Routes/Settings/IncrementRoute.php
+++ b/src/Rest/Routes/Settings/IncrementRoute.php
@@ -66,7 +66,7 @@ class IncrementRoute extends AbstractUtilsBaseRoute
 	}
 
 	/**
-	 * Method that returns rest response
+	 * Method that returns REST response.
 	 *
 	 * @param WP_REST_Request $request Data got from endpoint url.
 	 *

--- a/src/Rest/Routes/Settings/IncrementRoute.php
+++ b/src/Rest/Routes/Settings/IncrementRoute.php
@@ -56,7 +56,7 @@ class IncrementRoute extends AbstractUtilsBaseRoute
 	public const ROUTE_SLUG = 'increment';
 
 	/**
-	 * Get the base url of the route
+	 * Get the base url of the route.
 	 *
 	 * @return string The base URL for route you are adding.
 	 */

--- a/src/Rest/Routes/Settings/IncrementRoute.php
+++ b/src/Rest/Routes/Settings/IncrementRoute.php
@@ -37,7 +37,7 @@ class IncrementRoute extends AbstractUtilsBaseRoute
 	protected $manifestCache;
 
 	/**
-	 * Create a new instance that injects classes
+	 * Create a new instance that injects classes.
 	 *
 	 * @param ValidatorInterface $validator Inject validation methods.
 	 * @param ManifestCacheInterface $manifestCache Inject manifest cache interface.

--- a/src/Rest/Routes/Settings/IncrementRoute.php
+++ b/src/Rest/Routes/Settings/IncrementRoute.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * The class register route for increment endpoint.
+ *
+ * @package EightshiftForms\Rest\Routes\Settings
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Rest\Routes\Settings;
+
+use EightshiftForms\Entries\EntriesHelper;
+use EightshiftFormsVendor\EightshiftFormsUtils\Helpers\UtilsApiHelper;
+use EightshiftForms\Validation\ValidatorInterface;
+use EightshiftFormsVendor\EightshiftFormsUtils\Rest\Routes\AbstractUtilsBaseRoute;
+use EightshiftFormsVendor\EightshiftLibs\Cache\ManifestCacheInterface;
+use WP_REST_Request;
+
+/**
+ * Class IncrementRoute
+ */
+class IncrementRoute extends AbstractUtilsBaseRoute
+{
+	/**
+	 * Instance variable of ValidatorInterface data.
+	 *
+	 * @var ValidatorInterface
+	 */
+	protected $validator;
+
+	/**
+	 * Instance variable for listing data.
+	 *
+	 * @var ManifestCacheInterface
+	 */
+	protected $manifestCache;
+
+	/**
+	 * Create a new instance that injects classes
+	 *
+	 * @param ValidatorInterface $validator Inject validation methods.
+	 * @param ManifestCacheInterface $manifestCache Inject manifest cache interface.
+	 */
+	public function __construct(
+		ValidatorInterface $validator,
+		ManifestCacheInterface $manifestCache
+	) {
+		$this->validator = $validator;
+		$this->manifestCache = $manifestCache;
+	}
+
+	/**
+	 * Route slug.
+	 */
+	public const ROUTE_SLUG = 'increment';
+
+	/**
+	 * Get the base url of the route
+	 *
+	 * @return string The base URL for route you are adding.
+	 */
+	protected function getRouteName(): string
+	{
+		return self::ROUTE_SLUG;
+	}
+
+	/**
+	 * Method that returns rest response
+	 *
+	 * @param WP_REST_Request $request Data got from endpoint url.
+	 *
+	 * @return WP_REST_Response|mixed If response generated an error, WP_Error, if response
+	 *                                is already an instance, WP_HTTP_Response, otherwise
+	 *                                returns a new WP_REST_Response instance.
+	 */
+	public function routeCallback(WP_REST_Request $request)
+	{
+		$premission = $this->checkUserPermission();
+		if ($premission) {
+			return \rest_ensure_response($premission);
+		}
+
+		$debug = [
+			'request' => $request,
+		];
+
+		$params = $this->prepareSimpleApiParams($request);
+
+		$formId = $params['formId'] ?? '';
+		if (!$formId) {
+			return \rest_ensure_response(
+				UtilsApiHelper::getApiErrorPublicOutput(
+					\esc_html__('Form ID key was not provided.', 'eightshift-forms'),
+					[],
+					$debug
+				)
+			);
+		}
+
+		EntriesHelper::resetIncrement($formId);
+
+		return \rest_ensure_response(
+			UtilsApiHelper::getApiSuccessPublicOutput(
+				\esc_html__('Increment reset successful.', 'eightshift-forms'),
+				[],
+				$debug
+			)
+		);
+	}
+}


### PR DESCRIPTION
### Added

- `increment ID` option for entries so you can us them to track success submissions or use it a order number.
- `incrementId` key is now available in the email response tags.

### Changed

- `entries` listing now has new listing page with better UX and table layout.


