### PR TITLE
feature/alternative-params-security-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.4.0]
+
+### Added
+
+- Added `alternativeParamsSecurityCheck` filter to the validation filter group. Allows specifying form field keys whose values should be sanitized with `esc_html` instead of `wp_strip_all_tags` during API param security checks.
+- Added `SettingsHelpers::getSettingValueUnescaped()` helper that returns a setting value with HTML entities decoded via `html_entity_decode`.
+
 ## [9.3.0]
 
 ### Added
@@ -1825,6 +1832,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.4.0]: https://github.com/infinum/eightshift-forms/compare/9.3.0...9.4.0
 [9.3.0]: https://github.com/infinum/eightshift-forms/compare/9.2.0...9.3.0
 [9.2.0]: https://github.com/infinum/eightshift-forms/compare/9.1.6...9.2.0
 [9.1.6]: https://github.com/infinum/eightshift-forms/compare/9.1.5...9.1.6

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.3.0
+ * Version: 9.4.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.3.0",
+	"version": "9.4.0",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Helpers/SettingsHelpers.php
+++ b/src/Helpers/SettingsHelpers.php
@@ -34,6 +34,19 @@ final class SettingsHelpers
 	}
 
 	/**
+	 * Get settings value.
+	 *
+	 * @param string $key Key to find in db settings.
+	 * @param string $formId Form Id.
+	 *
+	 * @return string
+	 */
+	public static function getSettingValueUnescaped(string $key, string $formId): string
+	{
+		return \html_entity_decode(self::getSettingValue($key, $formId), \ENT_QUOTES, 'UTF-8');
+	}
+
+	/**
 	 * Get option value string saved as json array - used for textarea with : delimiter.
 	 *
 	 * @param string $key Providing string to append to.
@@ -389,7 +402,7 @@ final class SettingsHelpers
 
 			$value = \array_filter(
 				$value,
-				fn ($item) => $item <= $useNumber - 1,
+				fn($item) => $item <= $useNumber - 1,
 				\ARRAY_FILTER_USE_KEY
 			);
 

--- a/src/Hooks/Filters.php
+++ b/src/Hooks/Filters.php
@@ -327,6 +327,7 @@ final class Filters
 			],
 			'validation' => [
 				'forceMimetypeFromFs',
+				'alternativeParamsSecurityCheck',
 			],
 			'encryption' => [
 				'secretKey',

--- a/src/Rest/Routes/AbstractIntegrationFormSubmit.php
+++ b/src/Rest/Routes/AbstractIntegrationFormSubmit.php
@@ -1367,8 +1367,19 @@ abstract class AbstractIntegrationFormSubmit extends AbstractBaseRoute
 	 */
 	private function secureApiParams(array $params): array
 	{
+		$alternativeParamsSecurityCheck = \apply_filters(HooksHelpers::getFilterName(['validation', 'alternativeParamsSecurityCheck']), []);
+
+		if (!empty($alternativeParamsSecurityCheck)) {
+			$alternativeParamsSecurityCheck = \array_map(
+				static function ($item) {
+					return SettingsHelpers::getSettingName($item);
+				},
+				$alternativeParamsSecurityCheck
+			);
+		}
+
 		return \array_map(
-			static function ($item) {
+			static function ($item) use ($alternativeParamsSecurityCheck) {
 				// Check if array then output only value that is not empty.
 				if (\is_array($item)) {
 					// Loop all items and decode.
@@ -1418,7 +1429,22 @@ abstract class AbstractIntegrationFormSubmit extends AbstractBaseRoute
 				// Try to clean the string.
 				// Parts of the code taken from https://developer.wordpress.org/reference/functions/_sanitize_text_fields/.
 				$item = \wp_check_invalid_utf8($item);
-				$item = \wp_strip_all_tags($item);
+
+				if ($alternativeParamsSecurityCheck) {
+					\preg_match('/"name":"([^"]+)"/', $item, $matches);
+
+					if (\in_array($matches[1] ?? null, $alternativeParamsSecurityCheck, true)) {
+						$item = \json_decode($item, true) ?? [];
+						if (isset($item['value']) && !empty($item['value']) && \is_string($item['value'])) {
+							$item['value'] = \esc_html($item['value']);
+						}
+						$item = \wp_json_encode($item);
+					} else {
+						$item = \wp_strip_all_tags($item);
+					}
+				} else {
+					$item = \wp_strip_all_tags($item);
+				}
 
 				$filtered = \trim($item);
 


### PR DESCRIPTION
# Description

### Added

- Added `alternativeParamsSecurityCheck` filter to the validation filter group. Allows specifying form field keys whose values should be sanitized with `esc_html` instead of `wp_strip_all_tags` during the API param security check in `secureApiParams()`.
- Added `SettingsHelpers::getSettingValueUnescaped()` helper that returns a settings value with HTML entities decoded via `html_entity_decode` (useful when a stored value needs to be output in a plain-text context).

### Fixed

- Fixed PHPCS violations: `html_entity_decode`, `ENT_QUOTES`, `apply_filters`, and `array_map` now referenced with fully-qualified names.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Linked documentation PR

<!-- If this PR has documentation please put the link here. -->