### PR TITLE
adding corrections for payment integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,21 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [5.8.2]
 
+### Fixed
+
+- form submission for phone bugfix.
+- increment ID bugfix for length.
+
 ### Changed
 
-- location of increment settings and helpers.
+- Corvus integration now supports API key per store ID.
+
+### Added
+
+- Corvus integration setting for setting IBAN and subscription values.
+- Corvus integration order number will now use increment ID or entry ID based on the settings.
+- Paycek integration order number will now use increment ID or entry ID based on the settings.
+- Paycek now sends formId and order number as GET parameters for callback URL.
 
 ## [5.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [5.8.2]
+
+### Changed
+
+- location of increment settings and helpers.
+
 ## [5.8.1]
 
 ### Changed
@@ -934,6 +940,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[5.8.2]: https://github.com/infinum/eightshift-forms/compare/5.8.1...5.8.2
 [5.8.1]: https://github.com/infinum/eightshift-forms/compare/5.8.0...5.8.1
 [5.8.0]: https://github.com/infinum/eightshift-forms/compare/5.7.1...5.8.0
 [5.7.1]: https://github.com/infinum/eightshift-forms/compare/5.7.0...5.7.1

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 5.8.1
+ * Version: 5.8.2
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -752,7 +752,10 @@ export class Form {
 						break;
 					}
 
-					data.value = data?.value?.combined ?? '';
+					console.log(this.utils.getPhoneCombinedValue(formId, name));
+					
+
+					data.value = this.utils.getPhoneCombinedValue(formId, name);
 
 					this.FORM_DATA.append(name, JSON.stringify(data));
 					break;

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -752,9 +752,6 @@ export class Form {
 						break;
 					}
 
-					console.log(this.utils.getPhoneCombinedValue(formId, name));
-					
-
 					data.value = this.utils.getPhoneCombinedValue(formId, name);
 
 					this.FORM_DATA.append(name, JSON.stringify(data));

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -416,12 +416,10 @@ export function setStateFormInitial(formId) {
 					setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], { value: value }, formId);
 					setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], { value: value }, formId);
 				} else {
-					const newPhonePrefix = getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)?.[0]?.value ?? '';
 					const newPhoneValue = {
 						prefix: getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)?.[0]?.value ?? '',
 						value: value,
 						meta: getState([StateEnum.ELEMENTS, name, StateEnum.VALUE], formId)?.[0]?.meta ?? {},
-						combined: newPhonePrefix ? `${newPhonePrefix}${value}` : value,
 					};
 
 					setState([StateEnum.ELEMENTS, name, StateEnum.INITIAL], newPhoneValue, formId);
@@ -604,20 +602,7 @@ export function setSteps(formElement, formId) {
  */
 export function setStateValues(name, value, formId) {
 	setState([StateEnum.ELEMENTS, name, StateEnum.HAS_CHANGED], true, formId);
-
-	switch (getStateFieldType(name)) {
-		case 'phone':
-			const newValue = {
-				...value,
-				combined: value?.prefix ? `${value?.prefix}${value?.value}` : value?.value,
-			 };
-
-			setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], newValue, formId);
-			break;
-		default:
-			setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
-			break;
-	}
+	setState([StateEnum.ELEMENTS, name, StateEnum.VALUE], value, formId);
 }
 
 /**

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -1407,6 +1407,27 @@ export class Utils {
 		};
 	};
 
+	/**
+	 * Get phone combined value.
+	 *
+	 * @param {string} formId Form Id.
+	 *
+	 * @returns {string}
+	 */
+	getPhoneCombinedValue(formId, name) {
+		const data = this.state.getStateElementValue(name, formId);
+
+		if (!data || data?.value === '') {
+			return '';
+		}
+
+		if (!this.state.getStateFormConfigPhoneDisablePicker(formId)) {
+			return data?.prefix === '' ? '' : `${data?.prefix}${data?.value}`;
+		} else {
+			return data?.value;
+		}
+	}
+
 	////////////////////////////////////////////////////////////////
 	// Events callback
 	////////////////////////////////////////////////////////////////
