### PR TITLE
#191 - Forms and pricing accessibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.5.1]
+
+### Fixed
+
+- Added an accessible name to rendered forms so Safari / VoiceOver exposes them as landmarks.
+- Added live-region semantics for global form messages and alert semantics for notices so screen readers announce status changes.
+- Preserved accessible labels when fields use placeholder mode by keeping a visually hidden label in the DOM.
+- Added an accessible label to the phone country-code select so screen readers announce its purpose.
+
 ## [9.5.0]
 
 ### Added
@@ -1857,6 +1866,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.5.1]: https://github.com/infinum/eightshift-forms/compare/9.5.0...9.5.1
 [9.5.0]: https://github.com/infinum/eightshift-forms/compare/9.4.1...9.5.0
 [9.4.1]: https://github.com/infinum/eightshift-forms/compare/9.4.0...9.4.1
 [9.4.0]: https://github.com/infinum/eightshift-forms/compare/9.3.0...9.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.5.0",
+	"version": "9.5.1",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Blocks/components/field/field-frontend-mandatory.scss
+++ b/src/Blocks/components/field/field-frontend-mandatory.scss
@@ -25,4 +25,19 @@
 			inset-inline-end: 0;
 		}
 	}
+
+	&__label {
+		&--is-visually-hidden {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0 0 0 0);
+			clip-path: inset(50%);
+			white-space: nowrap;
+			border: 0;
+		}
+	}
 }

--- a/src/Blocks/components/field/field.php
+++ b/src/Blocks/components/field/field.php
@@ -35,6 +35,7 @@ $unique = Helpers::getUnique();
 
 $fieldLabel = Helpers::checkAttr('fieldLabel', $attributes, $manifest);
 $fieldHideLabel = Helpers::checkAttr('fieldHideLabel', $attributes, $manifest);
+$fieldHideLabelVisually = Helpers::checkAttr('fieldHideLabelVisually', $attributes, $manifest);
 $fieldId = Helpers::checkAttr('fieldId', $attributes, $manifest);
 $fieldName = Helpers::checkAttr('fieldName', $attributes, $manifest);
 $fieldBeforeContent = Helpers::checkAttr('fieldBeforeContent', $attributes, $manifest);
@@ -109,6 +110,12 @@ $labelInnerClass = Helpers::classnames([
 	FormsHelper::getTwPart($twClasses, 'field', 'label-inner', "{$componentClass}__label-inner"),
 	FormsHelper::getTwPart($twClasses, $selectorClass, 'field-label-inner'),
 ]);
