### PR TITLE
feature/textarea-alternative-escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.3.0]
+
+### Added
+
+- Added `textareaAlternativeOutputEscape` attribute to the textarea component. When enabled, textarea value output uses `esc_html` instead of `wp_kses_post`, useful when the value must be rendered as plain text inside an HTML context.
+
 ## [9.2.0]
 
 ### Added
@@ -1819,6 +1825,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.3.0]: https://github.com/infinum/eightshift-forms/compare/9.2.0...9.3.0
 [9.2.0]: https://github.com/infinum/eightshift-forms/compare/9.1.6...9.2.0
 [9.1.6]: https://github.com/infinum/eightshift-forms/compare/9.1.5...9.1.6
 [9.1.5]: https://github.com/infinum/eightshift-forms/compare/9.1.4...9.1.5

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.2.0
+ * Version: 9.3.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.2.0",
+	"version": "9.3.0",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Blocks/components/textarea/manifest.json
+++ b/src/Blocks/components/textarea/manifest.json
@@ -57,6 +57,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"textareaAlternativeOutputEscape": {
+			"type": "boolean",
+			"default": false
+		},
 		"textareaLimitHeight": {
 			"type": "boolean",
 			"default": false

--- a/src/Blocks/components/textarea/textarea.php
+++ b/src/Blocks/components/textarea/textarea.php
@@ -35,6 +35,7 @@ $textareaLimitHeight = Helpers::checkAttr('textareaLimitHeight', $attributes, $m
 $textareaIsPreventSubmit = Helpers::checkAttr('textareaIsPreventSubmit', $attributes, $manifest);
 $textareaUseLabelAsPlaceholder = Helpers::checkAttr('textareaUseLabelAsPlaceholder', $attributes, $manifest);
 $textareaTwSelectorsData = Helpers::checkAttr('textareaTwSelectorsData', $attributes, $manifest);
+$textareaAlternativeOutputEscape = Helpers::checkAttr('textareaAlternativeOutputEscape', $attributes, $manifest);
 
 $textareaId = $textareaName . '-' . Helpers::getUnique();
 
@@ -79,6 +80,13 @@ $textareaAttrs['aria-invalid'] = 'false';
 // Additional content filter.
 $additionalContent = GeneralHelpers::getBlockAdditionalContentViaFilter('textarea', $attributes);
 
+// For outputting textarea value as HTML, we need to escape the value.
+if ($textareaAlternativeOutputEscape) {
+	$textareaValue = esc_html($textareaValue);
+} else {
+	$textareaValue = wp_kses_post($textareaValue);
+}
+
 $textarea = '<textarea
 		class="' . esc_attr($textareaClass) . '"
 		name="' . esc_attr($textareaName) . '"
@@ -86,7 +94,7 @@ $textarea = '<textarea
 		' . disabled($textareaIsDisabled, true, false) . '
 		' . wp_readonly($textareaIsReadOnly, true, false) . '
 		' . Helpers::getAttrsOutput($textareaAttrs) . '
-	>' . wp_kses_post($textareaValue) . '</textarea>
+	>' . $textareaValue . '</textarea>
 	' . $additionalContent . '
 ';
 


### PR DESCRIPTION
# Description

### Added

- Added \`textareaAlternativeOutputEscape\` boolean attribute to the textarea component. When enabled, the textarea value is escaped with \`esc_html\` instead of \`wp_kses_post\`, making it safe for contexts where HTML tags must be rendered as plain text rather than allowed as markup.

## QA Guide

1. Open a form with a textarea field in the block editor.
2. In the textarea component settings, enable the **Alternative Output Escape** option.
3. Submit the form with a value containing HTML (e.g. `<strong>test</strong>`).
4. Verify the submitted value is rendered as escaped plain text (`&lt;strong&gt;test&lt;/strong&gt;`) rather than parsed HTML.
5. Disable the option and repeat — confirm HTML tags pass through `wp_kses_post` as before.

**Expected result:** With the attribute enabled, HTML in textarea values is fully escaped; with it disabled, behaviour is unchanged from before.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Linked documentation PR

<!-- If this PR has documentation please put the link here. -->