### PR TITLE
fix/country-field-null-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.10.1]
+
+### Fixed
+
+- Fixed a crash in the country field's select-options handling when `getStateElementCustom` returns no matching state element.
+
 ## [9.10.0]
 
 ### Added
@@ -1968,6 +1974,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.10.1]: https://github.com/infinum/eightshift-forms/compare/9.10.0...9.10.1
 [9.10.0]: https://github.com/infinum/eightshift-forms/compare/9.9.1...9.10.0
 [9.9.1]: https://github.com/infinum/eightshift-forms/compare/9.9.0...9.9.1
 [9.9.0]: https://github.com/infinum/eightshift-forms/compare/9.8.0...9.9.0

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.10.0
+ * Version: 9.10.1
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.10.0",
+	"version": "9.10.1",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -1706,13 +1706,13 @@ export class Utils {
 			return [];
 		}
 
-		const options = this.state.getStateElementCustom(name, formId).passedElement?.element?.selectedOptions;
+		const options = this.state.getStateElementCustom(name, formId)?.passedElement?.element?.selectedOptions;
 
 		if (!options.length) {
 			return [];
 		}
 
-		const type = this.state.getStateElementCustom(name, formId).passedElement?.element?.getAttribute(this.state.getStateAttribute('countryOutputType'));
+		const type = this.state.getStateElementCustom(name, formId)?.passedElement?.element?.getAttribute(this.state.getStateAttribute('countryOutputType'));
 
 		const output = [];
 


### PR DESCRIPTION
# Description

### Fixed

- Fixed a crash in the country field's select-options handling when `getStateElementCustom` returns no matching state element.

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
