### PR TITLE
feature/wpml-translation-support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.5.2]
+
+### Added
+
+- Added a `wpml-config.xml` so WPML's Advanced Translation Editor can translate Gutenberg form field strings (labels, help, placeholders, button text, step labels) without duplicating forms per language.
+
+### Changed
+
+- Updated the submit button so its default "Submit" label is provided as a translatable PHP fallback instead of a hardcoded manifest default.
+- Updated the form `method` attribute default to uppercase `POST`.
+
+### Fixed
+
+- Fixed an incorrect `uploadFile()` return-type annotation in `UploadHelpers` that triggered PHPStan errors.
+
 ## [9.5.1]
 
 ### Fixed
@@ -1866,6 +1881,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.5.2]: https://github.com/infinum/eightshift-forms/compare/9.5.1...9.5.2
 [9.5.1]: https://github.com/infinum/eightshift-forms/compare/9.5.0...9.5.1
 [9.5.0]: https://github.com/infinum/eightshift-forms/compare/9.4.1...9.5.0
 [9.4.1]: https://github.com/infinum/eightshift-forms/compare/9.4.0...9.4.1

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.5.0
+ * Version: 9.5.2
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.5.1",
+	"version": "9.5.2",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Blocks/components/form/manifest.json
+++ b/src/Blocks/components/form/manifest.json
@@ -39,7 +39,7 @@
 		},
 		"formMethod": {
 			"type": "string",
-			"default": "post"
+			"default": "POST"
 		},
 		"formId": {
 			"type": "string"

--- a/src/Blocks/components/submit/manifest.json
+++ b/src/Blocks/components/submit/manifest.json
@@ -21,8 +21,7 @@
 			"type": "string"
 		},
 		"submitValue": {
-			"type": "string",
-			"default": "Submit"
+			"type": "string"
 		},
 		"submitIsDisabled": {
 			"type": "boolean",

--- a/src/Blocks/components/submit/submit.php
+++ b/src/Blocks/components/submit/submit.php
@@ -46,6 +46,10 @@ if ($submitIcon) {
 	$submitIconContent = $submitIcon;
 }
 
+if ($submitValue === '') {
+	$submitValue = __('Submit', 'eightshift-forms');
+}
+
 $button = '
 	<button
 		class="' . esc_attr($submitClass) . '"

--- a/src/Helpers/UploadHelpers.php
+++ b/src/Helpers/UploadHelpers.php
@@ -56,7 +56,7 @@ final class UploadHelpers
 	 * @param array<string, array<int, string>> $extraAllowedMimes Optional `extension => [mime, ...]` supplement for the belt-and-braces security scan
 	 *                                                            (mirror of what the caller passed to the up-front Validator scan).
 	 *
-	 * @return array<string, array<int, array<string, mixed>>>
+	 * @return array<string, mixed>
 	 */
 	public static function uploadFile(array $file, array $extraAllowedMimes = []): array
 	{

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,173 @@
+<wpml-config>
+	<!--
+		WPML translatable Gutenberg block attributes for Eightshift Forms.
+
+		Lets WPML's Advanced Translation Editor (ATE) show form field strings
+		side by side instead of duplicating forms per language.
+
+		Attribute names are double-prefixed (blockName + componentName), e.g.
+		"inputInputFieldLabel" - this is how Eightshift's props() serializes them.
+
+		Only display strings are registered (labels, help, placeholders,
+		before/after/suffix content, button text, step labels).
+		Submission keys and identifiers (*Value, *Name, *Id, *Tracking, *Type)
+		are intentionally NOT translated - translating them breaks form
+		submissions and conditional tags.
+	-->
+	<gutenberg-blocks>
+
+		<!-- input -->
+		<gutenberg-block type="eightshift-forms/input" translate="1">
+			<key name="inputInputFieldLabel" />
+			<key name="inputInputFieldHelp" />
+			<key name="inputInputFieldBeforeContent" />
+			<key name="inputInputFieldAfterContent" />
+			<key name="inputInputFieldSuffixContent" />
+			<key name="inputInputPlaceholder" />
+			<key name="inputInputRangeShowMinPrefix" />
+			<key name="inputInputRangeShowMinSuffix" />
+			<key name="inputInputRangeShowMaxPrefix" />
+			<key name="inputInputRangeShowMaxSuffix" />
+			<key name="inputInputRangeShowCurrentPrefix" />
+			<key name="inputInputRangeShowCurrentSuffix" />
+		</gutenberg-block>
+
+		<!-- textarea -->
+		<gutenberg-block type="eightshift-forms/textarea" translate="1">
+			<key name="textareaTextareaFieldLabel" />
+			<key name="textareaTextareaFieldHelp" />
+			<key name="textareaTextareaFieldBeforeContent" />
+			<key name="textareaTextareaFieldAfterContent" />
+			<key name="textareaTextareaFieldSuffixContent" />
+			<key name="textareaTextareaPlaceholder" />
+		</gutenberg-block>
+
+		<!-- select -->
+		<gutenberg-block type="eightshift-forms/select" translate="1">
+			<key name="selectSelectFieldLabel" />
+			<key name="selectSelectFieldHelp" />
+			<key name="selectSelectFieldBeforeContent" />
+			<key name="selectSelectFieldAfterContent" />
+			<key name="selectSelectFieldSuffixContent" />
+			<key name="selectSelectPlaceholder" />
+		</gutenberg-block>
+
+		<!-- select-option -->
+		<gutenberg-block type="eightshift-forms/select-option" translate="1">
+			<key name="selectOptionSelectOptionLabel" />
+		</gutenberg-block>
+
+		<!-- checkbox -->
+		<gutenberg-block type="eightshift-forms/checkbox" translate="1">
+			<key name="checkboxCheckboxLabel" />
+			<key name="checkboxCheckboxHelp" />
+		</gutenberg-block>
+
+		<!-- checkboxes -->
+		<gutenberg-block type="eightshift-forms/checkboxes" translate="1">
+			<key name="checkboxesCheckboxesFieldLabel" />
+			<key name="checkboxesCheckboxesFieldHelp" />
+			<key name="checkboxesCheckboxesFieldBeforeContent" />
+			<key name="checkboxesCheckboxesFieldAfterContent" />
+			<key name="checkboxesCheckboxesFieldSuffixContent" />
+			<key name="checkboxesCheckboxesPlaceholder" />
+		</gutenberg-block>
+
+		<!-- radio -->
+		<gutenberg-block type="eightshift-forms/radio" translate="1">
+			<key name="radioRadioLabel" />
+		</gutenberg-block>
+
+		<!-- radios -->
+		<gutenberg-block type="eightshift-forms/radios" translate="1">
+			<key name="radiosRadiosFieldLabel" />
+			<key name="radiosRadiosFieldHelp" />
+			<key name="radiosRadiosFieldBeforeContent" />
+			<key name="radiosRadiosFieldAfterContent" />
+			<key name="radiosRadiosFieldSuffixContent" />
+			<key name="radiosRadiosPlaceholder" />
+		</gutenberg-block>
+
+		<!-- date -->
+		<gutenberg-block type="eightshift-forms/date" translate="1">
+			<key name="dateDateFieldLabel" />
+			<key name="dateDateFieldHelp" />
+			<key name="dateDateFieldBeforeContent" />
+			<key name="dateDateFieldAfterContent" />
+			<key name="dateDateFieldSuffixContent" />
+			<key name="dateDatePlaceholder" />
+		</gutenberg-block>
+
+		<!-- phone -->
+		<gutenberg-block type="eightshift-forms/phone" translate="1">
+			<key name="phonePhoneFieldLabel" />
+			<key name="phonePhoneFieldHelp" />
+			<key name="phonePhoneFieldBeforeContent" />
+			<key name="phonePhoneFieldAfterContent" />
+			<key name="phonePhoneFieldSuffixContent" />
+			<key name="phonePhonePlaceholder" />
+		</gutenberg-block>
+
+		<!-- country -->
+		<gutenberg-block type="eightshift-forms/country" translate="1">
+			<key name="countryCountryFieldLabel" />
+			<key name="countryCountryFieldHelp" />
+			<key name="countryCountryFieldBeforeContent" />
+			<key name="countryCountryFieldAfterContent" />
+			<key name="countryCountryFieldSuffixContent" />
+			<key name="countryCountryPlaceholder" />
+		</gutenberg-block>
+
+		<!-- file -->
+		<gutenberg-block type="eightshift-forms/file" translate="1">
+			<key name="fileFileFieldLabel" />
+			<key name="fileFileFieldHelp" />
+			<key name="fileFileFieldBeforeContent" />
+			<key name="fileFileFieldAfterContent" />
+			<key name="fileFileFieldSuffixContent" />
+			<key name="fileFileCustomInfoText" />
+			<key name="fileFileCustomInfoButtonText" />
+		</gutenberg-block>
+
+		<!-- rating -->
+		<gutenberg-block type="eightshift-forms/rating" translate="1">
+			<key name="ratingRatingFieldLabel" />
+			<key name="ratingRatingFieldHelp" />
+			<key name="ratingRatingFieldBeforeContent" />
+			<key name="ratingRatingFieldAfterContent" />
+			<key name="ratingRatingFieldSuffixContent" />
+		</gutenberg-block>
+
+		<!-- submit -->
+		<gutenberg-block type="eightshift-forms/submit" translate="1">
+			<key name="submitSubmitValue" />
+		</gutenberg-block>
+
+		<!-- step -->
+		<gutenberg-block type="eightshift-forms/step" translate="1">
+			<key name="stepStepLabel" />
+			<key name="stepStepContent" />
+			<key name="stepStepPrevLabel" />
+			<key name="stepStepNextLabel" />
+		</gutenberg-block>
+
+		<!-- field -->
+		<gutenberg-block type="eightshift-forms/field" translate="1">
+			<key name="fieldFieldLabel" />
+			<key name="fieldFieldHelp" />
+			<key name="fieldFieldContent" />
+			<key name="fieldFieldBeforeContent" />
+			<key name="fieldFieldAfterContent" />
+			<key name="fieldFieldSuffixContent" />
+		</gutenberg-block>
+
+		<!-- dynamic -->
+		<gutenberg-block type="eightshift-forms/dynamic" translate="1">
+			<key name="dynamicDynamicCustomLabel" />
+		</gutenberg-block>
+
+		<!-- forms: nothing translatable (only post IDs / config) -->
+		<!-- form-selector: no attributes -->
+
+	</gutenberg-blocks>
+</wpml-config>


### PR DESCRIPTION
# Description

### Added

- Added a `wpml-config.xml` registering translatable Gutenberg block attributes (labels, help, placeholders, before/after/suffix content, button text, step labels) so WPML's Advanced Translation Editor can translate form strings side by side instead of duplicating forms per language. Submission keys and identifiers (`*Value`, `*Name`, `*Id`, `*Tracking`, `*Type`) are intentionally excluded to avoid breaking submissions and conditional tags.

### Changed

- Updated the submit button so its default "Submit" label is now a translatable PHP fallback (`__('Submit', 'eightshift-forms')`) instead of a hardcoded manifest default, allowing the value to be translated and left empty in the editor.
- Updated the `form` block `method` attribute default to uppercase `POST`.

### Fixed

- Fixed an incorrect `uploadFile()` return-type annotation in `UploadHelpers` that produced PHPStan errors.

## QA Guide

Steps for QA to test this feature:
1. On a WPML multilingual site, edit a page with an Eightshift form and open the Advanced Translation Editor for a secondary language.
2. Confirm field labels, help text, placeholders, submit button text and step labels appear as translatable strings, while value/name/ID fields do not.
3. Add a submit button without entering a custom label and view the form on the front end.
4. Confirm the button renders the localized "Submit" label.

**Expected result:** Form display strings are translatable through WPML ATE; the submit button falls back to a translatable "Submit" label when left empty.

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
