### PR TITLE
feature/select-dropdown-body-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [9.11.0]
+
+### Added
+
+- Added a "Select dropdown location before body end" accessibility setting that renders select, country, and phone dropdowns before the `</body>` tag instead of under the field.
+
 ## [9.10.1]
 
 ### Fixed
@@ -1974,6 +1980,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[9.11.0]: https://github.com/infinum/eightshift-forms/compare/9.10.1...9.11.0
 [9.10.1]: https://github.com/infinum/eightshift-forms/compare/9.10.0...9.10.1
 [9.10.0]: https://github.com/infinum/eightshift-forms/compare/9.9.1...9.10.0
 [9.9.1]: https://github.com/infinum/eightshift-forms/compare/9.9.0...9.9.1

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 9.10.1
+ * Version: 9.11.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/eightshift-forms",
-	"version": "9.10.1",
+	"version": "9.11.0",
 	"description": "This repository contains all the tools you need to start building a modern WordPress project.",
 	"authors": [
 		{

--- a/src/Blocks/components/form/assets/form.js
+++ b/src/Blocks/components/form/assets/form.js
@@ -1472,7 +1472,155 @@ export class Form {
 			choices?.input?.element.addEventListener('focus', this.onSelectFocusEvent);
 			choices?.containerOuter?.element.addEventListener('blur', this.onBlurEvent);
 			choices?.input?.element.addEventListener('blur', this.onBlurEvent);
+
+			if (this.state.getStateSettingsDropdownBeforeBodyEnd()) {
+				this.setupSelectDropdownPortal(choices);
+			}
 		});
+	}
+
+	/**
+	 * Render the Choices.js dropdown at the end of `<body>` while it is open.
+	 *
+	 * Choices.js has no native "append to body" option (only `position: auto|top|bottom`), so
+	 * the dropdown stays inside `.choices` and gets clipped by ancestors with `overflow: hidden`
+	 * or a `transform`/`contain` containing block. This moves only the dropdown into a floating
+	 * wrapper on `<body>` while open (mirroring the outer classes so scoped styles still apply),
+	 * then moves it back on close.
+	 *
+	 * Choices.js delegates option selection (`mousedown`) and keyboard navigation (`keydown`)
+	 * from `containerOuter`, and gates its "inside the component" checks on
+	 * `containerOuter.contains()`. Because the dropdown leaves that container, this re-binds
+	 * those handlers onto the dropdown, extends `contains()` to include it, and suppresses the
+	 * spurious close the browser's focus loss on re-parenting would otherwise trigger.
+	 *
+	 * @param {object} choices Choices.js instance.
+	 *
+	 * @returns {void}
+	 */
+	setupSelectDropdownPortal(choices) {
+		const outer = choices?.containerOuter?.element;
+		const inner = choices?.containerInner?.element;
+		const dropdown = choices?.dropdown?.element;
+		const passed = choices?.passedElement?.element;
+
+		if (!outer || !inner || !dropdown || !passed) {
+			return;
+		}
+
+		// Treat the portaled dropdown as part of the component for outside-click/focus checks.
+		const nativeContains = outer.contains.bind(outer);
+		outer.contains = (node) => nativeContains(node) || dropdown.contains(node);
+
+		// Swallow the close that focus loss on re-parenting would otherwise trigger.
+		let isMoving = false;
+		const nativeHideDropdown = choices.hideDropdown.bind(choices);
+		choices.hideDropdown = (...args) => (isMoving ? choices : nativeHideDropdown(...args));
+
+		// Choices.js internal, instance-bound delegated handlers, re-bound onto the dropdown.
+		const onMouseDown = choices['_onMouseDown'];
+		const onKeyDown = choices['_onKeyDown'];
+
+		const wrapper = document.createElement('div');
+
+		const position = () => {
+			const rect = inner.getBoundingClientRect();
+			const spaceBelow = window.innerHeight - rect.bottom;
+			const flip = spaceBelow < dropdown.scrollHeight && rect.top > spaceBelow;
+
+			wrapper.style.width = `${rect.width}px`;
+			wrapper.style.left = `${rect.left}px`;
+			wrapper.classList.toggle('is-flipped', flip);
+
+			if (flip) {
+				wrapper.style.top = 'auto';
+				wrapper.style.bottom = `${window.innerHeight - rect.top}px`;
+			} else {
+				wrapper.style.bottom = 'auto';
+				wrapper.style.top = `${rect.bottom}px`;
+			}
+		};
+
+		// The portaled dropdown lives at the end of the DOM, so a native Tab would send focus to
+		// the page end and Choices re-opens on the resulting focus churn. Take over: close and
+		// return focus to the control, where tab order continues correctly.
+		const onTabKeyDown = (event) => {
+			if (event.key !== 'Tab') {
+				return;
+			}
+
+			event.preventDefault();
+			nativeHideDropdown(true);
+			outer.focus({ preventScroll: true });
+		};
+
+		const onShow = () => {
+			// Mirror the outer classes so the project's scoped dropdown styles still match.
+			wrapper.className = outer.className;
+			wrapper.style.position = 'fixed';
+			wrapper.style.margin = '0';
+			wrapper.style.zIndex = '999999';
+
+			// The wrapper owns positioning; the dropdown flows normally inside it.
+			isMoving = true;
+			dropdown.style.position = 'static';
+			wrapper.appendChild(dropdown);
+			document.body.appendChild(wrapper);
+			isMoving = false;
+
+			// Re-bind the handlers Choices.js attached to the now out-of-tree container.
+			dropdown.addEventListener('mousedown', onMouseDown, true);
+			dropdown.addEventListener('keydown', onKeyDown, true);
+			dropdown.addEventListener('keydown', onTabKeyDown, true);
+
+			// Keep the search input usable after the move.
+			if (choices.config?.searchEnabled) {
+				choices.input?.element?.focus({ preventScroll: true });
+			}
+
+			position();
+			window.addEventListener('scroll', position, true);
+			window.addEventListener('resize', position);
+		};
+
+		const onHide = () => {
+			window.removeEventListener('scroll', position, true);
+			window.removeEventListener('resize', position);
+
+			dropdown.removeEventListener('mousedown', onMouseDown, true);
+			dropdown.removeEventListener('keydown', onKeyDown, true);
+			dropdown.removeEventListener('keydown', onTabKeyDown, true);
+
+			dropdown.style.position = '';
+
+			// Restore the dropdown into its container so Choices.js internals and destroy work.
+			if (dropdown.parentElement === wrapper) {
+				outer.appendChild(dropdown);
+			}
+
+			wrapper.remove();
+
+			// Return focus to the control so keyboard/tab order does not jump to the end of the
+			// DOM after the portaled dropdown (and its focused search input) is removed. Skip when
+			// the user has already moved focus elsewhere (e.g. clicked another field).
+			const active = document.activeElement;
+
+			if (!active || active === document.body || dropdown.contains(active)) {
+				outer.focus({ preventScroll: true });
+			}
+		};
+
+		passed.addEventListener('showDropdown', onShow);
+		passed.addEventListener('hideDropdown', onHide);
+
+		// Store cleanup so it runs before Choices.js `destroy()`.
+		choices.esFormsDropdownPortalCleanup = () => {
+			onHide();
+			outer.contains = nativeContains;
+			choices.hideDropdown = nativeHideDropdown;
+			passed.removeEventListener('showDropdown', onShow);
+			passed.removeEventListener('hideDropdown', onHide);
+		};
 	}
 
 	/**
@@ -1690,6 +1838,7 @@ export class Form {
 				choices?.input?.element.removeEventListener('focus', this.onSelectFocusEvent);
 				choices?.containerOuter?.element.removeEventListener('blur', this.onBlurEvent);
 				choices?.input?.element.removeEventListener('blur', this.onBlurEvent);
+				choices?.esFormsDropdownPortalCleanup?.();
 				choices?.destroy();
 			});
 
@@ -2010,6 +2159,13 @@ export class Form {
 	onSelectFocusEvent = (event) => {
 		const formId = this.state.getFormIdByElement(event.target);
 		const field = this.state.getFormFieldElementByChild(event.target);
+
+		// The dropdown (and its search input) is portaled to `<body>` while open, so it no
+		// longer resolves to a field. The container-level handler manages the focus state.
+		if (!field) {
+			return;
+		}
+
 		const name = field.getAttribute(this.state.getStateAttribute('fieldName'));
 		const value = this.state.getStateElementValue(name, formId);
 		const custom = this.state.getStateElementCustom(name, formId);

--- a/src/Blocks/components/form/assets/state-init.js
+++ b/src/Blocks/components/form/assets/state-init.js
@@ -89,6 +89,7 @@ export const StateEnum = {
 	SETTINGS_DISABLE_SCROLL_TO_GLOBAL_MSG_ON_SUCCESS: 'disableScrollToGlobalMsgOnSuccess',
 	SETTINGS_DISABLE_SCROLL_TO_FIELD_ON_ERROR: 'disableScrollToFieldOnError',
 	SETTINGS_DISABLE_SCROLL_TO_FIELD_ON_FOCUS: 'disableScrollToFieldOnFocus',
+	SETTINGS_DROPDOWN_BEFORE_BODY_END_KEY: 'dropdownBeforeBodyEnd',
 	SETTINGS_FORM_RESET_ON_SUCCESS: 'formResetOnSuccess',
 	SETTINGS_REDIRECTION_TIMEOUT: 'redirectionTimeout',
 	SETTINGS_HIDE_GLOBAL_MESSAGE_TIMEOUT: 'hideGlobalMessageTimeout',
@@ -252,6 +253,7 @@ export function setStateInitial() {
 	setState([StateEnum.SETTINGS_DISABLE_SCROLL_TO_GLOBAL_MSG_ON_SUCCESS], Boolean(esFormsLocalization.formDisableScrollToGlobalMessageOnSuccess), StateEnum.SETTINGS);
 	setState([StateEnum.SETTINGS_DISABLE_SCROLL_TO_FIELD_ON_ERROR], Boolean(esFormsLocalization.formDisableScrollToFieldOnError), StateEnum.SETTINGS);
 	setState([StateEnum.SETTINGS_DISABLE_SCROLL_TO_FIELD_ON_FOCUS], Boolean(esFormsLocalization.formDisableScrollToFieldOnFocus), StateEnum.SETTINGS);
+	setState([StateEnum.SETTINGS_DROPDOWN_BEFORE_BODY_END_KEY], Boolean(esFormsLocalization.formDropdownBeforeBodyEnd), StateEnum.SETTINGS);
 	setState([StateEnum.SETTINGS_FORM_RESET_ON_SUCCESS], Boolean(esFormsLocalization.formResetOnSuccess), StateEnum.SETTINGS);
 	setState([StateEnum.SETTINGS_REDIRECTION_TIMEOUT], esFormsLocalization.redirectionTimeout ?? 600, StateEnum.SETTINGS);
 	setState([StateEnum.SETTINGS_HIDE_GLOBAL_MESSAGE_TIMEOUT], esFormsLocalization.hideGlobalMessageTimeout ?? 6000, StateEnum.SETTINGS);

--- a/src/Blocks/components/form/assets/state.js
+++ b/src/Blocks/components/form/assets/state.js
@@ -240,6 +240,9 @@ export class State {
 	getStateSettingsDisableScrollToFieldOnFocus = () => {
 		return getState([StateEnum.SETTINGS_DISABLE_SCROLL_TO_FIELD_ON_FOCUS], StateEnum.SETTINGS);
 	};
+	getStateSettingsDropdownBeforeBodyEnd = () => {
+		return getState([StateEnum.SETTINGS_DROPDOWN_BEFORE_BODY_END_KEY], StateEnum.SETTINGS);
+	};
 	getStateSettingsResetOnSuccess = () => {
 		return getState([StateEnum.SETTINGS_FORM_RESET_ON_SUCCESS], StateEnum.SETTINGS);
 	};

--- a/src/Blocks/components/form/assets/utils.js
+++ b/src/Blocks/components/form/assets/utils.js
@@ -812,6 +812,12 @@ export class Utils {
 	setOnFocus(target) {
 		const formId = this.state.getFormIdByElement(target);
 		const field = this.state.getFormFieldElementByChild(target);
+
+		// Target may be detached from its field (e.g. a portaled select dropdown search input).
+		if (!field) {
+			return;
+		}
+
 		const name = field.getAttribute(this.state.getStateAttribute('fieldName'));
 
 		this.setActiveState(formId, name);
@@ -828,6 +834,12 @@ export class Utils {
 	setOnBlur(target) {
 		const formId = this.state.getFormIdByElement(target);
 		const field = this.state.getFormFieldElementByChild(target);
+
+		// Target may be detached from its field (e.g. a portaled select dropdown search input).
+		if (!field) {
+			return;
+		}
+
 		const name = field.getAttribute(this.state.getStateAttribute('fieldName'));
 
 		this.unsetActiveState(formId, name);

--- a/src/Enqueue/Blocks/EnqueueBlocks.php
+++ b/src/Enqueue/Blocks/EnqueueBlocks.php
@@ -303,6 +303,10 @@ class EnqueueBlocks extends AbstractEnqueueBlocks
 			SettingsSettings::SETTINGS_GENERAL_A11Y_DISABLE_SCROLL_TO_FIELD_KEY,
 			SettingsSettings::SETTINGS_GENERAL_A11Y_KEY
 		);
+		$output['formDropdownBeforeBodyEnd'] = SettingsHelpers::isOptionCheckboxChecked(
+			SettingsSettings::SETTINGS_GENERAL_A11Y_DROPDOWN_BEFORE_BODY_END_KEY,
+			SettingsSettings::SETTINGS_GENERAL_A11Y_KEY
+		);
 		$output['formResetOnSuccess'] = !DeveloperHelpers::isDeveloperSkipFormResetActive();
 		$output['formServerErrorMsg'] = \esc_html__('A server error occurred while submitting your form. Please try again.', 'eightshift-forms');
 		$output['formCaptchaErrorMsg'] = \esc_html__('A ReCaptcha error has occurred. Please try again.', 'eightshift-forms');

--- a/src/Settings/SettingsSettings.php
+++ b/src/Settings/SettingsSettings.php
@@ -50,6 +50,7 @@ class SettingsSettings implements SettingGlobalInterface, ServiceInterface
 	 */
 	public const SETTINGS_GENERAL_A11Y_KEY = 'general-a11y';
 	public const SETTINGS_GENERAL_A11Y_DISABLE_SCROLL_TO_FIELD_KEY = 'disable-scroll-to-field-key';
