### PR TITLE
feature/fix-conditional-tags-show-as-conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.1.2]
+
+### Fixed
+
+- Fixed conditional tags being lost when converting between block types (checkboxes, radios, select) using the "show as" option. Both field-level and inner-item conditional tags are now correctly preserved across all conversion directions.
+
 ## [9.1.1]
 
 ### Fixed
@@ -1774,6 +1780,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.1.2]: https://github.com/infinum/eightshift-forms/compare/9.1.1...9.1.2
 [9.1.1]: https://github.com/infinum/eightshift-forms/compare/9.1.0...9.1.1
 [9.1.0]: https://github.com/infinum/eightshift-forms/compare/9.0.0...9.1.0
 [9.0.0]: https://github.com/infinum/eightshift-forms/compare/8.16.0...9.0.0

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.1.1
+ * Version: 9.1.2
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.1.1",
+	"version": "9.1.2",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Blocks/manifest.json
+++ b/src/Blocks/manifest.json
@@ -109,7 +109,13 @@
 				"checkboxesCheckboxesShowAs": "selectSelectShowAs",
 				"checkboxesCheckboxesFieldAttrs": "selectSelectFieldAttrs",
 				"checkboxesCheckboxesPlaceholder": "selectSelectPlaceholder",
-				"checkboxesCheckboxesUseLabelAsPlaceholder": "selectSelectUseLabelAsPlaceholder"
+				"checkboxesCheckboxesUseLabelAsPlaceholder": "selectSelectUseLabelAsPlaceholder",
+				"checkboxesCheckboxesConditionalTagsUse": "selectSelectConditionalTagsUse",
+				"checkboxesCheckboxesConditionalTagsRules": "selectSelectConditionalTagsRules",
+				"checkboxesCheckboxesConditionalTagsRulesForms": "selectSelectConditionalTagsRulesForms",
+				"checkboxesCheckboxesConditionalTagsPostId": "selectSelectConditionalTagsPostId",
+				"checkboxesCheckboxesConditionalTagsBlockName": "selectSelectConditionalTagsBlockName",
+				"checkboxesCheckboxesConditionalTagsIsHidden": "selectSelectConditionalTagsIsHidden"
 			},
 			"children": {
 				"checkboxCheckboxLabel": "selectOptionSelectOptionLabel",
@@ -118,7 +124,13 @@
 				"checkboxCheckboxIsDisabled": "selectOptionSelectOptionIsDisabled",
 				"checkboxCheckboxAttrs": "selectOptionSelectOptionAttrs",
 				"checkboxCheckboxIsHidden": "selectOptionSelectOptionIsHidden",
-				"checkboxCheckboxDisabledOptions": "selectOptionSelectOptionDisabledOptions"
+				"checkboxCheckboxDisabledOptions": "selectOptionSelectOptionDisabledOptions",
+				"checkboxCheckboxConditionalTagsUse": "selectOptionSelectOptionConditionalTagsUse",
+				"checkboxCheckboxConditionalTagsRules": "selectOptionSelectOptionConditionalTagsRules",
+				"checkboxCheckboxConditionalTagsRulesForms": "selectOptionSelectOptionConditionalTagsRulesForms",
+				"checkboxCheckboxConditionalTagsPostId": "selectOptionSelectOptionConditionalTagsPostId",
+				"checkboxCheckboxConditionalTagsBlockName": "selectOptionSelectOptionConditionalTagsBlockName",
+				"checkboxCheckboxConditionalTagsIsHidden": "selectOptionSelectOptionConditionalTagsIsHidden"
 			},
 			"append": {
 				"checkboxes": {
@@ -155,7 +167,13 @@
 				"checkboxesCheckboxesDisabledOptions": "radiosRadiosDisabledOptions",
 				"checkboxesCheckboxesTypeCustom": "radiosRadiosTypeCustom",
 				"checkboxesCheckboxesShowAs": "radiosRadiosShowAs",
-				"checkboxesCheckboxesFieldAttrs": "radiosRadiosFieldAttrs"
+				"checkboxesCheckboxesFieldAttrs": "radiosRadiosFieldAttrs",
+				"checkboxesCheckboxesConditionalTagsUse": "radiosRadiosConditionalTagsUse",
+				"checkboxesCheckboxesConditionalTagsRules": "radiosRadiosConditionalTagsRules",
+				"checkboxesCheckboxesConditionalTagsRulesForms": "radiosRadiosConditionalTagsRulesForms",
+				"checkboxesCheckboxesConditionalTagsPostId": "radiosRadiosConditionalTagsPostId",
+				"checkboxesCheckboxesConditionalTagsBlockName": "radiosRadiosConditionalTagsBlockName",
+				"checkboxesCheckboxesConditionalTagsIsHidden": "radiosRadiosConditionalTagsIsHidden"
 			},
 			"children": {
 				"checkboxCheckboxLabel": "radioRadioLabel",
@@ -164,7 +182,13 @@
 				"checkboxCheckboxIsDisabled": "radioRadioIsDisabled",
 				"checkboxCheckboxAttrs": "radioRadioAttrs",
 				"checkboxCheckboxIsHidden": "radioRadioIsHidden",
-				"checkboxCheckboxDisabledOptions": "radioRadioDisabledOptions"
+				"checkboxCheckboxDisabledOptions": "radioRadioDisabledOptions",
+				"checkboxCheckboxConditionalTagsUse": "radioRadioConditionalTagsUse",
+				"checkboxCheckboxConditionalTagsRules": "radioRadioConditionalTagsRules",
+				"checkboxCheckboxConditionalTagsRulesForms": "radioRadioConditionalTagsRulesForms",
+				"checkboxCheckboxConditionalTagsPostId": "radioRadioConditionalTagsPostId",
+				"checkboxCheckboxConditionalTagsBlockName": "radioRadioConditionalTagsBlockName",
+				"checkboxCheckboxConditionalTagsIsHidden": "radioRadioConditionalTagsIsHidden"
 			}
 		},
 		"radios-select": {
@@ -198,7 +222,13 @@
 				"radiosRadiosShowAs": "selectSelectShowAs",
 				"radiosRadiosFieldAttrs": "selectSelectFieldAttrs",
 				"radiosRadiosPlaceholder": "selectSelectPlaceholder",
-				"radiosRadiosUseLabelAsPlaceholder": "selectSelectUseLabelAsPlaceholder"
+				"radiosRadiosUseLabelAsPlaceholder": "selectSelectUseLabelAsPlaceholder",
+				"radiosRadiosConditionalTagsUse": "selectSelectConditionalTagsUse",
+				"radiosRadiosConditionalTagsRules": "selectSelectConditionalTagsRules",
+				"radiosRadiosConditionalTagsRulesForms": "selectSelectConditionalTagsRulesForms",
+				"radiosRadiosConditionalTagsPostId": "selectSelectConditionalTagsPostId",
+				"radiosRadiosConditionalTagsBlockName": "selectSelectConditionalTagsBlockName",
+				"radiosRadiosConditionalTagsIsHidden": "selectSelectConditionalTagsIsHidden"
 			},
 			"children": {
 				"radioRadioLabel": "selectOptionSelectOptionLabel",
@@ -207,7 +237,13 @@
 				"radioRadioIsDisabled": "selectOptionSelectOptionIsDisabled",
 				"radioRadioAttrs": "selectOptionSelectOptionAttrs",
 				"radioRadioIsHidden": "selectOptionSelectOptionIsHidden",
-				"radioRadioDisabledOptions": "selectOptionSelectOptionDisabledOptions"
+				"radioRadioDisabledOptions": "selectOptionSelectOptionDisabledOptions",
+				"radioRadioConditionalTagsUse": "selectOptionSelectOptionConditionalTagsUse",
+				"radioRadioConditionalTagsRules": "selectOptionSelectOptionConditionalTagsRules",
+				"radioRadioConditionalTagsRulesForms": "selectOptionSelectOptionConditionalTagsRulesForms",
+				"radioRadioConditionalTagsPostId": "selectOptionSelectOptionConditionalTagsPostId",
+				"radioRadioConditionalTagsBlockName": "selectOptionSelectOptionConditionalTagsBlockName",
+				"radioRadioConditionalTagsIsHidden": "selectOptionSelectOptionConditionalTagsIsHidden"
 			}
 		}
 	},


### PR DESCRIPTION
# Description

### Fixed

- Fixed conditional tags being lost when converting between block types (checkboxes, radios, select) using the "show as" option. Both field-level and per-option conditional tags are now correctly preserved across all three conversion directions (`checkboxes-select`, `checkboxes-radios`, `radios-select`).

## QA Guide

1. Create a form with a **Checkboxes** field that has conditional tags configured — both on the field itself (e.g. "hide this field when...") and on individual checkbox options (e.g. "hide option B when...").
2. In the block editor, use "Show as" → **Select** on the checkboxes field.
3. Save and preview the form on the frontend.
4. Verify the field-level conditional tag still works (field shows/hides correctly based on the rule).
5. Verify the per-option conditional tags still work (individual options show/hide correctly).
6. Repeat steps 1–5 converting **Checkboxes → Radios** and **Radios → Select**.

**Expected result:** All conditional tag rules are preserved after conversion and behave identically to before the conversion.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->