### PR TITLE
10.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [10.2.0]
+
+### Added
+
+- *Show as* on *Checkboxes* now passes through min. option count, and now allows setting a max. number of selections when set to `Select`, to match *Select* options.
+
+### Fixed
+
+- `min`/`max`/`step` attributes missing in output (added to `EscapedView`).
+
 ## [10.1.0]
 
 ### Fixed
@@ -2039,6 +2049,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[10.2.0]: https://github.com/infinum/eightshift-forms/compare/10.1.0...10.2.0
 [10.1.0]: https://github.com/infinum/eightshift-forms/compare/10.0.0...10.1.0
 [10.0.0]: https://github.com/infinum/eightshift-forms/compare/9.10.1...10.0.0
 [9.10.1]: https://github.com/infinum/eightshift-forms/compare/9.10.0...9.10.1

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 10.1.0
+ * Version: 10.2.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Blocks/components/checkboxes/components/checkboxes-options.js
+++ b/src/Blocks/components/checkboxes/components/checkboxes-options.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { checkAttr, getAttrKey, props } from '@eightshift/frontend-libs-tailwind/scripts';
 import { ContainerPanel, InputField, Toggle, Tab, TabList, Tabs, TabPanel, Container, ContainerGroup, OptionSelect } from '@eightshift/ui-components';
 import { FieldOptions, FieldOptionsMore, FieldOptionsLayout, FieldOptionsVisibility } from '../../field/components/field-options';
-import { buttonGhost, checks, design, fieldPlaceholder, moreH, optionListAlt, requiredAlt, sliders, tag } from '@eightshift/ui-components/icons';
+import { buttonGhost, checks, chevronLeft, chevronRight, design, fieldPlaceholder, moreH, optionListAlt, requiredAlt, sliders, tag } from '@eightshift/ui-components/icons';
 import { isOptionDisabled, NameField } from './../../utils';
 import { ConditionalTagsOptions } from '../../conditional-tags/components/conditional-tags-options';
 import manifest from '../manifest.json';
@@ -22,11 +22,12 @@ export const CheckboxesOptions = (attributes) => {
 
 	const checkboxesName = checkAttr('checkboxesName', attributes, manifest);
 	const checkboxesIsRequired = checkAttr('checkboxesIsRequired', attributes, manifest);
-	const checkboxesIsRequiredCount = checkAttr('checkboxesIsRequiredCount', attributes, manifest);
+	const checkboxesIsRequiredCount = checkAttr('checkboxesIsRequiredCount', attributes, manifest, true);
 	const checkboxesDisabledOptions = checkAttr('checkboxesDisabledOptions', attributes, manifest);
 	const checkboxesShowAs = checkAttr('checkboxesShowAs', attributes, manifest);
 	const checkboxesUseLabelAsPlaceholder = checkAttr('checkboxesUseLabelAsPlaceholder', attributes, manifest);
 	const checkboxesPlaceholder = checkAttr('checkboxesPlaceholder', attributes, manifest);
+	const checkboxesDropdownMaxCount = checkAttr('checkboxesDropdownMaxCount', attributes, manifest, true);
 
 	const [countInnerBlocks, setCountInnerBlocks] = useState(0);
 
@@ -210,13 +211,28 @@ export const CheckboxesOptions = (attributes) => {
 
 						<Container hidden={!checkboxesIsRequired || checkboxesShowAs === 'radio'}>
 							<NumberPicker
-								icon={optionListAlt}
-								label={__('Minimum selections', 'eightshift-forms')}
+								icon={checkboxesShowAs === 'select' ? chevronRight : optionListAlt}
+								label={checkboxesShowAs === 'select' ? __('Min. selected options', 'eightshift-forms') : __('Minimum selections', 'eightshift-forms')}
 								value={checkboxesIsRequiredCount}
 								onChange={(value) => setAttributes({ [getAttrKey('checkboxesIsRequiredCount', attributes, manifest)]: value })}
 								min={options.checkboxesIsRequiredCount.min}
 								max={countInnerBlocks}
 								disabled={isOptionDisabled(getAttrKey('checkboxesIsRequiredCount', attributes, manifest), checkboxesDisabledOptions)}
+								fixedWidth={4}
+								inline
+							/>
+						</Container>
+
+						<Container hidden={!checkboxesIsRequired || checkboxesShowAs !== 'select'}>
+							<NumberPicker
+								icon={chevronLeft}
+								label={__('Max. selected options', 'eightshift-forms')}
+								value={checkboxesDropdownMaxCount}
+								onChange={(value) => setAttributes({ [getAttrKey('checkboxesDropdownMaxCount', attributes, manifest)]: value })}
+								min={options.checkboxesDropdownMaxCount.min}
+								step={options.checkboxesDropdownMaxCount.step}
+								disabled={isOptionDisabled(getAttrKey('checkboxesDropdownMaxCount', attributes, manifest), checkboxesDisabledOptions)}
+								fixedWidth={4}
 								inline
 							/>
 						</Container>

--- a/src/Blocks/components/checkboxes/manifest.json
+++ b/src/Blocks/components/checkboxes/manifest.json
@@ -57,11 +57,18 @@
 		},
 		"checkboxesTwSelectorsData": {
 			"type": "array"
+		},
+		"checkboxesDropdownMaxCount": {
+			"type": "integer"
 		}
 	},
 	"options": {
 		"checkboxesIsRequiredCount": {
-			"min":  1,
+			"min": 1,
+			"step": 1
+		},
+		"checkboxesDropdownMaxCount": {
+			"min": 1,
 			"step": 1
 		}
 	}

