### PR TITLE
hotfix/pardot — Fix Pardot OAuth session-expiry detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.10.2]
+
+### Fixed
+
+- Fixed Pardot OAuth session-expiry detection to check the API response `code` (`184`) instead of the removed `errorCode` (`INVALID_SESSION_ID`) field.
+
 ## [9.10.1]
 
 ### Fixed
@@ -1995,6 +2001,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.10.2]: https://github.com/infinum/eightshift-forms/compare/9.10.1...9.10.2
 [9.10.1]: https://github.com/infinum/eightshift-forms/compare/9.10.0...9.10.1
 [9.10.0]: https://github.com/infinum/eightshift-forms/compare/9.9.1...9.10.0
 [9.9.1]: https://github.com/infinum/eightshift-forms/compare/9.9.0...9.9.1

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.10.1
+ * Version: 9.10.2
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.10.1",
+	"version": "9.10.2",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Integrations/Pardot/OauthPardot.php
+++ b/src/Integrations/Pardot/OauthPardot.php
@@ -152,7 +152,7 @@ class OauthPardot extends AbstractOauth
 	 */
 	public function hasTokenExpired(array $body): bool
 	{
-		return ($body['errorCode'] ?? '') === 'INVALID_SESSION_ID';
+		return (int) ($body['code'] ?? 0) === 184;
 	}
 
 	/**


### PR DESCRIPTION
# Description

### Fixed

- Fixed Pardot OAuth session-expiry detection. The check now inspects the API response `code` field (`184`) instead of the removed `errorCode` field (`INVALID_SESSION_ID`), so expired sessions are correctly detected and re-authenticated.

## QA Guide

Steps for QA to test this feature:
1. Configure a form with the Pardot integration and connect a valid Pardot account.
2. Let the Pardot OAuth session expire (or invalidate it server-side).
3. Submit the form.

**Expected result:** The expired session is detected, the plugin transparently re-authenticates, and the submission goes through without a session error.

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->