### PR TITLE
feature/pardot-visitor-cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.9.1]
+
+### Added
+
+- Added forwarding of the Pardot visitor tracking cookie (`visitor_id{accountId}`) with form handler submissions, so submissions are linked to the prospect's activity history and campaign.
+
+### Fixed
+
+- Fixed Pardot OAuth refresh token being overwritten with an empty value on token refresh — Salesforce doesn't rotate refresh tokens, so the stored one is now kept when the response omits it.
+
 ## [9.9.0]
 
 ### Added
@@ -1944,6 +1954,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.9.1]: https://github.com/infinum/eightshift-forms/compare/9.9.0...9.9.1
 [9.9.0]: https://github.com/infinum/eightshift-forms/compare/9.8.0...9.9.0
 [9.8.0]: https://github.com/infinum/eightshift-forms/compare/9.7.1...9.8.0
 [9.7.1]: https://github.com/infinum/eightshift-forms/compare/9.7.0...9.7.1

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.9.0
+ * Version: 9.9.1
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.9.0",
+	"version": "9.9.1",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Integrations/Pardot/OauthPardot.php
+++ b/src/Integrations/Pardot/OauthPardot.php
@@ -196,7 +196,11 @@ class OauthPardot extends AbstractOauth
 
 		if (ApiHelpers::isSuccessResponse($code)) {
 			\update_option(SettingsHelpers::getSettingName(OauthPardot::OAUTH_PARDOT_ACCESS_TOKEN_KEY), $body['access_token']);
-			\update_option(SettingsHelpers::getSettingName(OauthPardot::OAUTH_PARDOT_REFRESH_TOKEN_KEY), $body['refresh_token']);
+
+			// Salesforce doesn't rotate refresh tokens - the refresh_token grant response omits it, so keep the stored one.
+			if (!empty($body['refresh_token'])) {
+				\update_option(SettingsHelpers::getSettingName(OauthPardot::OAUTH_PARDOT_REFRESH_TOKEN_KEY), $body['refresh_token']);
+			}
 
 			return true;
 		}

--- a/src/Integrations/Pardot/PardotClient.php
+++ b/src/Integrations/Pardot/PardotClient.php
@@ -200,12 +200,19 @@ class PardotClient implements PardotClientInterface
 
 		$body = $this->prepareParams($params, $mapParams);
 
+		$headers = [
+			'Content-Type' => 'application/x-www-form-urlencoded',
+		];
+
+		$visitorCookieHeader = $this->getVisitorCookieHeader($url);
+		if ($visitorCookieHeader) {
+			$headers['Cookie'] = $visitorCookieHeader;
+		}
+
 		$response = \wp_remote_post(
 			$url,
 			[
-				'headers' => [
-					'Content-Type' => 'application/x-www-form-urlencoded',
-				],
+				'headers' => $headers,
 				'body' => $body,
 				'redirection' => 0,
 			]
@@ -418,6 +425,40 @@ class PardotClient implements PardotClientInterface
 		\preg_match('/action=["\']([^"\']+)["\']/', $embedCode, $matches);
 
 		return $matches[1] ?? '';
+	}
+
+	/**
+	 * Get Pardot visitor tracking cookie header to forward with the form handler POST.
+	 *
+	 * The visitor_id{accountId} cookie is set first-party on the site by the Pardot tracking
+	 * script (pd.js). Forwarding it links the submission to the prospect's activity history
+	 * and campaign, matching the behavior of a native browser POST.
+	 *
+	 * @param string $url Form handler submit URL.
+	 *
+	 * @return string
+	 */
+	private function getVisitorCookieHeader(string $url): string
+	{
+		if (!\preg_match('~/l/(\d+)/~', $url, $matches)) {
+			return '';
+		}
+
+		$accountId = $matches[1];
+
+		$output = [];
+
+		foreach (["visitor_id{$accountId}", "visitor_id{$accountId}-hash"] as $name) {
+			$value = isset($_COOKIE[$name]) ? \sanitize_text_field(\wp_unslash($_COOKIE[$name])) : ''; // phpcs:ignore
+
+			if (!$value || \preg_match('/[^A-Za-z0-9._%-]/', $value)) {
+				continue;
+			}
+
+			$output[] = "{$name}={$value}";
+		}
+
+		return \implode('; ', $output);
 	}
 
 	/**


### PR DESCRIPTION
# Description

### Added

- Added forwarding of the Pardot visitor tracking cookie (`visitor_id{accountId}` and its `-hash` counterpart) with the form handler POST, so submissions are linked to the prospect's activity history and campaign — matching the behavior of a native browser POST. The account ID is parsed from the form handler URL, and cookie values are sanitized and validated before being forwarded.

### Fixed

- Fixed Pardot OAuth refresh token being overwritten with an empty value on token refresh. Salesforce doesn't rotate refresh tokens — the `refresh_token` grant response omits it — so the stored token is now kept when the response doesn't include a new one.

## QA Guide

Steps for QA to test this feature:
1. Connect the Pardot integration via OAuth and confirm forms submit successfully.
2. Visit the site in a browser where the Pardot tracking script (pd.js) has set the `visitor_id{accountId}` cookie, then submit a Pardot form.
3. In Pardot, open the prospect record and verify the submission is linked to the visitor's activity history and campaign.
4. Wait for (or force) an access token refresh, then submit the form again to confirm the integration still works — the refresh token must not be lost.

**Expected result:** Form submissions succeed, prospects are linked to their tracked visitor activity in Pardot, and the OAuth connection stays valid after token refreshes.

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)