### PR TITLE
feature/connected-forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.10.0]
+
+### Added
+
+- Added a Connected form feature — a new "Connected" tab in the form's general settings where you can select another form and map its fields; after a successful submission, the connected form's fields are auto-populated with the submitted values.
+- Added `connectedFormId` and `connectedFormMap` response output keys sent with integration form submissions.
+- Added `esFormsBeforeEnrichmentConnectedFormFill` and `esFormsAfterEnrichmentConnectedFormFill` JS events dispatched around the connected form fill.
+- Added a `setManualValuesByFieldType` utility (also exposed on the public JS API) that sets a field's value based on its type, replacing the repeated per-type switch statements.
+
+### Changed
+
+- Updated general settings tab labels: "After form submission" is now "Redirect" and "Single submit" is now "Auto-submit".
+- Updated conditional tags, enrichment, and form reset logic to set field values through the new `setManualValuesByFieldType` utility.
+
 ## [9.9.1]
 
 ### Added
@@ -1954,6 +1968,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.10.0]: https://github.com/infinum/eightshift-forms/compare/9.9.1...9.10.0
 [9.9.1]: https://github.com/infinum/eightshift-forms/compare/9.9.0...9.9.1
 [9.9.0]: https://github.com/infinum/eightshift-forms/compare/9.8.0...9.9.0
 [9.8.0]: https://github.com/infinum/eightshift-forms/compare/9.7.1...9.8.0

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.9.1
+ * Version: 9.10.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.9.1",
+	"version": "9.10.0",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Blocks/components/form/assets/conditional-tags.js
+++ b/src/Blocks/components/form/assets/conditional-tags.js
@@ -923,36 +923,20 @@ export class ConditionalTags {
 	 * @returns {void}
 	 */
 	removeActiveFieldsOnHideItem(formId, name) {
+		let value = '';
+
 		switch (this.state.getStateElementTypeField(name, formId)) {
-			case 'range':
-				this.utils.setManualRangeValue(formId, name, '', false);
-				break;
-			case 'rating':
-				this.utils.setManualRatingValue(formId, name, '', false);
-				break;
-			case 'radio':
-				this.utils.setManualRadioValue(formId, name, '', false);
-				break;
 			case 'checkbox':
-				this.utils.setManualCheckboxValue(formId, name, {}, false);
+			case 'phone':
+				value = {};
 				break;
 			case 'select':
-				this.utils.setManualSelectValue(formId, name, [], false);
-				break;
 			case 'country':
-				this.utils.setManualCountryValue(formId, name, [], false);
-				break;
-			case 'phone':
-				this.utils.setManualPhoneValue(formId, name, {}, false);
-				break;
-			case 'date':
-			case 'dateTime':
-				this.utils.setManualDateValue(formId, name, '', false);
-				break;
-			default:
-				this.utils.setManualInputValue(formId, name, '', false);
+				value = [];
 				break;
 		}
+
+		this.utils.setManualValuesByFieldType(formId, name, value, false);
 	}
 
 	////////////////////////////////////////////////////////////////

--- a/src/Blocks/components/form/assets/enrichment.js
+++ b/src/Blocks/components/form/assets/enrichment.js
@@ -376,11 +376,7 @@ export class Enrichment {
 						value: phoneValue[0],
 					};
 
-					this.utils.setManualPhoneValue(formId, name, newPhoneValue);
-					break;
-				case 'date':
-				case 'dateTime':
-					this.utils.setManualDateValue(formId, name, value);
+					this.utils.setManualValuesByFieldType(formId, name, newPhoneValue);
 					break;
 				case 'select':
 					const selectValue = value.split('---');
@@ -389,7 +385,7 @@ export class Enrichment {
 						break;
 					}
 
-					this.utils.setManualSelectValue(formId, name, selectValue);
+					this.utils.setManualValuesByFieldType(formId, name, selectValue);
 					break;
 				case 'country':
 					const countryValue = value.split('---');
@@ -398,7 +394,7 @@ export class Enrichment {
 						break;
 					}
 
-					this.utils.setManualCountryValue(formId, name, countryValue);
+					this.utils.setManualValuesByFieldType(formId, name, countryValue);
 					break;
 				case 'checkbox':
 					const checkboxValue = value.split('---');
@@ -407,19 +403,10 @@ export class Enrichment {
 						break;
 					}
 
-					this.utils.setManualCheckboxValue(formId, name, checkboxValue);
-					break;
-				case 'radio':
-					this.utils.setManualRadioValue(formId, name, value);
-					break;
-				case 'rating':
-					this.utils.setManualRatingValue(formId, name, value);
-					break;
-				case 'range':
-					this.utils.setManualRangeValue(formId, name, value);
+					this.utils.setManualValuesByFieldType(formId, name, checkboxValue);
 					break;
 				default:
-					this.utils.setManualInputValue(formId, name, value);
+					this.utils.setManualValuesByFieldType(formId, name, value);
 					break;
 			}
 		});
