### PR TITLE
feature/ui-fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,22 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [10.3.0]
+
+### Changed
+
+- Updated the `$schema` path in all block and component manifests to point to `eightshift-frontend-libs-tailwind`.
+
+### Fixed
+
+- Fixed arbitrary values not working in the `col-end-span-*` utility, which caused incorrect field widths.
+- Fixed a broken field style attribute on older projects, where a non-array value would break the `field`, `checkboxes` and `radios` components.
+
 ## [10.2.0]
 
 ### Added
 
-- *Show as* on *Checkboxes* now passes through min. option count, and now allows setting a max. number of selections when set to `Select`, to match *Select* options.
+- _Show as_ on _Checkboxes_ now passes through min. option count, and now allows setting a max. number of selections when set to `Select`, to match _Select_ options.
 
 ### Fixed
 
@@ -2049,6 +2060,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Initial production release.
 
+[10.3.0]: https://github.com/infinum/eightshift-forms/compare/10.2.0...10.3.0
 [10.2.0]: https://github.com/infinum/eightshift-forms/compare/10.1.0...10.2.0
 [10.1.0]: https://github.com/infinum/eightshift-forms/compare/10.0.0...10.1.0
 [10.0.0]: https://github.com/infinum/eightshift-forms/compare/9.10.1...10.0.0

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fdadcbfe12776a154dd7d7c4b62abf5",
+    "content-hash": "7d3b283dac5bea074933fe19b7d5bf0b",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -1149,16 +1149,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/03cd615cdd5648abb5f10ff3a684fdb976687190",
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190",
                 "shasum": ""
             },
             "require": {
@@ -1197,7 +1197,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.2"
             },
             "funding": [
                 {
@@ -1205,7 +1205,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-03T17:30:34+00:00"
+            "time": "2026-08-12T06:23:05+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -1213,12 +1213,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "f4f38b8750fb0db0242fb03d4727517e3611da8b"
+                "reference": "ebb428a8010d5f244e8449fb45dde34f2eb58586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f4f38b8750fb0db0242fb03d4727517e3611da8b",
-                "reference": "f4f38b8750fb0db0242fb03d4727517e3611da8b",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/ebb428a8010d5f244e8449fb45dde34f2eb58586",
+                "reference": "ebb428a8010d5f244e8449fb45dde34f2eb58586",
                 "shasum": ""
             },
             "conflict": {
@@ -1317,7 +1317,7 @@
                 "brotkrueml/codehighlight": "<2.7",
                 "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
                 "brotkrueml/typo3-matomo-integration": "<1.3.2",
-                "buddypress/buddypress": "<7.2.1",
+                "buddypress/buddypress": "<14.5",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
                 "bvbmedia/multishop": "<2.0.39",
                 "bytefury/crater": "<6.0.2",
@@ -1456,7 +1456,7 @@
                 "drupal/umami_analytics": "<1.0.1",
                 "duncanmcclean/guest-entries": "<3.1.2",
                 "dweeves/magmi": "<=0.7.24",
-                "easycorp/easyadmin-bundle": ">=4,<4.29.10|>=5,<5.0.13",
+                "easycorp/easyadmin-bundle": ">=4,<4.29.16|>=5,<5.5.1",
                 "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.3.1",
                 "ecodev/newsletter": "<=4",
                 "ectouch/ectouch": "<=2.7.2",
@@ -1688,7 +1688,7 @@
                 "leantime/leantime": "<3.3",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
                 "libreform/libreform": ">=2,<=2.0.8",
-                "librenms/librenms": "<26.3",
+                "librenms/librenms": "<=26.4",
                 "liftkit/database": "<2.13.2",
                 "lightsaml/lightsaml": "<1.3.5",
                 "limesurvey/limesurvey": "<=7.0.0.0-beta1",
@@ -1857,6 +1857,7 @@
                 "php-standard-library/h2": ">=6.1,<6.1.2|>=6.2,<6.2.1",
                 "php-standard-library/php-standard-library": ">=6.1,<6.1.2|>=6.2,<6.2.1",
                 "phpbb/phpbb": "<3.3.16|==4.0.0.0-alpha1",
+                "phpcsstandards/phpcsutils": ">=1.0.0.0-alpha1,<1.2.3",
                 "phpems/phpems": ">=6,<=6.1.3",
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
@@ -2118,7 +2119,7 @@
                 "thelia/thelia": ">=2.0.0.0-beta1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<6.0.8",
-                "thorsten/phpmyfaq": "<4.1.4",
+                "thorsten/phpmyfaq": "<4.2.0.0-alpha",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
                 "tinymce/tinymce": "<7.9.3|>=8,<8.5.1",
@@ -2145,7 +2146,7 @@
                 "typo3/cms-backend": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
                 "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-beuser": ">=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
-                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.31|>=14,<14.3.3",
+                "typo3/cms-core": "<10.4.57|>=11,<11.5.51|>=12,<12.4.46|>=13,<13.4.34|>=14,<14.3.6",
                 "typo3/cms-dashboard": ">=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
                 "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
                 "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
@@ -2215,8 +2216,8 @@
                 "wikibase/wikibase": "<=1.39.3",
                 "wikimedia/parsoid": "<0.12.2",
                 "willdurand/js-translation-bundle": "<2.1.1",
-                "winter/wn-backend-module": "<1.2.12",
-                "winter/wn-cms-module": "<=1.2.9",
+                "winter/wn-backend-module": "<1.2.13",
+                "winter/wn-cms-module": "<=1.2.12",
                 "winter/wn-dusk-plugin": "<2.1",
                 "winter/wn-system-module": "<1.2.4",
                 "wintercms/winter": "<=1.2.3",
@@ -2331,7 +2332,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-07T18:55:46+00:00"
+            "time": "2026-08-13T08:20:14+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/eightshift-forms.php
+++ b/eightshift-forms.php
@@ -6,7 +6,7 @@
  * Description: Eightshift Forms is a complete form builder plugin that utilizes modern Block editor features with multiple third-party integrations, bringing your project to a new level.
  * Author: WordPress team @Infinum
  * Author URI: https://eightshift.com/
- * Version: 10.2.0
+ * Version: 10.3.0
  * Text Domain: eightshift-forms
  *
  * @package EightshiftForms

--- a/src/Blocks/components/admin-listing/manifest.json
+++ b/src/Blocks/components/admin-listing/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "admin-listing",
 	"title": "Admin Listing",
 	"componentClass": "es-admin-listing",

--- a/src/Blocks/components/admin-settings-section/manifest.json
+++ b/src/Blocks/components/admin-settings-section/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "admin-settings-section",
 	"title": "Admin Settings Section",
 	"componentClass": "es-admin-settings-section"

--- a/src/Blocks/components/admin-settings/manifest.json
+++ b/src/Blocks/components/admin-settings/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "admin-settings",
 	"title": "Admin Settings",
 	"componentClass": "es-admin-settings",

--- a/src/Blocks/components/button/manifest.json
+++ b/src/Blocks/components/button/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "button",
 	"title": "Button",
 	"attributes": {

--- a/src/Blocks/components/card-inline/manifest.json
+++ b/src/Blocks/components/card-inline/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "card-inline",
 	"title": "Card inline",
 	"componentClass": "es-card-inline",

--- a/src/Blocks/components/card-listing/manifest.json
+++ b/src/Blocks/components/card-listing/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "card-listing",
 	"title": "Card Listing",
 	"componentClass": "es-card-listing",

--- a/src/Blocks/components/checkbox/manifest.json
+++ b/src/Blocks/components/checkbox/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "checkbox",
 	"title": "Checkbox",
 	"componentClass": "es-checkbox",

--- a/src/Blocks/components/checkboxes/checkboxes.php
+++ b/src/Blocks/components/checkboxes/checkboxes.php
@@ -26,6 +26,10 @@ $checkboxesShowAs = $attributes[Helpers::getAttrKey('checkboxesShowAs', $attribu
 $twSelectorsData = FormsHelper::getTwSelectorsData($attributes);
 $checkboxesFieldStyle = is_admin() ? [] : Helpers::checkAttr(Helpers::getAttrKey('checkboxesFieldStyle', $attributes, $manifest), $attributes, $manifest);
 
+if (!is_array($checkboxesFieldStyle)) {
+	$checkboxesFieldStyle = [$checkboxesFieldStyle];
+}
+
 $fieldStyleOverrides = [
 	'content' => FormsHelper::getTwFieldStyleOutput($twSelectorsData, $checkboxesFieldStyle, $checkboxesShowAs ?: $manifest['componentName'], 'content'),
 	'label' => FormsHelper::getTwFieldStyleOutput($twSelectorsData, $checkboxesFieldStyle, $checkboxesShowAs ?: $manifest['componentName'], 'label'),

--- a/src/Blocks/components/checkboxes/manifest.json
+++ b/src/Blocks/components/checkboxes/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "checkboxes",
 	"title": "checkboxes",
 	"componentClass": "es-checkboxes",

--- a/src/Blocks/components/conditional-tags/manifest.json
+++ b/src/Blocks/components/conditional-tags/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "conditional-tags",
 	"componentClass": "es-conditional-tags",
 	"title": "Conditional tags",

--- a/src/Blocks/components/country/manifest.json
+++ b/src/Blocks/components/country/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "country",
 	"title": "Country",
 	"componentClass": "es-country",

--- a/src/Blocks/components/date/manifest.json
+++ b/src/Blocks/components/date/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "date",
 	"title": "Date",
 	"componentClass": "es-date",

--- a/src/Blocks/components/divider/manifest.json
+++ b/src/Blocks/components/divider/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "divider",
 	"title": "Divider",
 	"componentClass": "es-divider",

--- a/src/Blocks/components/dynamic/manifest.json
+++ b/src/Blocks/components/dynamic/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "dynamic",
 	"title": "Dynamic",
 	"componentClass": "es-dynamic",

--- a/src/Blocks/components/error/manifest.json
+++ b/src/Blocks/components/error/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "error",
 	"title": "Error",
 	"componentClass": "es-error",

--- a/src/Blocks/components/field/field.php
+++ b/src/Blocks/components/field/field.php
@@ -78,6 +78,10 @@ if ($fieldStyle && gettype($fieldStyle) === 'array') {
 	);
 }
 
+if (!is_array($fieldStyle)) {
+	$fieldStyle = [$fieldStyle];
+}
+
 $twClasses = FormsHelper::getTwSelectors($fieldTwSelectorsData, [
 	'field',
 	$fieldTypeInternal,

--- a/src/Blocks/components/field/manifest.json
+++ b/src/Blocks/components/field/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "field",
 	"title": "Field",
 	"componentClass": "es-field",

--- a/src/Blocks/components/file/manifest.json
+++ b/src/Blocks/components/file/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "file",
 	"title": "file",
 	"componentClass": "es-file",

--- a/src/Blocks/components/form-edit-actions/manifest.json
+++ b/src/Blocks/components/form-edit-actions/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "form-edit-actions",
 	"title": "Form edit actions",
 	"componentClass": "es-block-edit-options",

--- a/src/Blocks/components/form/manifest.json
+++ b/src/Blocks/components/form/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "form",
 	"title": "form",
 	"componentClass": "es-form",

--- a/src/Blocks/components/global-msg/manifest.json
+++ b/src/Blocks/components/global-msg/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "global-msg",
 	"title": "Global Msg",
 	"componentClass": "es-global-msg",

--- a/src/Blocks/components/group/manifest.json
+++ b/src/Blocks/components/group/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "group",
 	"title": "Group",
 	"componentClass": "es-group",

--- a/src/Blocks/components/input/manifest.json
+++ b/src/Blocks/components/input/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "input",
 	"title": "Input",
 	"componentClass": "es-input",

--- a/src/Blocks/components/integrations/manifest.json
+++ b/src/Blocks/components/integrations/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "integrations",
 	"title": "Integrations",
 	"componentClass": "es-integrations"

--- a/src/Blocks/components/intro/manifest.json
+++ b/src/Blocks/components/intro/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "intro",
 	"title": "Intro",
 	"componentClass": "es-intro",

--- a/src/Blocks/components/invalid/manifest.json
+++ b/src/Blocks/components/invalid/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "invalid",
 	"title": "Invalid",
 	"componentClass": "es-invalid"

--- a/src/Blocks/components/layout/manifest.json
+++ b/src/Blocks/components/layout/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "layout",
 	"title": "Layout",
 	"componentClass": "es-layout",

--- a/src/Blocks/components/loader/manifest.json
+++ b/src/Blocks/components/loader/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "loader",
 	"title": "Loader",
 	"componentClass": "es-loader",

--- a/src/Blocks/components/notice/manifest.json
+++ b/src/Blocks/components/notice/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "notice",
 	"title": "Notice",
 	"componentClass": "es-notice",

--- a/src/Blocks/components/pagination/manifest.json
+++ b/src/Blocks/components/pagination/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "pagination",
 	"title": "Pagination",
 	"componentClass": "es-pagination",

--- a/src/Blocks/components/phone/manifest.json
+++ b/src/Blocks/components/phone/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "phone",
 	"title": "Phone",
 	"componentClass": "es-phone",

--- a/src/Blocks/components/progress-bar/manifest.json
+++ b/src/Blocks/components/progress-bar/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "progress-bar",
 	"title": "Progress bar",
 	"componentClass": "es-progress-bar",

--- a/src/Blocks/components/radio/manifest.json
+++ b/src/Blocks/components/radio/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "radio",
 	"title": "Radio",
 	"componentClass": "es-radio",

--- a/src/Blocks/components/radios/manifest.json
+++ b/src/Blocks/components/radios/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "radios",
 	"title": "radios",
 	"componentClass": "es-radios",

--- a/src/Blocks/components/radios/radios.php
+++ b/src/Blocks/components/radios/radios.php
@@ -27,6 +27,10 @@ $radiosShowAs = $attributes[Helpers::getAttrKey('radiosShowAs', $attributes, $ma
 $twSelectorsData = FormsHelper::getTwSelectorsData($attributes);
 $radiosFieldStyle = is_admin() ? [] : Helpers::checkAttr('radiosFieldStyle', $attributes, $manifest);
 
+if (!is_array($radiosFieldStyle)) {
+	$radiosFieldStyle = [$radiosFieldStyle];
+}
+
 $fieldStyleOverrides = [
 	'content' => FormsHelper::getTwFieldStyleOutput($twSelectorsData, $radiosFieldStyle, $radiosShowAs ?: $manifest['componentName'], 'content'),
 	'label' => FormsHelper::getTwFieldStyleOutput($twSelectorsData, $radiosFieldStyle, $radiosShowAs ?: $manifest['componentName'], 'label'),

--- a/src/Blocks/components/rating/manifest.json
+++ b/src/Blocks/components/rating/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "rating",
 	"title": "Rating",
 	"componentClass": "es-rating",

--- a/src/Blocks/components/react-flow/manifest.json
+++ b/src/Blocks/components/react-flow/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "react-flow",
 	"title": "React Flow"
 }

--- a/src/Blocks/components/select-option/manifest.json
+++ b/src/Blocks/components/select-option/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "select-option",
 	"title": "Select Option",
 	"componentClass": "es-select-option",

--- a/src/Blocks/components/select/manifest.json
+++ b/src/Blocks/components/select/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "select",
 	"title": "Select",
 	"componentClass": "es-select",

--- a/src/Blocks/components/spacer/manifest.json
+++ b/src/Blocks/components/spacer/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "spacer",
 	"title": "Spacer",
 	"componentClass": "es-spacer"

--- a/src/Blocks/components/status-light/manifest.json
+++ b/src/Blocks/components/status-light/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "status-light",
 	"title": "Status light",
 	"componentClass": "es-status-light",

--- a/src/Blocks/components/step/manifest.json
+++ b/src/Blocks/components/step/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "step",
 	"title": "Step",
 	"componentClass": "es-step",

--- a/src/Blocks/components/steps/manifest.json
+++ b/src/Blocks/components/steps/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "steps",
 	"title": "Steps",
 	"componentClass": "es-steps",

--- a/src/Blocks/components/submit/manifest.json
+++ b/src/Blocks/components/submit/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "submit",
 	"title": "Submit",
 	"componentClass": "es-submit",

--- a/src/Blocks/components/tab/manifest.json
+++ b/src/Blocks/components/tab/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "tab",
 	"title": "Tab",
 	"componentClass": "es-tab",

--- a/src/Blocks/components/table/manifest.json
+++ b/src/Blocks/components/table/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "table",
 	"title": "table",
 	"componentClass": "es-table",

--- a/src/Blocks/components/tabs/manifest.json
+++ b/src/Blocks/components/tabs/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "tabs",
 	"title": "Tabs",
 	"componentClass": "es-tabs",

--- a/src/Blocks/components/textarea/manifest.json
+++ b/src/Blocks/components/textarea/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "textarea",
 	"title": "Textarea",
 	"componentClass": "es-textarea",

--- a/src/Blocks/components/tooltip/manifest.json
+++ b/src/Blocks/components/tooltip/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "tooltip",
 	"title": "Tooltip",
 	"componentClass": "es-tooltip",

--- a/src/Blocks/components/utils/manifest.json
+++ b/src/Blocks/components/utils/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/component.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/component.json",
 	"componentName": "utils",
 	"title": "Utils"
 }

--- a/src/Blocks/custom/activecampaign/manifest.json
+++ b/src/Blocks/custom/activecampaign/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "activecampaign",
 	"title": "ActiveCampaign form",

--- a/src/Blocks/custom/airtable/manifest.json
+++ b/src/Blocks/custom/airtable/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "airtable",
 	"title": "Airtable form",

--- a/src/Blocks/custom/calculator/manifest.json
+++ b/src/Blocks/custom/calculator/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "calculator",
 	"title": "Calculator form",

--- a/src/Blocks/custom/checkbox/manifest.json
+++ b/src/Blocks/custom/checkbox/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "checkbox",
 	"title": "Checkbox",

--- a/src/Blocks/custom/checkboxes/manifest.json
+++ b/src/Blocks/custom/checkboxes/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "checkboxes",
 	"title": "Checkboxes",

--- a/src/Blocks/custom/corvus/manifest.json
+++ b/src/Blocks/custom/corvus/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "corvus",
 	"title": "Corvus form",

--- a/src/Blocks/custom/country/manifest.json
+++ b/src/Blocks/custom/country/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "country",
 	"title": "Country",

--- a/src/Blocks/custom/date/manifest.json
+++ b/src/Blocks/custom/date/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "date",
 	"title": "Date",

--- a/src/Blocks/custom/dynamic/manifest.json
+++ b/src/Blocks/custom/dynamic/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "dynamic",
 	"title": "Dynamic",

--- a/src/Blocks/custom/field/manifest.json
+++ b/src/Blocks/custom/field/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "field",
 	"title": "Field",

--- a/src/Blocks/custom/file/manifest.json
+++ b/src/Blocks/custom/file/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "file",
 	"title": "File",

--- a/src/Blocks/custom/form-selector/manifest.json
+++ b/src/Blocks/custom/form-selector/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "form-selector",
 	"title": "Form selector",

--- a/src/Blocks/custom/forms/manifest.json
+++ b/src/Blocks/custom/forms/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "forms",
 	"title": "Form",

--- a/src/Blocks/custom/goodbits/manifest.json
+++ b/src/Blocks/custom/goodbits/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "goodbits",
 	"title": "Goodbits form",

--- a/src/Blocks/custom/greenhouse/manifest.json
+++ b/src/Blocks/custom/greenhouse/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "greenhouse",
 	"title": "Greenhouse form",

--- a/src/Blocks/custom/hubspot/manifest.json
+++ b/src/Blocks/custom/hubspot/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "hubspot",
 	"title": "HubSpot form",

--- a/src/Blocks/custom/input/manifest.json
+++ b/src/Blocks/custom/input/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "input",
 	"title": "Input",

--- a/src/Blocks/custom/jira/manifest.json
+++ b/src/Blocks/custom/jira/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "jira",
 	"title": "Jira form",

--- a/src/Blocks/custom/mailchimp/manifest.json
+++ b/src/Blocks/custom/mailchimp/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "mailchimp",
 	"title": "Mailchimp form",

--- a/src/Blocks/custom/mailer/manifest.json
+++ b/src/Blocks/custom/mailer/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "mailer",
 	"title": "Mailer form",

--- a/src/Blocks/custom/mailerlite/manifest.json
+++ b/src/Blocks/custom/mailerlite/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "mailerlite",
 	"title": "MailerLite form",

--- a/src/Blocks/custom/moments/manifest.json
+++ b/src/Blocks/custom/moments/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "moments",
 	"title": "Moments form",

--- a/src/Blocks/custom/nationbuilder/manifest.json
+++ b/src/Blocks/custom/nationbuilder/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "nationbuilder",
 	"title": "NationBuilder form",

--- a/src/Blocks/custom/pardot/manifest.json
+++ b/src/Blocks/custom/pardot/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"blockName": "pardot",
 	"title": "Pardot form",
 	"description": "Pardot (Account Engagement) form block",

--- a/src/Blocks/custom/paycek/manifest.json
+++ b/src/Blocks/custom/paycek/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "paycek",
 	"title": "PayCek form",

--- a/src/Blocks/custom/phone/manifest.json
+++ b/src/Blocks/custom/phone/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "phone",
 	"title": "Phone",

--- a/src/Blocks/custom/pipedrive/manifest.json
+++ b/src/Blocks/custom/pipedrive/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "pipedrive",
 	"title": "Pipedrive form",

--- a/src/Blocks/custom/radio/manifest.json
+++ b/src/Blocks/custom/radio/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "radio",
 	"title": "Radio button",

--- a/src/Blocks/custom/radios/manifest.json
+++ b/src/Blocks/custom/radios/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "radios",
 	"title": "Radio buttons",

--- a/src/Blocks/custom/rating/manifest.json
+++ b/src/Blocks/custom/rating/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "rating",
 	"title": "Rating",

--- a/src/Blocks/custom/result-output-item/manifest.json
+++ b/src/Blocks/custom/result-output-item/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "result-output-item",
 	"title": "Result output item",

--- a/src/Blocks/custom/result-output/manifest.json
+++ b/src/Blocks/custom/result-output/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "result-output",
 	"title": "Result output",

--- a/src/Blocks/custom/select-option/manifest.json
+++ b/src/Blocks/custom/select-option/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "select-option",
 	"title": "Option",

--- a/src/Blocks/custom/select/manifest.json
+++ b/src/Blocks/custom/select/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "select",
 	"title": "Select",

--- a/src/Blocks/custom/step/manifest.json
+++ b/src/Blocks/custom/step/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "step",
 	"title": "Step",

--- a/src/Blocks/custom/submit/manifest.json
+++ b/src/Blocks/custom/submit/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "submit",
 	"title": "Submit",

--- a/src/Blocks/custom/talentlyft/manifest.json
+++ b/src/Blocks/custom/talentlyft/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "talentlyft",
 	"title": "Talentlyft form",

--- a/src/Blocks/custom/textarea/manifest.json
+++ b/src/Blocks/custom/textarea/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "textarea",
 	"title": "Multiline text",

--- a/src/Blocks/custom/workable/manifest.json
+++ b/src/Blocks/custom/workable/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/block.json",
 	"apiVersion": 3,
 	"blockName": "workable",
 	"title": "Workable form",

--- a/src/Blocks/manifest.json
+++ b/src/Blocks/manifest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/globalManifest.json",
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs-tailwind/main/schemas/globalManifest.json",
 	"namespace": "eightshift-forms",
 	"background": "#ffffff",
 	"foreground": "#594c5b",

--- a/tailwind.css
+++ b/tailwind.css
@@ -119,6 +119,7 @@
 
 @utility col-end-span-* {
 	grid-column-end: span --value(integer);
+	grid-column-end: span --value([*]);
 }
 
 @utility row-end-span-* {


### PR DESCRIPTION
# Description

Version `10.3.0` — a set of UI/compatibility fixes.

### Changed

- Updated the `$schema` path in all block and component manifests to point to `eightshift-frontend-libs-tailwind` instead of `eightshift-frontend-libs`, so manifest schema validation resolves correctly.

### Fixed

- Fixed arbitrary values not working in the `col-end-span-*` Tailwind utility (`grid-column-end: span --value([*])` was missing), which caused incorrect field widths.
- Fixed a broken field style attribute on older projects — `field`, `checkboxes` and `radios` now normalize a non-array `fieldStyle` value into an array before it reaches `FormsHelper::getTwFieldStyleOutput()`, preventing a breakage on projects that still store it as a string.

## QA Guide

Steps for QA to test this feature:

1. Open a form in the block editor and set a field width using an arbitrary column value (e.g. a custom width on a field inside a grid).
2. Check the rendered form on the frontend — the field should respect the width set in the editor.
3. Open a form on an older project (one migrated from a pre-Tailwind version) that has a field style saved as a single string value, and render it on the frontend.
4. Confirm the `field`, `checkboxes` and `radios` components render without a PHP error or notice.
5. Open any `manifest.json` in `src/Blocks/components` or `src/Blocks/custom` in an editor with JSON schema support and confirm the schema resolves without errors.

**Expected result:** Field widths render as configured, older projects with string field styles render without errors, and manifest schemas validate against `eightshift-frontend-libs-tailwind`.

# Screenshots / Videos

<!--- Show us what you did. -->

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