+	public const SETTINGS_GENERAL_A11Y_DROPDOWN_BEFORE_BODY_END_KEY = 'dropdown-before-body-end-key';
 
 	/**
 	 * Hide global message timeout key.
@@ -73,6 +74,8 @@ class SettingsSettings implements SettingGlobalInterface, ServiceInterface
 	 */
 	public function getSettingsGlobalData(): array
 	{
+		$dropdownPosition = SettingsHelpers::isOptionCheckboxChecked(self::SETTINGS_GENERAL_A11Y_DROPDOWN_BEFORE_BODY_END_KEY, self::SETTINGS_GENERAL_A11Y_KEY);
+
 		return [
 			SettingsOutputHelpers::getIntro(self::SETTINGS_TYPE_KEY),
 			[
@@ -167,6 +170,16 @@ class SettingsSettings implements SettingGlobalInterface, ServiceInterface
 										'checkboxHelp' => \__('Affected fields are: select, country, phone, date, dateTime.', 'eightshift-forms'),
 										'checkboxIsChecked' => SettingsHelpers::isOptionCheckboxChecked(self::SETTINGS_GENERAL_A11Y_DISABLE_SCROLL_TO_FIELD_KEY, self::SETTINGS_GENERAL_A11Y_KEY),
 										'checkboxValue' => self::SETTINGS_GENERAL_A11Y_DISABLE_SCROLL_TO_FIELD_KEY,
+										'checkboxAsToggle' => true,
+										'checkboxSingleSubmit' => true,
+									],
+									[
+										'component' => 'checkbox',
+										'checkboxLabel' => \__('Select dropdown location before body end', 'eightshift-forms'),
+										// translators: %s is the current dropdown render location (either "under field" or "before body end").
+										'checkboxHelp' => \sprintf(\__('Select dropdown will be displayed %s. Affected fields are: select, country, phone.', 'eightshift-forms'), !$dropdownPosition ? 'under field' : 'before body end'),
+										'checkboxIsChecked' => $dropdownPosition,
+										'checkboxValue' => self::SETTINGS_GENERAL_A11Y_DROPDOWN_BEFORE_BODY_END_KEY,
 										'checkboxAsToggle' => true,
 										'checkboxSingleSubmit' => true,
 									],


### PR DESCRIPTION
# Description

Adds a new accessibility setting, **"Select dropdown location before body end"**, that renders Choices.js dropdowns (select, country, phone) in a floating wrapper at the end of `<body>` instead of inside the field. This prevents the dropdown from being clipped by ancestors with `overflow: hidden` or a `transform`/`contain` containing block.

### Added

- Added the `SETTINGS_GENERAL_A11Y_DROPDOWN_BEFORE_BODY_END_KEY` setting with a toggle in the general accessibility settings, and exposed it to the frontend via the `formDropdownBeforeBodyEnd` localization output.
- Added `setupSelectDropdownPortal()` in `form.js` that portals the open dropdown to `<body>`, mirrors the outer classes so scoped styles still apply, handles positioning/flip, re-binds Choices.js delegated mouse/keyboard handlers, manages Tab focus, and cleans up on close/destroy.
- Added the `getStateSettingsDropdownBeforeBodyEnd` state getter and the `dropdownBeforeBodyEnd` state key wired through `state.js` / `state-init.js`.

### Fixed

- Fixed active/focus state handlers in `utils.js` and `form.js` throwing when the event target is detached from its field (e.g. the portaled dropdown's search input) by guarding against a missing field.

## QA Guide

Steps for QA to test this feature:

1. Go to **Eightshift Forms → Global Settings → General → Accessibility** and enable **"Select dropdown location before body end"**.
2. On the frontend, open a form with a select, country, or phone field — ideally one placed inside a container with `overflow: hidden` or a CSS `transform` (e.g. a modal, slider, or scroll area).
3. Open the dropdown and verify it renders fully (not clipped), positioned correctly below/above the field.
4. Verify option selection via mouse and keyboard, search filtering, flip-when-no-space-below, closing on outside click, and Tab moving focus back to the field.
5. Disable the setting and confirm the dropdown reverts to rendering under the field as before.

**Expected result:** With the setting on, dropdowns render at the end of `<body>` and are never clipped, with mouse/keyboard/search/focus behaving identically to the default inline dropdown. With it off, behavior is unchanged.

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