@@ -1573,6 +1594,9 @@ export class Utils {
 			},
 			getComparator: () => {
 				return this.getComparator();
+			},
+			getPhoneCombinedValue: (formId, name) => {
+				return this.getPhoneCombinedValue(formId, name);
 			},
 		};
 	}

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -1411,6 +1411,7 @@ export class Utils {
 	 * Get phone combined value.
 	 *
 	 * @param {string} formId Form Id.
+	 * @param {string} name Field name.
 	 *
 	 * @returns {string}
 	 */

--- a/src/Helpers/FormsHelper.php
+++ b/src/Helpers/FormsHelper.php
@@ -307,7 +307,7 @@ final class FormsHelper
 
 		\update_post_meta((int) $formId, UtilsSettingsHelper::getSettingName(SettingsGeneral::INCREMENT_META_KEY), $value);
 
-		return (string) $value;
+		return static::getIncrement($formId);
 	}
 
 	/**

--- a/src/Hooks/Variables.php
+++ b/src/Hooks/Variables.php
@@ -258,11 +258,14 @@ class Variables
 	/**
 	 * Get API Key for Corvus.
 	 *
+	 * @param string $storeId Store ID.
+	 *
 	 * @return string
 	 */
-	public static function getApiKeyCorvus(): string
+	public static function getApiKeyCorvus(string $storeId): string
 	{
-		return \defined('ES_API_KEY_CORVUS') ? \ES_API_KEY_CORVUS : '';
+		$key = "ES_API_KEY_CORVUS_{$storeId}";
+		return \defined($key) ? \constant($key) : '';
 	}
 
 	/**

--- a/src/Integrations/Corvus/SettingsCorvus.php
+++ b/src/Integrations/Corvus/SettingsCorvus.php
@@ -61,6 +61,11 @@ class SettingsCorvus extends AbstractSettingsIntegrations implements UtilsSettin
 	public const SETTINGS_CORVUS_IBAN_USE_KEY = 'corvus-iban-use';
 
 	/**
+	 * Corvus Entry ID use key.
+	 */
+	public const SETTINGS_CORVUS_ENTRY_ID_USE_KEY = 'corvus-entry-id-use';
+
+	/**
 	 * API Key.
 	 */
 	public const SETTINGS_CORVUS_API_KEY_KEY = 'corvus-api-key';
@@ -104,6 +109,16 @@ class SettingsCorvus extends AbstractSettingsIntegrations implements UtilsSettin
 	 * Corvus cart desc key.
 	 */
 	public const SETTINGS_CORVUS_CART_DESC_KEY = 'corvus-cart-desc';
