### PR TITLE
8.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [8.6.2]
+
+### Fixed
+
+- Display issue with `input` range fields if value is 0 and `min` is not set due to browser implementations of `<input type="range">`.
+
+### Changed
+
+- `input` will no longer output `max` and `step` if not set.
+
 ## [8.6.1]
 
 ### Fixed
@@ -1517,6 +1527,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[8.6.2]: https://github.com/infinum/eightshift-forms/compare/8.6.1...8.6.2
 [8.6.1]: https://github.com/infinum/eightshift-forms/compare/8.6.0...8.6.1
 [8.6.0]: https://github.com/infinum/eightshift-forms/compare/8.5.4...8.6.0
 [8.5.4]: https://github.com/infinum/eightshift-forms/compare/8.5.3...8.5.4

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 8.6.1
+ * Version: 8.6.2
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Blocks/components/input/input.php
+++ b/src/Blocks/components/input/input.php
@@ -77,12 +77,20 @@ if ($inputUseLabelAsPlaceholder) {
 }
 
 if ($inputType === 'range') {
-	$inputAttrs['min'] = esc_attr($inputMin);
-	$inputAttrs['max'] = esc_attr($inputMax);
-	$inputAttrs['step'] = esc_attr($inputStep);
+	// Fallback is the browser default value if no min is set.
+	// Without fallback .value in JS returns a mid value between min (or 0 if unset) and max (or 100 if unset), which can cause weird display issue.
+	$inputAttrs['min'] = esc_attr($inputMin ?: 0);
+
+	if ($inputMax) {
+		$inputAttrs['max'] = esc_attr($inputMax);
+	}
+
+	if ($inputStep) {
+		$inputAttrs['step'] = esc_attr($inputStep);
+	}
 
 	if (!$inputValue) {
-		$inputAttrs['value'] = esc_attr($inputMin);
+		$inputAttrs['value'] = esc_attr($inputAttrs['min']);
 	}
 
 	if ($inputRangeShowMin) {


### PR DESCRIPTION
### Fixed

- Display issue with `input` range fields if value is 0 and `min` is not set due to browser implementations of `<input type="range">`.

### Changed

- `input` will no longer output `max` and `step` if not set.