+
+if ($fieldHideLabelVisually) {
+	$screenReaderOnlyStyle = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0, 0, 0, 0);white-space:nowrap;border:0;';
+	$existingLabelStyle = $fieldAttrsLabel['style'] ?? '';
+	$fieldAttrsLabel['style'] = trim("{$existingLabelStyle};{$screenReaderOnlyStyle}", ';');
+}
 
 $innerClass = Helpers::classnames([
 	FormsHelper::getTwPart($twClasses, 'field', 'inner', "{$componentClass}__inner"),
@@ -200,7 +207,7 @@ $additionalContent = GeneralHelpers::getBlockAdditionalContentViaFilter('field',
 
 	?>
 	<div class="<?php echo esc_attr($innerClass); ?>">
-		<?php if ($fieldLabel && !$fieldHideLabel) { ?>
+		<?php if ($fieldLabel && (!$fieldHideLabel || $fieldHideLabelVisually)) { ?>
 			<<?php echo esc_attr($labelTag); ?>
 				class="<?php echo esc_attr($labelClass); ?>"
 				<?php

--- a/src/Blocks/components/field/field.php
+++ b/src/Blocks/components/field/field.php
@@ -104,18 +104,13 @@ $labelClass = Helpers::classnames([
 	FormsHelper::getTwPart($twClasses, 'field', 'label', "{$componentClass}__label"),
 	FormsHelper::getTwPart($twClasses, $selectorClass, 'field-label'),
 	Helpers::selector($fieldIsRequired && $componentClass, $componentClass, 'label', 'is-required'),
+	Helpers::selector($fieldHideLabelVisually && $componentClass, $componentClass, 'label', 'is-visually-hidden'),
 ]);
 
 $labelInnerClass = Helpers::classnames([
 	FormsHelper::getTwPart($twClasses, 'field', 'label-inner', "{$componentClass}__label-inner"),
 	FormsHelper::getTwPart($twClasses, $selectorClass, 'field-label-inner'),
 ]);
-
-if ($fieldHideLabelVisually) {
-	$screenReaderOnlyStyle = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0, 0, 0, 0);white-space:nowrap;border:0;';
-	$existingLabelStyle = $fieldAttrsLabel['style'] ?? '';
-	$fieldAttrsLabel['style'] = trim("{$existingLabelStyle};{$screenReaderOnlyStyle}", ';');
-}
 
 $innerClass = Helpers::classnames([
 	FormsHelper::getTwPart($twClasses, 'field', 'inner', "{$componentClass}__inner"),

--- a/src/Blocks/components/field/manifest.json
+++ b/src/Blocks/components/field/manifest.json
@@ -49,6 +49,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"fieldHideLabelVisually": {
+			"type": "boolean",
+			"default": false
+		},
 		"fieldHidden": {
 			"type": "boolean",
 			"default": false

--- a/src/Blocks/components/form/form.php
+++ b/src/Blocks/components/form/form.php
@@ -135,6 +135,11 @@ if ($formMethod) {
 $formAttrs[UtilsHelper::getStateAttribute('blockSsr')] = wp_json_encode($blockSsr);
 $formAttrs[UtilsHelper::getStateAttribute('disabledDefaultStyles')] = wp_json_encode($formDisabledDefaultStyles);
 
+// A11y: Provide an accessible name so Safari/VoiceOver exposes <form> as a landmark (WCAG 1.3.1, 4.1.2).
+if ($formPostId) {
+	$formAttrs['aria-label'] = esc_attr(get_the_title((int) $formPostId));
+}
+
 ?>
 
 <form

--- a/src/Blocks/components/global-msg/global-msg.php
+++ b/src/Blocks/components/global-msg/global-msg.php
@@ -49,6 +49,8 @@ if (has_filter($filterName) && !is_admin()) {
 
 <div
 	class="<?php echo esc_attr($globalMsgClass); ?>"
+	role="status"
+	aria-live="polite"
 	<?php echo Helpers::getAttrsOutput($globalMsgAttrs); // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped 
 	?>>
 	<?php echo esc_html($globalMsgValue); ?>

--- a/src/Blocks/components/input/input.php
+++ b/src/Blocks/components/input/input.php
@@ -186,6 +186,10 @@ if ($inputHideLabel || $inputType === 'hidden') {
 	$fieldOutput['fieldHideLabel'] = true;
 }
 
+if ($inputHideLabel) {
+	$fieldOutput['fieldHideLabelVisually'] = true;
+}
+
 echo Helpers::render(
 	'field',
 	array_merge(

--- a/src/Blocks/components/notice/notice.php
+++ b/src/Blocks/components/notice/notice.php
@@ -23,7 +23,7 @@ $noticeClass = Helpers::classnames([
 
 ?>
 
-<div class="<?php echo esc_attr($noticeClass); ?>">
+<div class="<?php echo esc_attr($noticeClass); ?>" role="alert">
 	<span class="<?php echo esc_attr("{$componentClass}__icon"); ?>">
 		<?php echo UtilsHelper::getUtilsIcons('warning'); // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped 
 		?>

--- a/src/Blocks/components/phone/phone.php
+++ b/src/Blocks/components/phone/phone.php
@@ -178,6 +178,7 @@ $fieldOutput = [
 // Hide label if needed but separated like this so we can utilize normal fieldHideLabel attribute from field component.
 if ($phoneHideLabel) {
 	$fieldOutput['fieldHideLabel'] = true;
+	$fieldOutput['fieldHideLabelVisually'] = true;
 }
 
 echo Helpers::render(

--- a/src/Blocks/components/phone/phone.php
+++ b/src/Blocks/components/phone/phone.php
@@ -142,6 +142,7 @@ $phone = '
 	<select
 		class="' . esc_attr($phoneSelectClass) . '"
 		name="' . esc_attr($phoneName) . '"
+		aria-label="' . esc_attr__('Country code', 'eightshift-forms') . '"
 		' . Helpers::getAttrsOutput($phoneAttrsSelect) . '
 	>' . implode('', $options) . '</select>
 	<input

--- a/src/Blocks/components/select/select.php
+++ b/src/Blocks/components/select/select.php
@@ -130,6 +130,7 @@ $fieldOutput = [
 // Hide label if needed but separated like this so we can utilize normal fieldHideLabel attribute from field component.
 if ($selectHideLabel) {
 	$fieldOutput['fieldHideLabel'] = true;
+	$fieldOutput['fieldHideLabelVisually'] = true;
 }
 
 echo Helpers::render(

--- a/src/Blocks/components/textarea/textarea.php
+++ b/src/Blocks/components/textarea/textarea.php
@@ -118,6 +118,7 @@ $fieldOutput = [
 // Hide label if needed but separated like this so we can utilize normal fieldHideLabel attribute from field component.
 if ($textareaHideLabel) {
 	$fieldOutput['fieldHideLabel'] = true;
+	$fieldOutput['fieldHideLabelVisually'] = true;
 }
 
 echo Helpers::render(


### PR DESCRIPTION
# Description

- Added an accessible name to rendered forms so Safari / VoiceOver exposes them as landmarks.
- Added live-region semantics for global form messages and alert semantics for notices so screen readers announce status changes.
- Preserved accessible labels when fields use placeholder mode by keeping a visually hidden label in the DOM.
- Added an accessible label to the phone country-code select so screen readers announce its purpose.
- Addresses the Eightshift Forms plugin-level accessibility issues identified in Infobip a11y review issue #191.

# How to test

> QA note: no CLI/SSH/database access needed.

1. Create or edit a page that contains an Eightshift Forms form with:
   - a standard input field
   - a field using placeholder-as-label mode
   - a phone field
   - validation/global notice output enabled
2. Open the page in Safari with VoiceOver turned on.
3. Navigate by landmarks and confirm the form is announced as a form landmark.
4. Trigger a validation or submit message and confirm the global message / notice is announced without manually navigating to it.
5. Focus the placeholder-mode field and confirm VoiceOver still announces the field label even though the visible label is hidden.
6. Focus the phone country-code select and confirm VoiceOver announces meaningful context for the control.

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->

# Related ticket / issue

https://github.com/infobipcth/a11y-review/issues/191