+
+	/**
+	 * Corvus subscription value key.
+	 */
+	public const SETTINGS_CORVUS_SUBSCRIPTION_VALUE_KEY = 'corvus-subscription-value';
+
+	/**
+	 * Corvus iban value key.
+	 */
+	public const SETTINGS_CORVUS_IBAN_VALUE_KEY = 'corvus-iban-value';
 
 	/**
 	 * Skip integration.
@@ -470,22 +485,6 @@ class SettingsCorvus extends AbstractSettingsIntegrations implements UtilsSettin
 									'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_CORVUS_CART_DESC_KEY, $formId),
 								],
 								[
-									'component' => 'checkboxes',
-									'checkboxesFieldLabel' => '',
-									'checkboxesName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_CORVUS_REQ_COMPLETE_KEY),
-									'checkboxesContent' => [
-										[
-											'component' => 'checkbox',
-											'checkboxLabel' => \__('Require complete', 'eightshift-forms'),
-											'checkboxHelp' => \__('Checked indicates an pre-authorization. Unchecked indicates a sale. Note: applicable only for card transactions.', 'eightshift-forms'),
-											'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_CORVUS_REQ_COMPLETE_KEY, self::SETTINGS_CORVUS_REQ_COMPLETE_KEY, $formId),
-											'checkboxValue' => self::SETTINGS_CORVUS_REQ_COMPLETE_KEY,
-											'checkboxAsToggle' => true,
-											'checkboxSingleSubmit' => true,
-										]
-									]
-								],
-								[
 									'component' => 'divider',
 									'dividerExtraVSpacing' => true,
 								],
@@ -500,6 +499,42 @@ class SettingsCorvus extends AbstractSettingsIntegrations implements UtilsSettin
 											'checkboxHelp' => \__('To use IBAN Payment you must have this feature enabled in your Corvus account by contacting support.', 'eightshift-forms'),
 											'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_CORVUS_IBAN_USE_KEY, self::SETTINGS_CORVUS_IBAN_USE_KEY, $formId),
 											'checkboxValue' => self::SETTINGS_CORVUS_IBAN_USE_KEY,
+											'checkboxAsToggle' => true,
+											'checkboxSingleSubmit' => true,
+										]
+									]
+								],
+								[
+									'component' => 'divider',
+									'dividerExtraVSpacing' => true,
+								],
+								[
+									'component' => 'checkboxes',
+									'checkboxesFieldLabel' => '',
+									'checkboxesName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_CORVUS_ENTRY_ID_USE_KEY),
+									'checkboxesContent' => [
+										[
+											'component' => 'checkbox',
+											'checkboxLabel' => \__('Use Entry Id', 'eightshift-forms'),
+											'checkboxHelp' => \__('Use Entry Id instead of `increment ID` as Corvus `order_number` value. This is used if you want to refference the entry after the form submission. Make sure you have Entries feature turened `on`.', 'eightshift-forms'),
+											'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_CORVUS_ENTRY_ID_USE_KEY, self::SETTINGS_CORVUS_ENTRY_ID_USE_KEY, $formId),
+											'checkboxValue' => self::SETTINGS_CORVUS_ENTRY_ID_USE_KEY,
+											'checkboxAsToggle' => true,
+											'checkboxSingleSubmit' => true,
+										]
+									]
+								],
+								[
+									'component' => 'checkboxes',
+									'checkboxesFieldLabel' => '',
+									'checkboxesName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_CORVUS_REQ_COMPLETE_KEY),
+									'checkboxesContent' => [
+										[
+											'component' => 'checkbox',
+											'checkboxLabel' => \__('Require complete', 'eightshift-forms'),
+											'checkboxHelp' => \__('Checked indicates an pre-authorization. Unchecked indicates a sale. Note: applicable only for card transactions.', 'eightshift-forms'),
+											'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_CORVUS_REQ_COMPLETE_KEY, self::SETTINGS_CORVUS_REQ_COMPLETE_KEY, $formId),
+											'checkboxValue' => self::SETTINGS_CORVUS_REQ_COMPLETE_KEY,
 											'checkboxAsToggle' => true,
 											'checkboxSingleSubmit' => true,
 										]
@@ -558,6 +593,7 @@ class SettingsCorvus extends AbstractSettingsIntegrations implements UtilsSettin
 												'component' => 'select',
 												'selectName' => $item['id'],
 												'selectFieldLabel' => $item['title'],
+												'selectFieldHelp' => $item['help'] ?? '',
 												'selectFieldIsFiftyFiftyHorizontal' => true,
 												'selectFieldBeforeContent' => '&rarr;',
 												'selectIsRequired' => $item['required'],
@@ -568,6 +604,22 @@ class SettingsCorvus extends AbstractSettingsIntegrations implements UtilsSettin
 										$this->getCorvusParams()
 									),
 								],
+							],
+							[
+								'component' => 'input',
+								'inputPlaceholder' => 'true',
+								'inputName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_CORVUS_SUBSCRIPTION_VALUE_KEY),
+								'inputFieldLabel' => \__('Subscription field value', 'eightshift-forms'),
+								'inputFieldHelp' => \__('If you want to create a subscription, sent value must be `true` or value defined in this field.', 'eightshift-forms'),
+								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_CORVUS_SUBSCRIPTION_VALUE_KEY, $formId),
+							],
+							[
+								'component' => 'input',
+								'inputPlaceholder' => 'true',
+								'inputName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_CORVUS_IBAN_VALUE_KEY),
+								'inputFieldLabel' => \__('IBAN field value', 'eightshift-forms'),
+								'inputFieldHelp' => \__('If you want to create a IBAN payment, sent value must be `true` or value defined in this field.', 'eightshift-forms'),
+								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_CORVUS_IBAN_VALUE_KEY, $formId),
 							],
 						],
 					] : [],
@@ -767,6 +819,12 @@ class SettingsCorvus extends AbstractSettingsIntegrations implements UtilsSettin
 			[
 				'id' => 'subscription',
 				'title' => \__('Subscription', 'eightshift-forms'),
+				'type' => 'bool',
+				'required' => false,
+			],
+			[
+				'id' => 'iban',
+				'title' => \__('IBAN', 'eightshift-forms'),
 				'type' => 'bool',
 				'required' => false,
 			],

--- a/src/Integrations/Paycek/SettingsPaycek.php
+++ b/src/Integrations/Paycek/SettingsPaycek.php
@@ -101,6 +101,11 @@ class SettingsPaycek extends AbstractSettingsIntegrations implements UtilsSettin
 	public const SETTINGS_PAYCEK_SKIP_INTEGRATION_KEY = 'paycek-skip-integration';
 
 	/**
+	 * Entry ID use key.
+	 */
+	public const SETTINGS_PAYCEK_ENTRY_ID_USE_KEY = 'paycek-entry-id-use';
+
+	/**
 	 * Instance variable for Fallback settings.
 	 *
 	 * @var SettingsFallbackDataInterface
@@ -215,6 +220,10 @@ class SettingsPaycek extends AbstractSettingsIntegrations implements UtilsSettin
 								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_PAYCEK_CART_DESC_KEY, $formId),
 							],
 							[
+								'component' => 'divider',
+								'dividerExtraVSpacing' => true,
+							],
+							[
 								'component' => 'input',
 								'inputIsRequired' => true,
 								'inputName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_PAYCEK_URL_SUCCESS),
@@ -243,6 +252,26 @@ class SettingsPaycek extends AbstractSettingsIntegrations implements UtilsSettin
 								'inputIsUrl' => true,
 								'inputType' => 'url',
 								'inputValue' => UtilsSettingsHelper::getSettingValue(self::SETTINGS_PAYCEK_URL_CANCEL, $formId),
+							],
+							[
+								'component' => 'divider',
+								'dividerExtraVSpacing' => true,
+							],
+							[
+								'component' => 'checkboxes',
+								'checkboxesFieldLabel' => '',
+								'checkboxesName' => UtilsSettingsHelper::getSettingName(self::SETTINGS_PAYCEK_ENTRY_ID_USE_KEY),
+								'checkboxesContent' => [
+									[
+										'component' => 'checkbox',
+										'checkboxLabel' => \__('Use Entry Id', 'eightshift-forms'),
+										'checkboxHelp' => \__('Use Entry Id instead of `increment ID` as Paycek `paymentId` value. This is used if you want to refference the entry after the form submission. Make sure you have Entries feature turened `on`.', 'eightshift-forms'),
+										'checkboxIsChecked' => UtilsSettingsHelper::isSettingCheckboxChecked(self::SETTINGS_PAYCEK_ENTRY_ID_USE_KEY, self::SETTINGS_PAYCEK_ENTRY_ID_USE_KEY, $formId),
+										'checkboxValue' => self::SETTINGS_PAYCEK_ENTRY_ID_USE_KEY,
+										'checkboxAsToggle' => true,
+										'checkboxSingleSubmit' => true,
+									]
+								]
 							],
 						],
 					],

--- a/src/Rest/Routes/Integrations/Paycek/FormSubmitPaycekRoute.php
+++ b/src/Rest/Routes/Integrations/Paycek/FormSubmitPaycekRoute.php
@@ -228,7 +228,7 @@ class FormSubmitPaycekRoute extends AbstractFormSubmit
 		$params['urlFail'] = $this->getCallbackUrl($formId, $orderId, UtilsSettingsHelper::getSettingValue(SettingsPaycek::SETTINGS_PAYCEK_URL_FAIL, $formId));
 		$params['urlCancel'] = $this->getCallbackUrl($formId, $orderId, UtilsSettingsHelper::getSettingValue(SettingsPaycek::SETTINGS_PAYCEK_URL_CANCEL, $formId));
 
-		// Set the correct order as it is req by Corvus.
+		// Set the correct order as it is req by Paycek.
 		\ksort($params);
 
 		return $params;


### PR DESCRIPTION
### Fixed

- form submission for phone bugfix.
- increment ID bugfix for length.

### Changed

- Corvus integration now supports API key per store ID.

### Added

- Corvus integration setting for setting IBAN and subscription values.
- Corvus integration order number will now use increment ID or entry ID based on the settings.
- Paycek integration order number will now use increment ID or entry ID based on the settings.
- Paycek now sends formId and order number as GET parameters for callback URL.