### PR TITLE
release/9.1.3

### DIFF
--- a/.github/workflows/bundle-release.yml
+++ b/.github/workflows/bundle-release.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           PROJECT_PATH: 'wp-content/plugins/eightshift-forms'
           NODE_VERSION: ${{ matrix.node }}
-          USE_BUN: true
 
       - name: Set cache
         uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main
@@ -63,5 +62,52 @@ jobs:
         with:
           repo_token: ${{ secrets.WORDPRESS_GH_ACTIONS }}
           file: release.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+
+  release-sourcemaps:
+    name: Create release with sourcemaps
+    runs-on: ubuntu-latest
+    needs: bundle
+    steps:
+      - name: Install plugin
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/setup/theme-or-plugin@main
+        with:
+          PROJECT_PATH: 'wp-content/plugins/eightshift-forms'
+          NODE_VERSION: ${{ matrix.node }}
+          BUILD_SOURCEMAPS: true
+
+      - name: Clear previous cache
+        working-directory: 'wp-content/plugins/eightshift-forms'
+        shell: bash
+        run: |
+          rm -rf eightshift
+
+      - name: Set cache
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/set/cache@main
+        with:
+          PROJECT_PATH: 'wp-content/plugins/eightshift-forms'
+
+      - name: Post install cleanup - plugin
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/cleanup/project@main
+        with:
+          PROJECT_PATH: 'wp-content/plugins/eightshift-forms'
+
+      - name: Setup correct folder/file permissions
+        uses: infinum/eightshift-deploy-actions-public/.github/actions/set/permissions@main
+        with:
+          PROJECT_PATH: 'wp-content/plugins/eightshift-forms'
+
+      - name: Zip Plugin
+        shell: bash
+        run: |
+          cd wp-content/plugins
+          zip -rq ../../release-sourcemaps.zip eightshift-forms
+
+      - name: Upload zip to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.WORDPRESS_GH_ACTIONS }}
+          file: release-sourcemaps.zip
           tag: ${{ github.ref }}
           overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,3 @@ jobs:
         with:
           NODE_VERSION: ${{ matrix.node }}
           PROJECT_PATH: '.'
-          USE_BUN: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.1.3]
+
+### Added
+
+- Added sourcemaps to the release as a separate artifact.
+
 ## [9.1.2]
 
 ### Fixed
@@ -1780,6 +1786,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.1.3]: https://github.com/infinum/eightshift-forms/compare/9.1.2...9.1.3
 [9.1.2]: https://github.com/infinum/eightshift-forms/compare/9.1.1...9.1.2
 [9.1.1]: https://github.com/infinum/eightshift-forms/compare/9.1.0...9.1.1
 [9.1.0]: https://github.com/infinum/eightshift-forms/compare/9.0.0...9.1.0

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.1.2
+ * Version: 9.1.3
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"lint": "eslint",
 		"start": "webpack --watch --mode development",
 		"build": "webpack --mode production",
+		"build:sourcemaps": "webpack --mode production --env sourcemaps",
 		"prepare": "husky",
 		"test:e2e:playground": "npx @wp-playground/cli@latest server --auto-mount --blueprint=./tests/e2e/playground/playground.json",
 		"test:e2e": "playwright test",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,17 +7,12 @@ const path = require('path');
  * Please referer to Eightshift-libs wiki for details.
  */
 module.exports = (env, argv) => {
-
 	const projectConfig = {
 		config: {
 			projectDir: __dirname, // Current project directory absolute path.
 			projectPath: 'wp-content/plugins/eightshift-forms', // Project path relative to project root.
 		},
-		overrides: [
-			'application',
-			'applicationAdmin',
-			'applicationBlocks',
-		],
+		overrides: ['application', 'applicationAdmin', 'applicationBlocks'],
 	};
 
 	// Generate Webpack config for this project using options object.
@@ -27,7 +22,7 @@ module.exports = (env, argv) => {
 		// Load all projects config from eightshift-frontend-libs.
 		...project,
 
-		...(argv.mode === 'production' && { devtool: 'source-map' }),
+		...(env?.sourcemaps && { devtool: 'source-map' }),
 
 		output: {
 			// Load all output config from eightshift-frontend-libs.


### PR DESCRIPTION
# Description

### Added

- Added sourcemaps as a separate release artifact via a new `release-sourcemaps` workflow job
- Added `build:sourcemaps` npm script for generating builds with source maps

### Changed

- Updated sourcemap generation to be opt-in via `env.sourcemaps` flag instead of always building in production mode
- Updated webpack config overrides formatting
- Removed `USE_BUN` flag from CI and bundle-release workflows

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Linked documentation PR

<!-- If this PR has documentation please put the link here. -->