--- a/src/Blocks/components/select/components/select-options.js
+++ b/src/Blocks/components/select/components/select-options.js
@@ -26,8 +26,8 @@ export const SelectOptions = (attributes) => {
 	const selectPlaceholder = checkAttr('selectPlaceholder', attributes, manifest);
 	const selectUseLabelAsPlaceholder = checkAttr('selectUseLabelAsPlaceholder', attributes, manifest);
 	const selectIsMultiple = checkAttr('selectIsMultiple', attributes, manifest);
-	const selectMinCount = checkAttr('selectMinCount', attributes, manifest);
-	const selectMaxCount = checkAttr('selectMaxCount', attributes, manifest);
+	const selectMinCount = checkAttr('selectMinCount', attributes, manifest, true);
+	const selectMaxCount = checkAttr('selectMaxCount', attributes, manifest, true);
 	const selectShowAs = checkAttr('selectShowAs', attributes, manifest);
 
 	return (

--- a/src/Blocks/manifest.json
+++ b/src/Blocks/manifest.json
@@ -111,7 +111,9 @@
 				"checkboxesCheckboxesConditionalTagsRulesForms": "selectSelectConditionalTagsRulesForms",
 				"checkboxesCheckboxesConditionalTagsPostId": "selectSelectConditionalTagsPostId",
 				"checkboxesCheckboxesConditionalTagsBlockName": "selectSelectConditionalTagsBlockName",
-				"checkboxesCheckboxesConditionalTagsIsHidden": "selectSelectConditionalTagsIsHidden"
+				"checkboxesCheckboxesConditionalTagsIsHidden": "selectSelectConditionalTagsIsHidden",
+				"checkboxesCheckboxesIsRequiredCount": "selectSelectMinCount",
+				"checkboxesCheckboxesDropdownMaxCount": "selectSelectMaxCount"
 			},
 			"children": {
 				"checkboxCheckboxLabel": "selectOptionSelectOptionLabel",

--- a/src/View/EscapedView.php
+++ b/src/View/EscapedView.php
@@ -40,12 +40,16 @@ class EscapedView extends AbstractEscapedView implements ServiceInterface
 		foreach ($items as $item) {
 			$output[$item]['data-*'] = true;
 			$output[$item]['aria-*'] = true;
+			$output[$item]['role'] = true;
+			$output[$item]['value'] = true;
+			$output[$item]['placeholder'] = true;
+			$output[$item]['min'] = true;
+			$output[$item]['max'] = true;
+			$output[$item]['step'] = true;
+			$output[$item]['autocomplete'] = true;
 		}
 
 		$output['select']['multiple'] = true;
-
-		$output['input']['autocomplete'] = true;
-		$output['textarea']['autocomplete'] = true;
 
 		return $output;
 	}


### PR DESCRIPTION
### Added

- *Show as* on *Checkboxes* now passes through min. option count, and now allows setting a max. number of selections when set to `Select`, to match *Select* options.

### Fixed

- `min`/`max`/`step` attributes missing in output (added to `EscapedView`).