@@ -443,39 +430,46 @@ export class Enrichment {
 				return;
 			}
 
-			switch (this.state.getStateElementTypeField(name, formId)) {
-				case 'phone':
-					this.utils.setManualPhoneValue(formId, name, value);
-					break;
-				case 'date':
-				case 'dateTime':
-					this.utils.setManualDateValue(formId, name, value);
-					break;
-				case 'select':
-					this.utils.setManualSelectValue(formId, name, value);
-					break;
-				case 'country':
-					this.utils.setManualCountryValue(formId, name, value);
-					break;
-				case 'checkbox':
-					this.utils.setManualCheckboxValue(formId, name, value);
-					break;
-				case 'radio':
-					this.utils.setManualRadioValue(formId, name, value);
-					break;
-				case 'rating':
-					this.utils.setManualRatingValue(formId, name, value);
-					break;
-				case 'range':
-					this.utils.setManualRangeValue(formId, name, value);
-					break;
-				default:
-					this.utils.setManualInputValue(formId, name, value);
-					break;
-			}
+			this.utils.setManualValuesByFieldType(formId, name, value);
 		});
 
 		this.utils.dispatchFormEventForm(this.state.getStateEvent('afterEnrichmentLocalstoragePrefill'), formId, data);
+	}
+
+	/**
+	 * Populate connected form fields with data from API response.
+	 *
+	 * @param {string} form1Id Form 1 ID.
+	 * @param {string} form2RealId Form 2 Real ID.
+	 * @param {object} data Map data.
+	 * @param {object} variationData Variation data.
+	 *
+	 * @returns {void}
+	 */
+	populateConnectedForm(form1Id, form2RealId, data, variationData) {
+		const form2 = document.querySelector(`${this.state.getStateSelector('form', true)}[${this.state.getStateAttribute('formFid')}="${form2RealId}"]`);
+
+		if (!form2) {
+			return;
+		}
+
+		const form2Id = this.state.getFormId(form2);
+
+		this.utils.dispatchFormEventForm(this.state.getStateEvent('beforeEnrichmentConnectedFormFill'), form1Id, data);
+
+		if (data) {
+			Object.entries(data).forEach(([form1FieldName, form2FieldName]) => {
+				this.utils.setManualValuesByFieldType(form2Id, form2FieldName, this.state.getStateElementValue(form1FieldName, form1Id));
+			});
+		}
+
+		if (variationData) {
+			Object.entries(variationData).forEach(([variationName, variationValue]) => {
+				this.utils.setManualValuesByFieldType(form2Id, variationName, variationValue);
+			});
+		}
+
+		this.utils.dispatchFormEventForm(this.state.getStateEvent('afterEnrichmentConnectedFormFill'), form1Id, data);
 	}
 
 	////////////////////////////////////////////////////////////////

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -159,8 +159,7 @@ export class Form {
 
 			// Remove loading class from forms element.
 			formsElement?.classList?.remove(this.state.getStateSelector('isGeoLoading'));
-
-		} catch ({name, message}) {
+		} catch ({ name, message }) {
 			if (name === 'AbortError') {
 				return;
 			}
@@ -343,7 +342,7 @@ export class Form {
 			this.CONTROLLER = null;
 
 			return parsedResponse;
-		} catch ({name, message}) {
+		} catch ({ name, message }) {
 			if (name === 'AbortError') {
 				return;
 			}
@@ -397,7 +396,7 @@ export class Form {
 			this.steps.formStepSubmit(formId, parsedResponse);
 			this.steps.formStepSubmitAfter(formId, parsedResponse);
 			this.state.setStateFormIsProcessing(false, formId);
-		} catch ({name, message}) {
+		} catch ({ name, message }) {
 			if (name === 'AbortError') {
 				return;
 			}
@@ -483,6 +482,15 @@ export class Form {
 				// Remove local storage for prefill.
 				if (this.state.getStateEnrichmentIsUsed()) {
 					this.enrichment.deleteLocalStorage(this.state.getStateEnrichmentFormPrefillStorageName(formId));
+				}
+
+				if (data?.[this.state.getStateResponseOutputKey('connectedFormId')]) {
+					this.enrichment.populateConnectedForm(
+						formId,
+						data?.[this.state.getStateResponseOutputKey('connectedFormId')],
+						data?.[this.state.getStateResponseOutputKey('connectedFormMap')],
+						data?.[this.state.getStateResponseOutputKey('variation')],
+					);
 				}
 
 				// Return to original first step.
@@ -633,7 +641,7 @@ export class Form {
 				if (response?.data?.[this.state.getStateResponseOutputKey('captchaRetry')] && retry === false) {
 					this.executeEnterpriseCaptcha(actionName, siteKey, formId, true, filter);
 				}
-			} catch ({name, message}) {
+			} catch ({ name, message }) {
 				if (name === 'AbortError') {
 					return;
 				}
@@ -683,7 +691,7 @@ export class Form {
 				if (response?.data?.[this.state.getStateResponseOutputKey('captchaRetry')] && retry === false) {
 					this.executeFreeCaptcha(actionName, siteKey, formId, true, filter);
 				}
-			} catch ({name, message}) {
+			} catch ({ name, message }) {
 				if (name === 'AbortError') {
 					return;
 				}
@@ -1042,13 +1050,16 @@ export class Form {
 	 * @returns {void}
 	 */
 	setFormDataStep(formId) {
-		this.utils.buildFormDataItems([
-			{
-				name: this.state.getStateParam('steps'),
-				value: this.state.getStateFormStepsItem(this.state.getStateFormStepsCurrent(formId), formId),
-				custom: this.state.getStateFormStepsCurrent(formId),
-			},
-		], this.FORM_DATA);
+		this.utils.buildFormDataItems(
+			[
+				{
+					name: this.state.getStateParam('steps'),
+					value: this.state.getStateFormStepsItem(this.state.getStateFormStepsCurrent(formId), formId),
+					custom: this.state.getStateFormStepsCurrent(formId),
+				},
+			],
+			this.FORM_DATA,
+		);
 	}
 
 	/**
@@ -1059,32 +1070,35 @@ export class Form {
 	 * @returns {void}
 	 */
 	setFormDataCommon(formId) {
-		this.utils.buildFormDataItems([
-			{
-				name: this.state.getStateParam('formId'),
-				value: this.state.getStateFormFid(formId),
-			},
-			{
-				name: this.state.getStateParam('postId'),
-				value: this.state.getStateFormPostId(formId),
-			},
-			{
-				name: this.state.getStateParam('type'),
-				value: this.state.getStateFormType(formId),
-			},
-			{
-				name: this.state.getStateParam('action'),
-				value: this.state.getStateFormAction(formId) ?? '',
-			},
-			{
-				name: this.state.getStateParam('actionExternal'),
-				value: this.state.getStateFormActionExternal(formId) ?? '',
-			},
-			{
-				name: this.state.getStateParam('secureData'),
-				value: this.state.getStateFormSecureData(formId) ?? '',
-			},
-		], this.FORM_DATA);
+		this.utils.buildFormDataItems(
+			[
+				{
+					name: this.state.getStateParam('formId'),
+					value: this.state.getStateFormFid(formId),
+				},
+				{
+					name: this.state.getStateParam('postId'),
+					value: this.state.getStateFormPostId(formId),
+				},
+				{
+					name: this.state.getStateParam('type'),
+					value: this.state.getStateFormType(formId),
+				},
+				{
+					name: this.state.getStateParam('action'),
+					value: this.state.getStateFormAction(formId) ?? '',
+				},
+				{
+					name: this.state.getStateParam('actionExternal'),
+					value: this.state.getStateFormActionExternal(formId) ?? '',
+				},
+				{
+					name: this.state.getStateParam('secureData'),
+					value: this.state.getStateFormSecureData(formId) ?? '',
+				},
+			],
+			this.FORM_DATA,
+		);
 	}
 
 	/**
@@ -1102,12 +1116,15 @@ export class Form {
 		const data = this.enrichment.getLocalStorage(this.state.getStateEnrichmentStorageName());
 
 		if (data) {
-			this.utils.buildFormDataItems([
-				{
-					name: this.state.getStateParam('storage'),
-					value: data,
-				},
-			], this.FORM_DATA);
+			this.utils.buildFormDataItems(
+				[
+					{
+						name: this.state.getStateParam('storage'),
+						value: data,
+					},
+				],
+				this.FORM_DATA,
+			);
 		}
 	}
 
@@ -1119,12 +1136,15 @@ export class Form {
 	 * @returns {void}
 	 */
 	setFormDataAdmin(formId) {
-		this.utils.buildFormDataItems([
-			{
-				name: this.state.getStateParam('settingsType'),
-				value: this.state.getStateFormTypeSettings(formId),
-			},
-		], this.FORM_DATA);
+		this.utils.buildFormDataItems(
+			[
+				{
+					name: this.state.getStateParam('settingsType'),
+					value: this.state.getStateFormTypeSettings(formId),
+				},
+			],
+			this.FORM_DATA,
+		);
 	}
 
 	/**
@@ -1168,12 +1188,15 @@ export class Form {
 	 * @returns {void}
 	 */
 	setFormDataCaptcha(data) {
-		this.utils.buildFormDataItems([
-			{
-				name: this.state.getStateParam('captcha'),
-				value: data,
-			},
-		], this.FORM_DATA);
+		this.utils.buildFormDataItems(
+			[
+				{
+					name: this.state.getStateParam('captcha'),
+					value: data,
+				},
+			],
+			this.FORM_DATA,
+		);
 	}
 
 	////////////////////////////////////////////////////////////////
@@ -1595,7 +1618,7 @@ export class Form {
 
 					button.focus();
 					this.utils.setOnFocus(button);
-				} catch ({name, message}) {
+				} catch ({ name, message }) {
 					file.previewTemplate.querySelector('.dz-error-message span').innerHTML = this.state.getStateSettingsFormServerErrorMsg();
 					button.focus();
 					this.utils.setOnFocus(button);
@@ -1621,7 +1644,7 @@ export class Form {
 
 					button.focus();
 					this.utils.setOnFocus(button);
-				} catch ({name, message}) {
+				} catch ({ name, message }) {
 					file.previewTemplate.querySelector('.dz-error-message span').innerHTML = this.state.getStateSettingsFormServerErrorMsg();
 					button.focus();
 					this.utils.setOnFocus(button);

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -624,39 +624,12 @@ export class Utils {
 
 		for (const [name] of this.state.getStateElements(formId)) {
 			const initial = this.state.getStateElementInitial(name, formId);
+			const type = this.state.getStateElementTypeField(name, formId);
 
-			switch (this.state.getStateElementTypeField(name, formId)) {
-				case 'phone':
-					this.setManualPhoneValue(formId, name, initial);
-					break;
-				case 'date':
-				case 'dateTime':
-					this.setManualDateValue(formId, name, initial);
-					break;
-				case 'country':
-					this.setManualCountryValue(formId, name, initial);
-					break;
-				case 'select':
-					this.setManualSelectValue(formId, name, initial);
-					break;
-				case 'checkbox':
-					this.setManualCheckboxValue(formId, name, initial);
-					break;
-				case 'radio':
-					this.setManualRadioValue(formId, name, initial);
-					break;
-				case 'rating':
-					this.setManualRatingValue(formId, name, initial);
-					break;
-				case 'range':
-					this.setManualRangeValue(formId, name, initial);
-					break;
-				case 'file':
-					this.state.getStateElementCustom(name, formId)?.removeAllFiles();
-					break;
-				default:
-					this.setManualInputValue(formId, name, initial);
-					break;
+			if (type === 'file') {
+				this.state.getStateElementCustom(name, formId)?.removeAllFiles();
+			} else {
+				this.setManualValuesByFieldType(formId, name, initial);
 			}
 		}
 
@@ -1460,6 +1433,48 @@ export class Utils {
 	}
 
 	/**
+	 * Set manual field values by field type
+	 *
+	 * @param {string} formId Form Id.
+	 * @param {string} name Field name.
+	 * @param {string} value Field value.
+	 *
+	 * @returns {void}
+	 */
+	setManualValuesByFieldType(formId, name, value, fullSet = true) {
+		switch (this.state.getStateElementTypeField(name, formId)) {
+			case 'phone':
+				this.setManualPhoneValue(formId, name, value, fullSet);
+				break;
+			case 'date':
+			case 'dateTime':
+				this.setManualDateValue(formId, name, value, fullSet);
+				break;
+			case 'country':
+				this.setManualCountryValue(formId, name, value, fullSet);
+				break;
+			case 'select':
+				this.setManualSelectValue(formId, name, value, fullSet);
+				break;
+			case 'checkbox':
+				this.setManualCheckboxValue(formId, name, value, fullSet);
+				break;
+			case 'radio':
+				this.setManualRadioValue(formId, name, value, fullSet);
+				break;
+			case 'rating':
+				this.setManualRatingValue(formId, name, value, fullSet);
+				break;
+			case 'range':
+				this.setManualRangeValue(formId, name, value, fullSet);
+				break;
+			default:
+				this.setManualInputValue(formId, name, value, fullSet);
+				break;
+		}
+	}
+
+	/**
 	 * Set output results.
 	 *
 	 * @param {string} formId Form Id.
@@ -1915,6 +1930,9 @@ export class Utils {
 			},
 			setRangeCurrentValue: (formId, name) => {
 				this.setRangeCurrentValue(formId, name);
+			},
+			setManualValuesByFieldType: (formId, name, value, fullSet = true) => {
+				this.setManualValuesByFieldType(formId, name, value, fullSet);
 			},
 			setResultsOutput: (formId, data) => {
 				this.setResultsOutput(formId, data);

--- a/src/Blocks/manifest.json
+++ b/src/Blocks/manifest.json
@@ -496,6 +496,8 @@
 			"afterEnrichmentUrlPrefill": "esFormsAfterEnrichmentUrlPrefill",
 			"beforeEnrichmentLocalstoragePrefill": "esFormsBeforeEnrichmentLocalstoragePrefill",
 			"afterEnrichmentLocalstoragePrefill": "esFormsAfterEnrichmentLocalstoragePrefill",
+			"beforeEnrichmentConnectedFormFill": "esFormsBeforeEnrichmentConnectedFormFill",
+			"afterEnrichmentConnectedFormFill": "esFormsAfterEnrichmentConnectedFormFill",
 			"onFieldChange": "esFormsOnFieldChange",
 			"afterResultsOutput": "esFormsAfterResultsOutput"
 		},
@@ -700,6 +702,8 @@
 			"hideFormOnSuccess": "hideFormOnSuccess",
 			"skipResetFormOnSuccess": "skipResetFormOnSuccess",
 			"variation": "variation",
+			"connectedFormId": "connectedFormId",
+			"connectedFormMap": "connectedFormMap",
 			"entry": "entry",
 			"formId": "formId",
 			"geoId": "geoId",

--- a/src/General/SettingsGeneral.php
+++ b/src/General/SettingsGeneral.php
@@ -19,6 +19,7 @@ use EightshiftForms\Hooks\FiltersOutputMock;
 use EightshiftForms\Config\Config;
 use EightshiftForms\Helpers\UtilsHelper;
 use EightshiftForms\I18n\I18n;
+use EightshiftForms\Listing\FormListingInterface;
 use EightshiftFormsVendor\EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -126,6 +127,33 @@ class SettingsGeneral implements SettingInterface, ServiceInterface
 	public const string SETTINGS_FORCE_LOCALE = 'force-locale';
 
 	/**
+	 * Connected form key.
+	 */
+	public const string SETTINGS_CONNECTED_FORM = 'connected-form';
+
+	/**
+	 * Connected form map key.
+	 */
+	public const string SETTINGS_CONNECTED_FORM_MAP = 'connected-form-map';
+
+	/**
+	 * Instance variable for listing data.
+	 *
+	 * @var FormListingInterface
+	 */
+	protected $formsListing;
+
+	/**
+	 * Create a new instance.
+	 *
+	 * @param FormListingInterface $formsListing Inject form listing data.
+	 */
+	public function __construct(FormListingInterface $formsListing)
+	{
+		$this->formsListing = $formsListing;
+	}
+
+	/**
 	 * Register all the hooks
 	 *
 	 * @return void
@@ -160,6 +188,8 @@ class SettingsGeneral implements SettingInterface, ServiceInterface
 		$trackingEventName = FiltersOutputMock::getTrackingEventNameFilterValue($formType, $formId);
 		$trackingAdditionalData = FiltersOutputMock::getTrackingAdditionalDataFilterValue($formType, $formId);
 
+		$connectedFormValue = SettingsHelpers::getSettingValue(self::SETTINGS_CONNECTED_FORM, $formId);
+
 		return [
 			SettingsOutputHelpers::getIntro(self::SETTINGS_TYPE_KEY),
 			[
@@ -167,7 +197,7 @@ class SettingsGeneral implements SettingInterface, ServiceInterface
 				'tabsContent' => [
 					[
 						'component' => 'tab',
-						'tabLabel' => \__('After form submission', 'eightshift-forms'),
+						'tabLabel' => \__('Redirect', 'eightshift-forms'),
 						'tabContent' => [
 							[
 								'component' => 'input',
@@ -405,7 +435,7 @@ class SettingsGeneral implements SettingInterface, ServiceInterface
 					],
 					[
 						'component' => 'tab',
-						'tabLabel' => \__('Single submit', 'eightshift-forms'),
+						'tabLabel' => \__('Auto-submit', 'eightshift-forms'),
 						'tabContent' => [
 							[
 								'component' => 'checkboxes',
@@ -511,6 +541,65 @@ class SettingsGeneral implements SettingInterface, ServiceInterface
 									],
 								],
 							],
+						],
+					],
+					[
+						'component' => 'tab',
+						'tabLabel' => \__('Connected', 'eightshift-forms'),
+						'tabContent' => [
+							[
+								'component' => 'select',
+								'selectName' => SettingsHelpers::getSettingName(self::SETTINGS_CONNECTED_FORM),
+								'selectId' => SettingsHelpers::getSettingName(self::SETTINGS_CONNECTED_FORM),
+								'selectSingleSubmit' => true,
+								'selectFieldLabel' => \__('Connected form', 'eightshift-forms'),
+								'selectFieldHelp' => \__('Select form you want to connect to this form.', 'eightshift-forms'),
+								'selectContent' => \array_map(static function ($item) use ($connectedFormValue) {
+									$id = $item['id'] ?? '';
+									$title = $item['title'] ?? '';
+
+									return [
+										'component' => 'select-option',
+										// translators: %s will be replaced by the form id.
+										'selectOptionLabel' => $title === '' ? \sprintf(\__('Form %s', 'eightshift-forms'), $id) : $title,
+										'selectOptionValue' => $id,
+										'selectOptionIsSelected' => $id === (int) $connectedFormValue,
+									];
+								}, $this->formsListing->getFormsList()['items'] ?? []),
+								'selectValue' => $connectedFormValue,
+							],
+							...($connectedFormValue) ? [
+								[
+									'component' => 'textarea',
+									'textareaFieldLabel' => \__('Connected fields', 'eightshift-forms'),
+									'textareaIsMonospace' => true,
+									'textareaSaveAsJson' => true,
+									'textareaName' => SettingsHelpers::getSettingName(self::SETTINGS_CONNECTED_FORM_MAP),
+									'textareaFieldHelp' => \sprintf(
+										// translators: %1$s will be replaced by current form fields, %2$s will be replaced by connected form fields.
+										\__('After a successful submission, this form will auto populate the fields in the connected form.<br />
+										<details class="is-filter-applied">
+											<summary>Available field names</summary>
+											<ul>
+												%1$s
+											</ul>
+											<br />
+											Tag missing? Make sure its field has a <b>Name</b> set!
+										</details>
+										<details class="is-filter-applied">
+											<summary>Available connected field names</summary>
+											<ul>
+												%2$s
+											</ul>
+											<br />
+											Tag missing? Make sure its field has a <b>Name</b> set!
+										</details>', 'eightshift-forms'),
+										SettingsOutputHelpers::getPartialFormFieldNames($formDetails[Config::FD_FIELD_NAMES], ''),
+										SettingsOutputHelpers::getPartialFormFieldNames(GeneralHelpers::getFormDetails($connectedFormValue)[Config::FD_FIELD_NAMES], '')
+									),
+									'textareaValue' => SettingsHelpers::getSettingValueAsJson(self::SETTINGS_CONNECTED_FORM_MAP, $formId, 2),
+								],
+							] : [],
 						],
 					],
 				]

--- a/src/Helpers/SettingsOutputHelpers.php
+++ b/src/Helpers/SettingsOutputHelpers.php
@@ -438,6 +438,9 @@ final class SettingsOutputHelpers
 				case '$':
 					$output[] = "<li><code>$" . $item . "</code></li>";
 					break;
+				case '':
+					$output[] = "<li><code>" . $item . "</code></li>";
+					break;
 				default:
 					$output[] = "<li><code>{" . $item . "}</code></li>";
 					break;

--- a/src/Rest/Routes/AbstractIntegrationFormSubmit.php
+++ b/src/Rest/Routes/AbstractIntegrationFormSubmit.php
@@ -589,6 +589,9 @@ abstract class AbstractIntegrationFormSubmit extends AbstractBaseRoute
 		// Update created entry with additional values.
 		$output = $this->setIntegrationResponseEntryUpdate($output, $formDetails);
 
+		// Set connected forms data.
+		$output = $this->setIntegrationResponseConnectedForms($output, $formDetails);
+
 		$finalOutput = [
 			'private' => $output['private'],
 			'public' => $output['public'],
@@ -978,6 +981,50 @@ abstract class AbstractIntegrationFormSubmit extends AbstractBaseRoute
 		}
 
 		$output['public'][UtilsHelper::getStateResponseOutputKey('variation')] = $variation;
+
+		return $output;
+	}
+
+	/**
+	 * Set integration response - connected forms.
+	 *
+	 * @param array<string, mixed> $output Output data.
+	 * @param array<string, mixed> $formDetails Data passed from the `getFormDetailsApi` function.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function setIntegrationResponseConnectedForms(array $output, array $formDetails): array
+	{
+		$formId = $formDetails[Config::FD_FORM_ID] ?? '';
+
+		$connectedFormId = SettingsHelpers::getSettingValue(SettingsGeneral::SETTINGS_CONNECTED_FORM, $formId);
+
+		if (!$connectedFormId) {
+			return $output;
+		}
+
+		$output['public'][UtilsHelper::getStateResponseOutputKey('connectedFormId')] = $connectedFormId;
+
+		$connectedFormMap = SettingsHelpers::getSettingValueGroup(SettingsGeneral::SETTINGS_CONNECTED_FORM_MAP, $formId);
+
+		if (!$connectedFormMap) {
+			return $output;
+		}
+
+		$connectedMap = [];
+
+		foreach ($connectedFormMap as $item) {
+			$form1 = $item[0] ?? '';
+			$form2 = $item[1] ?? '';
+
+			if (!$form1 || !$form2) {
+				continue;
+			}
+
+			$connectedMap[$item[0]] = $item[1];
+		}
+
+		$output['public'][UtilsHelper::getStateResponseOutputKey('connectedFormMap')] = $connectedMap;
 
 		return $output;
 	}


### PR DESCRIPTION
# Description

### Added

- Added a Connected form feature — a new **Connected** tab in the form's general settings where you can select another form and define a field mapping between the two.
- Added auto-population of the connected form's fields after a successful submission, including variation data.
- Added `connectedFormId` and `connectedFormMap` response output keys returned with integration form submissions.
- Added `esFormsBeforeEnrichmentConnectedFormFill` and `esFormsAfterEnrichmentConnectedFormFill` JS events dispatched around the connected form fill.
- Added a `setManualValuesByFieldType` utility (also exposed on the public JS API) that sets a field's value based on its type.

### Changed

- Updated general settings tab labels: **After form submission** is now **Redirect** and **Single submit** is now **Auto-submit**.
- Updated conditional tags, enrichment, and form reset logic to set field values through the new `setManualValuesByFieldType` utility instead of repeated per-type switch statements.

## QA Guide

Steps for QA to test this feature:
1. Create two forms on the same page (form A with an integration, form B as the connected target), giving fields on both forms a **Name**.
2. In form A's settings, open **General → Connected**, select form B as the connected form, and map form A field names to form B field names in the **Connected fields** textarea.
3. Submit form A successfully and observe form B on the same page.
4. Also verify existing behavior still works: conditional tags hiding/clearing fields, URL/localStorage enrichment prefill, and form reset after submission.

**Expected result:** After form A submits successfully, the mapped fields in form B are automatically populated with form A's submitted values. Field clearing on conditional-tag hide, enrichment prefill, and form reset all still set values correctly for every field type.

# Screenshots / Videos

<!-- Add screenshots or screen recordings showing the changes in action. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)