### PR TITLE
8.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [8.6.1]
+
+### Fixed
+
+- `esFormsAfterCaptchaInit` only outputting the raw response, which is already used so it can't be read again
+
 ## [8.6.0]
 
 ### Added
@@ -1511,6 +1517,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[8.6.1]: https://github.com/infinum/eightshift-forms/compare/8.6.0...8.6.1
 [8.6.0]: https://github.com/infinum/eightshift-forms/compare/8.5.4...8.6.0
 [8.5.4]: https://github.com/infinum/eightshift-forms/compare/8.5.3...8.5.4
 [8.5.3]: https://github.com/infinum/eightshift-forms/compare/8.5.2...8.5.3

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 8.6.0
+ * Version: 8.6.1
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Blocks/components/form/assets/captcha.js
+++ b/src/Blocks/components/form/assets/captcha.js
@@ -22,7 +22,7 @@ export class Captcha {
 
 	/**
 	 * Init all actions.
-	 * 
+	 *
 	 * @returns {void}
 	 */
 	init() {
@@ -75,7 +75,7 @@ export class Captcha {
 
 	/**
 	 * Handle form submit and all logic in case we have captcha in place for init load.
-	 * 
+	 *
 	 * @param {string} token Captcha token from api.
 	 * @param {bool} isEnterprise Is enterprise setup.
 	 * @param {string} action Action to use.
@@ -111,7 +111,7 @@ export class Captcha {
 				throw new Error(`API response returned an error. Function used: "formSubmitCaptchaInvisible". Msg: ${response?.message} Action: ${action}`);
 			}
 
-			this.utils.dispatchFormEventWindow(this.state.getStateEvent('afterCaptchaInit'), response);
+			this.utils.dispatchFormEventWindow(this.state.getStateEvent('afterCaptchaInit'), { responseData: parsedResponse, rawResponse: response });
 		} catch ({name, message}) {
 			if (name === 'AbortError') {
 				return;
@@ -140,7 +140,7 @@ export class Captcha {
 
 	/**
 	 * Set all public methods.
-	 * 
+	 *
 	 * @returns {void}
 	 */
 	publicMethods() {


### PR DESCRIPTION
Changes:

### Fixed

- `esFormsAfterCaptchaInit` only outputting the raw response, which is already used so it can't be read again


Closes #548